### PR TITLE
Fix link on index to the Python getting started

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -84,7 +84,7 @@ highlighted:
     - name: PHP
       url: "/languages/php/start"
     - name: Python
-      url: "/languages/php/python"
+      url: "/languages/python/start"
     - name: Java
       url: "/languages/java/start"
   databases:


### PR DESCRIPTION
Fix #493 
https://documentation-service-pr495.scalingo.io/