### PR TITLE
[changelog] Announce Redis 5.0.4 and alerts duration before trigger

### DIFF
--- a/changelog/databases/_posts/2019-04-16-redis-5.0.4.markdown
+++ b/changelog/databases/_posts/2019-04-16-redis-5.0.4.markdown
@@ -1,0 +1,13 @@
+---
+modified_at:	2019-04-16 10:00:00
+title:	'Redis - New version: 5.0.4-1'
+---
+
+New default version: **5.0.4-1**
+
+More information on our [blog
+article](https://scalingo.com/articles/2019/04/16/redis-5.html).
+
+Docker Image:
+
+* `scalingo/redis:5.0.4-1`

--- a/changelog/features/_posts/2019-04-12-alerts-duration.markdown
+++ b/changelog/features/_posts/2019-04-12-alerts-duration.markdown
@@ -1,0 +1,11 @@
+---
+modified_at:	2019-04-12 10:00:00
+title:	'Alerts - New parameter to trigger an alert after a specified duration'
+---
+
+Alerts now support a new parameter: the duration before it gets triggered. An
+alert can now be triggered if the value of the observed metrics gets above the
+user-defined threshold during a specified amount of time.
+
+More information on the [documentation
+page](https://doc.scalingo.com/platform/app/alerts#alert-parameters).


### PR DESCRIPTION
https://documentation-service-pr554.scalingo.io/changelog