### PR TITLE
Links to changelog with anchor

### DIFF
--- a/index.md
+++ b/index.md
@@ -133,7 +133,11 @@ modified_at: 2015-09-09 00:00:00
         {% assign recent_posts = site.posts | sort: 'modified_at' | reverse %}
         {% for post in recent_posts limit:10 %}
         <div class="d-flex justify-content-between">
-          <a href="{{ post.url }}" class="text-truncate">{{ post.title }}</a>
+          {% if post.categories contains 'changelog' %}
+            <a href="{{ post.id | slugify | prepend: "/changelog#" }}" class="text-truncate">{{ post.title }}</a>
+          {% else %}
+            <a href="{{ post.url }}" class="text-truncate">{{ post.title }}</a>
+          {% endif %}
           <small class="text-muted text-nowrap pl-1" style="position:relative;bottom:-4px;">
             {{ post.modified_at | date_to_string }}
           </small>


### PR DESCRIPTION
I am wondering whether it is possible to open the designated entry when it's targeted by an anchor link

http://documentation-service-pr453.scalingo.io/

Fix #448