### PR TITLE
customize Node.js version when using Ruby buildpack

### DIFF
--- a/_posts/languages/ruby/rails/2000-01-01-start.md
+++ b/_posts/languages/ruby/rails/2000-01-01-start.md
@@ -1,7 +1,7 @@
 ---
 title: Get Started with Ruby on Rails on Scalingo
 nav: Get Started
-modified_at: 2015-11-30 00:00:00
+modified_at: 2018-09-07 00:00:00
 tags: ruby rails tutorial getting-started-tutorial
 index: 3
 ---
@@ -115,3 +115,23 @@ Waiting for your application to boot...
 
 A new application will render a 404 error `The page you were looking for doesn't exist.`,
 but it's expected. There is nothing in the project, it's time to build your product!
+
+## Specifying a custom Node.js runtime
+
+Latest version of Rails application also use Node.js in case ExecJS or
+Webpacker is detected. The Node.js version built inside the Ruby buildpack is
+frozen. It is 6.11 at the time of writing.
+
+If you ever need to specify a different version of Node.js, you need to setup
+the [multi buildpacks]({% post_url
+platform/deployment/buildpacks/2000-01-01-multi %})), in order to use both the Node.js and the Ruby buildpack. The content of your `.buildpacks` file must respect the following order between the buildpacks:
+
+```text
+https://github.com/Scalingo/nodejs-buildpack.git
+https://github.com/Scalingo/ruby-buildpack.git
+```
+
+You also need to remove the file `bin/yarn` if it already exists.
+
+You eventually need to specify the [Node.js version]({% post_url
+languages/nodejs/2000-01-01-start %}#specifying-a-nodejs-version) in your `package.json`.


### PR DESCRIPTION
https://documentation-service-pr426.scalingo.io/languages/ruby/rails/start#specifying-a-custom-nodejs-runtime

Fix #418