### PR TITLE
More info about golang-migrate

### DIFF
--- a/_posts/languages/go/2000-01-01-dep.md
+++ b/_posts/languages/go/2000-01-01-dep.md
@@ -37,15 +37,17 @@ correctly the application:
   If the tool has multiple versions an optional `@<version>` suffix can be
   specified to select that specific version of the tool. Otherwise the
   buildpack’s default version is chosen. Currently the only supported tool is
-  `github.com/mattes/migrate` at `v3.0.0` (also the default version).
+  `github.com/golang-migrate/migrate` at `v3.0.0` (also the default version).
 
-Here is an example with [https://github.com/Scalingo/sample-go-martini](https://github.com/Scalingo/sample-go-martini/tree/deps-dep).
+Here is an example with
+[https://github.com/Scalingo/sample-go-martini](https://github.com/Scalingo/sample-go-martini/tree/deps-dep).
 
 ```toml
 [metadata.scalingo]
   root-package = "github.com/Scalingo/sample-go-martini"
   go-version = "go1.10.0"
   install = [ "./..." ]
+  additional-tools = ["github.com/golang-migrate/migrate"]
 ...
 ```
 


### PR DESCRIPTION
We should fix Scalingo/go-buildpack#3 before merging this.

There is no tutorial on how to use this lib. But there is a plan to add one: golang-migrate/migrate#40. Then we can write our own tuto

Fix #223