### PR TITLE
Header modifications

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,12 +1,11 @@
 <header class="mdl-layout__header mdl-color--light-blue">
   <div class="mdl-layout__header-row header-row">
-    <a class="mdl-layout-title" href="/">
+    <a class="mdl-layout-title" href="https://scalingo.com/">
       <img class="logo-img" src="http://scalingo.com/logo-white.svg">
     </a>
     <div class="mdl-layout-spacer"></div>
     <div class="mdl-layout--large-screen-only">
       <nav class="mdl-navigation sub-nav">
-        <a class="mdl-navigation__link mdl-typography--text-capitalize" href="https://scalingo.com">Homepage</a>
         <a class="mdl-navigation__link mdl-typography--text-capitalize" href="http://blog.scalingo.com">Blog</a>
         <a class="mdl-navigation__link mdl-typography--text-capitalize" href="http://doc.scalingo.com">Documentation</a>
         <a class="mdl-navigation__link mdl-typography--text-capitalize" href="http://changelog.scalingo.com">Changelog</a>

--- a/_includes/search.html
+++ b/_includes/search.html
@@ -1,5 +1,5 @@
 <div class="search-block">
-  <h2><a href="/">Scalingo Documentation</a></h2>
+  <h2><a href="/">Documentation Center</a></h2>
   <form action="/" class="search-form">
     <label class="search-label material-icons" for="search">
       <input type="search" id="st-search-input" class="search-input" placeholder="Search the Documentation" autofocus="true">

--- a/_sass/header.sass
+++ b/_sass/header.sass
@@ -36,6 +36,7 @@ header
       font-size: 120%
       font-weight: bold
   .sub-nav
+    font-weight: 300
     height: auto
     float: right
     margin: 0 0 0 0


### PR DESCRIPTION
- Logo now links to Homepage
- Homepage link removed from header subnav
- Banner title: "Scalingo Documentation" -> "Documentation Center"
- Header subnav links: reduced font-weight