### PR TITLE
Mention the 'release' vs postdeploy entry in heroku compatibility page

### DIFF
--- a/_posts/platform/getting-started/2000-01-01-heroku-compatibility.md
+++ b/_posts/platform/getting-started/2000-01-01-heroku-compatibility.md
@@ -1,6 +1,6 @@
 ---
 title: Heroku Compatibility
-modified_at: 2019-09-10 21:00:00
+modified_at: 2018-09-10 21:00:00
 tags: heroku
 index: 10
 ---

--- a/_posts/platform/getting-started/2000-01-01-heroku-compatibility.md
+++ b/_posts/platform/getting-started/2000-01-01-heroku-compatibility.md
@@ -15,9 +15,8 @@ If a **Procfile** is available in the source of your app, it will be used. See
 the [dedicated Procfile page]({% post_url platform/app/2000-01-01-procfile %})
 for more informations.
 
-If a `release` entry is defined in your **Procfile**, you should use our
-[postdeploy hook]({% post_url platform/app/2000-01-01-postdeploy-hook %})
-instead, the *release* entry would not be executed. The difference is that the
+The Procfile `release` entry does not exist on Scalingo thus it won't be executed. The
+[postdeploy hook]({% post_url platform/app/2000-01-01-postdeploy-hook %}) exists with similar functionnality. The difference is that the
 *postdeploy* hook is only getting executed at the end of a successful
 deployment, not at each change of variable/addon modification (creating a
 release).

--- a/_posts/platform/getting-started/2000-01-01-heroku-compatibility.md
+++ b/_posts/platform/getting-started/2000-01-01-heroku-compatibility.md
@@ -1,23 +1,39 @@
 ---
 title: Heroku Compatibility
-modified_at: 2015-09-17 21:00:00
+modified_at: 2017-09-10 21:00:00
 tags: heroku
 index: 10
 ---
 
-Our aim for Scalingo is to be fully compatible with Heroku. If your app works on Heroku, it will work on Scalingo. We've added several compatibility layers for that matter.
+Our aim for Scalingo is to be fully compatible with Heroku. If your app works
+on Heroku, it will work on Scalingo. We've added several compatibility layers
+for that matter.
 
 ## Procfile
 
-If a Procfile is available in the source of your app, it will be used. See the [dedicated Procfile page](/internals/procfile.html) for more informations.
+If a **Procfile** is available in the source of your app, it will be used. See the
+[dedicated Procfile page](/internals/procfile.html) for more informations.
+
+If a `release` entry is defined in your **Procfile**, you should use our
+[postdeploy hook]({% post_url platform/app/2000-01-01-postdeploy-hook %})
+instead, the *release* entry would not be executed. The difference is that the
+*postdeploy* hook is only getting executed at the end of a successful
+deployment, not at each change of variable/addon modification (creating a
+release)
 
 ## Buildpacks
 
-Most buildpacks and their functionalities work exactly the same as on Heroku. Some buildpacks are written and maintained by our own. It's open source. Check your [GitHub account](https://github.com/Scalingo/?query=buildpack) to see the whole list.
+Most buildpacks and their functionalities work exactly the same as on Heroku.
+Some buildpacks are written and maintained by our own. It's open source. Check
+your [GitHub account](https://github.com/Scalingo/?query=buildpack) to see the
+whole list.
 
 ## Environment variables
 
-Because we'd like to conform as much as possible to the [12-factor](http://12factor.net/) principle, you can configure your app through [environment variables]({% post_url platform/app/2000-01-01-environment %}) which are injected into the context of your application.
+Because we'd like to conform as much as possible to the
+[12-factor](http://12factor.net/) principle, you can configure your app through
+[environment variables]({% post_url platform/app/2000-01-01-environment %})
+which are injected into the context of your application.
 
 ## Realtime deployment
 

--- a/_posts/platform/getting-started/2000-01-01-heroku-compatibility.md
+++ b/_posts/platform/getting-started/2000-01-01-heroku-compatibility.md
@@ -1,6 +1,6 @@
 ---
 title: Heroku Compatibility
-modified_at: 2017-09-10 21:00:00
+modified_at: 2019-09-10 21:00:00
 tags: heroku
 index: 10
 ---
@@ -11,21 +11,22 @@ for that matter.
 
 ## Procfile
 
-If a **Procfile** is available in the source of your app, it will be used. See the
-[dedicated Procfile page](/internals/procfile.html) for more informations.
+If a **Procfile** is available in the source of your app, it will be used. See
+the [dedicated Procfile page]({% post_url platform/app/2000-01-01-procfile %})
+for more informations.
 
 If a `release` entry is defined in your **Procfile**, you should use our
 [postdeploy hook]({% post_url platform/app/2000-01-01-postdeploy-hook %})
 instead, the *release* entry would not be executed. The difference is that the
 *postdeploy* hook is only getting executed at the end of a successful
 deployment, not at each change of variable/addon modification (creating a
-release)
+release).
 
 ## Buildpacks
 
 Most buildpacks and their functionalities work exactly the same as on Heroku.
 Some buildpacks are written and maintained by our own. It's open source. Check
-your [GitHub account](https://github.com/Scalingo/?query=buildpack) to see the
+our [GitHub account](https://github.com/Scalingo/?query=buildpack) to see the
 whole list.
 
 ## Environment variables


### PR DESCRIPTION
Fixes #380