### PR TITLE
Detecting HTTPS requests

### DIFF
--- a/source/index.html.haml
+++ b/source/index.html.haml
@@ -10,11 +10,13 @@
         %li
           %a{href: "/heroku-compatibility"}Heroku compatibility
         %li
-          %a{href: "/internals/procfile"}Procfile - How your app is started
+          %a{href: "/internals/procfile.html"}Procfile - How your app is started
         %li
-          %a{href: "/app/environment"}Environment - Configure your app
+          %a{href: "/internals/detecting-https-requests.html"}Detecting HTTPS requests
         %li
-          %a{href: "/app/domain"}Custom Domain Name
+          %a{href: "/app/environment.html"}Environment - Configure your app
+        %li
+          %a{href: "/app/domain.html"}Custom Domain Name
         %li
           %a{href: "/databases"}Databases
   .col-xs-12.col-sm-6

--- a/source/internals/detecting-https-requests.md
+++ b/source/internals/detecting-https-requests.md
@@ -1,0 +1,63 @@
+---
+title: Detecting HTTPS requests
+category: internals
+tags: internals, request, https
+date: 13/03/2015
+---
+
+# Detecting HTTPS requests
+
+## Background
+
+Your application runs behind a load balancer which does all the request handling
+to your (optionally) scaled application. The communication between the load
+balancer and your application (specifically the `web` container within your
+application) is carried out via HTTP and you are not able to detect a HTTPS
+request via standard methods of your web framework.
+
+That is why the HTTP headers of the external request are enriched with
+a `x-forwarded-proto` header (among others) by the load balancer and handed
+over to your `web` contaner.
+
+You would then check if the header value contains `https` to detect a HTTPS
+request.
+
+## Simple Java+Wicket example
+
+
+```java
+public class RequestUtil {
+
+	private static final Logger log = LoggerFactory.getLogger(RequestUtil.class);
+
+	public static boolean isSecure() {
+		return isSecureScalingo() || isSecureRegular();
+	}
+
+	private static boolean isSecureScalingo() {
+		final HttpServletRequest servletRequest = getServletRequest();
+		if (null == servletRequest) {
+			return false;
+		}
+		final String header = servletRequest.getHeader("x-forwarded-proto");
+		return !Strings.isEmpty(header) && "https".equalsIgnoreCase(header);
+	}
+
+	private static boolean isSecureRegular() {
+		final HttpServletRequest servletRequest = getServletRequest();
+		return null != servletRequest ? servletRequest.isSecure() : false;
+	}
+
+	@Nullable
+	public static HttpServletRequest getServletRequest() {
+		final Object containerRequest = RequestCycle.get().getRequest().getContainerRequest();
+		if (containerRequest instanceof HttpServletRequest) {
+			return ((HttpServletRequest) containerRequest);
+		} else {
+			log.warn("Current request is no HttpServletRequest! (" + containerRequest + ")");
+			return null;
+		}
+	}
+
+}
+```


### PR DESCRIPTION
* Due to the missing "Internals" section on the front page I put
  that into the "Getting started" section for now.
* Additionally fixed the links to "Getting started" entries where
  the target is not a directory with "index.html" but a concrete
  *.html file which "middleman server" is not able to deliver in
  contrast to github (jekyll?).