### PR TITLE
Explain HTTP 502 in router error codes page

### DIFF
--- a/_posts/platform/internals/2000-01-01-router-error-codes.md
+++ b/_posts/platform/internals/2000-01-01-router-error-codes.md
@@ -11,7 +11,9 @@ Here is the list of error codes emitted by our routing layer:
 
 * `499 Client Closed Request`: client closed the connection before the server answered the request.
   It is usually caused by client side timeout
-* `503 Service Unavailable`
+* `502 Bad Gateway`: your application sent an invalid response to our reverse proxy. This error is
+  often sent when your application is abruptly cutting connections.
+* `503 Service Unavailable`:
   * The application [requests queue]({% post_url platform/internals/2000-01-01-routing
     %}#requests-queue) is full, so the newly incoming request has not been dequeued
   * The application has been stopped by its owner


### PR DESCRIPTION
https://documentation-service-pr373.scalingo.io/platform/internals/router-error-codes

Fix #363