### PR TITLE
Add nginx buildpack documentation

### DIFF
--- a/_posts/platform/deployment/buildpacks/2000-01-01-nginx.md
+++ b/_posts/platform/deployment/buildpacks/2000-01-01-nginx.md
@@ -7,10 +7,10 @@ tags: buildpacks build nginx
 
 ## Purpose of this buildpack
 
-Your applications are hosted behind a reverse proxy. You might need to customize the way the reverse
-proxy acts for your apps. The [Nginx buildpack](https://github.com/Scalingo/nginx-buildpack) lets
-you specify custom Nginx configuration. With this buildpack, you can provide a Nginx configuration
-file with the rules you want to set.
+Looking for a reverse proxy or an API gateway for your apps? This buildpack might be the solution
+you are looking for. The [Nginx buildpack](https://github.com/Scalingo/nginx-buildpack) lets you
+specify custom Nginx configuration. With this buildpack, you can provide a Nginx configuration file
+with the rules you want to set.
 
 ## Set up this buildpack
 

--- a/_posts/platform/deployment/buildpacks/2000-01-01-nginx.md
+++ b/_posts/platform/deployment/buildpacks/2000-01-01-nginx.md
@@ -1,0 +1,83 @@
+---
+title: Nginx Buildpack for Custom Reverse Proxy
+nav: Nginx Buildpack
+modified_at: 2018-06-01 00:00:00
+tags: buildpacks build nginx
+---
+
+## Purpose of this buildpack
+
+Your applications are hosted behind a reverse proxy. You might need to customize the way the reverse
+proxy acts for your apps. The [Nginx buildpack](https://github.com/Scalingo/nginx-buildpack) lets
+you specify custom Nginx configuration. With this buildpack, you can provide a Nginx configuration
+file with the rules you want to set.
+
+## Set up this buildpack
+
+This buildpack is designed to be used in conjunction with one or more additional
+buildpacks, thanks to the [multi buildpack]({% post_url
+platform/deployment/buildpacks/2000-01-01-multi %}).
+
+For instance, using the Scalingo CLI:
+
+```console
+$ scalingo create my-app
+$ scalingo env-set BUILDPACK_URL=https://github.com/Scalingo/nginx-buildpack.git
+```
+
+## Configuration
+
+The buildpack is expecting a configuration file at the root of the project which can be:
+
+- `nginx.conf`: simple configuration file
+- `nginx.conf.erb`: template to generate the configuration file
+
+If the template is found, it will be rendered as configuration file, it let you use environment
+variables as in the following examples.
+
+### Specify Nginx Version
+
+By default we're installing the latest available version of Nginx, but if you want to use a specific
+version, you can define the environment variable `NGINX_VERSION`:
+
+```console
+$ scalingo env-set NGINX_VERSION=1.8.0
+```
+
+### Discouraged Directives
+
+The following directives should not be used in you configuration file:
+`listen`, `access_log`, `error_log` and `server_name`.
+
+### Configuration Examples
+
+Split traffic to 2 APIs
+
+```nginx
+location /api/v1 {
+  proxy_pass <%= ENV["API_V1_BACKEND"] %>;
+}
+
+location /api/v2 {
+	proxy_pass <%= ENV["API_V2_BACKEND"] %>;
+}
+```
+
+Use nginx configuration: [nginx.org/en/docs](https://nginx.org/en/docs) to get
+details about how to configure your app.
+
+## Output
+
+The application deployment output will look like:
+
+```text
+-----> Cloning custom buildpack: https://github.com/Scalingo/nginx-buildpack.git#master
+-----> Bundling NGINX 1.10.1
+```
+
+## Advanced Informations
+
+The configuration file you have to provide is at the `server` level, if you
+need to add something at the `http` level, please open an
+[issue](https://github.com/Scalingo/nginx-buildpack/issues/new) or a pull
+request and we'll discuss it.

--- a/_posts/platform/deployment/buildpacks/2000-01-01-ssh-key.md
+++ b/_posts/platform/deployment/buildpacks/2000-01-01-ssh-key.md
@@ -1,7 +1,7 @@
 ---
 title: SSH Private Key Buildpack
 modified_at: 2018-02-23 00:00:00
-tags: buildpacks build locale language
+tags: buildpacks build ssh key
 ---
 
 ## Purpose of this buildpack


### PR DESCRIPTION
Fix #228

https://documentation-service-pr352.scalingo.io/platform/deployment/buildpacks/nginx