### PR TITLE
Mention on all DBs pages that we have encryption at rest by default

### DIFF
--- a/_includes/encryption_at_rest.md
+++ b/_includes/encryption_at_rest.md
@@ -1,0 +1,9 @@
+{% note %}
+All databases created after the 6th of January 2019 have encryption at rest enabled. In other words,
+all your data are encrypted before being stored on disk.
+<br>
+<br>
+For databases created before this date, encryption at rest is activable on-demand through the
+support. Activating it is achieved with a short downtime for your database, from seconds to minutes
+depending on the amount of data.
+{% endnote %}

--- a/_posts/databases/elasticsearch/2000-01-01-start.md
+++ b/_posts/databases/elasticsearch/2000-01-01-start.md
@@ -291,3 +291,5 @@ database specific dashboard:
 
 {% assign img_url = "https://cdn.scalingo.com/documentation/screenshot_dashboard_addons_elasticsearch_restore.png" %}
 {% include mdl_img.html %}
+
+{% include encryption_at_rest.md %}

--- a/_posts/databases/influxdb/2000-01-01-start.md
+++ b/_posts/databases/influxdb/2000-01-01-start.md
@@ -232,6 +232,8 @@ Automated backups are listed in the database specific dashboard.
 
 Follow our guide: [How to dump and restore my InfluxDB database on Scalingo]({% post_url databases/influxdb/2000-01-01-dump-restore %})
 
+{% include encryption_at_rest.md %}
+
 ## Add Retention Policies
 
 InfluxDB provides a way to automatically delete records older than a certain date called retention

--- a/_posts/databases/mongodb/2000-01-01-start.md
+++ b/_posts/databases/mongodb/2000-01-01-start.md
@@ -256,6 +256,8 @@ Automated backups are listed in the database specific dashboard.
 
 If you wish to manually backup your database, please follow [How to dump and restore my MongoDB database on Scalingo]({% post_url databases/mongodb/2000-01-01-dump-restore %}) guide.
 
+{% include encryption_at_rest.md %}
+
 ## MongoDB Oplog
 
 Oplog is a MongoDB feature which logs all the operations achieved on a MongoDB cluster. This feature is tightly related to MongoDB replication, but is also used by Meteor to increase app performance. If you wish to use Oplog in your application please refer to the official [MongoDB documentation](https://docs.mongodb.org/manual/core/replica-set-oplog/). Oplog can be enabled from the database dashboard, when activated it will automatically add the `MONGO_OPLOG_URL` variable in your application.

--- a/_posts/databases/mysql/2000-01-01-start.md
+++ b/_posts/databases/mysql/2000-01-01-start.md
@@ -242,6 +242,8 @@ Automated backups are listed in the database specific dashboard.
 
 If you wish to manually backup your database, please follow [How to dump and restore my MySQL database on Scalingo]({% post_url databases/mysql/2000-01-01-dump-restore %}) guide.
 
+{% include encryption_at_rest.md %}
+
 ## Web Administration Tools
 
 ### phpMyAdmin

--- a/_posts/databases/postgresql/2000-01-01-start.md
+++ b/_posts/databases/postgresql/2000-01-01-start.md
@@ -239,3 +239,5 @@ Automated backups are listed in the database specific dashboard.
 ### Manual database backup
 
 If you wish to manually backup your database, please follow [How to dump and restore my PostgreSQL database on Scalingo]({% post_url databases/postgresql/2000-01-01-dump-restore %}) guide.
+
+{% include encryption_at_rest.md %}

--- a/_posts/databases/redis/2000-01-01-start.md
+++ b/_posts/databases/redis/2000-01-01-start.md
@@ -255,3 +255,5 @@ Automated backups are listed in the database specific dashboard.
 
 {% assign img_url = "https://cdn.scalingo.com/documentation/screenshot_database_redis_backups.png" %}
 {% include mdl_img.html %}
+
+{% include encryption_at_rest.md %}


### PR DESCRIPTION
https://documentation-service-pr491.scalingo.io/databases/postgresql/start#manual-database-backup

I'm not really satisfied with the location of this new bloc but I don't know where to put it....

Related to Scalingo/homepage#739

Fix #490 