### PR TITLE
Doc custom Node.js cache folder

### DIFF
--- a/_posts/languages/nodejs/2000-01-01-start.md
+++ b/_posts/languages/nodejs/2000-01-01-start.md
@@ -153,6 +153,21 @@ You may want to run custom commands or scripts before or after the installation 
 }
 ```
 
+### Custom Cache Folder
+
+By default, Scalingo stores the directories `bower_components` and `node_modules` at the root of the
+project in the deployment
+cache. But you might need to add different folders to this cache. You can override these defaults by
+specifying the `cacheDirectories` (or `cache_directories`) key at the root of your `package.json`
+file.
+
+For example, if your application has a client and a server in the same repository, you can specify
+these folders to store them in the deployment cache with:
+
+```json
+"cacheDirectories": ["client/node_modules", "server/node_modules"]
+```
+
 ## Meteor application
 
 If a `.meteor` file is detected at the root of your project, your app will


### PR DESCRIPTION
Fix #227 

https://documentation-service-pr353.scalingo.io/languages/nodejs/start#custom-cache-folder

@Soulou I am not sure this is what you meant for this issue. If it is, what is the purpose of customizing this folder?