### PR TITLE
Document NPM_NO_BUILD for Node.js apps

### DIFF
--- a/_posts/languages/nodejs/2000-01-01-start.md
+++ b/_posts/languages/nodejs/2000-01-01-start.md
@@ -141,20 +141,30 @@ Example of `package.json`:
 
 ### Node.js Build Hooks
 
-You may want to run custom commands or scripts before or after the installation of dependencies. This is possible thanks to commands named `prebuild` and `build`. The first is run before installing dependencies and the latter after. To use them, add the commands you wish to run in the `package.json` the following way:
+You may want to run custom commands or scripts before or after the installation
+of dependencies. This is possible thanks to commands named `prebuild` and
+`postbuild`. The first is run before installing dependencies and the latter after.
+To use them, add the commands you wish to run in the `package.json` the
+following way:
 
 ```json
 {
   ...
   "scripts": {
     "prebuild": "node prebuild.js",
-    "build": "grunt build"
+    "build": "grunt build",
+    "postbuild": "newrelic deployments"
   }
 }
 ```
 
 * The hook `prebuild` has the following alias: `scalingo-prebuild`
-* The hook `build` has the following aliases: `postbuild`, `scalingo-postbuild`
+* The hook `postbuild` has the following alias: `scalingo-postbuild`
+
+{% note %}
+You can disable the build phase for your app by setting the environment
+variable `NPM_NO_BUILD=true`.
+{% endnote %}
 
 ### Custom Cache Folder
 

--- a/_posts/languages/nodejs/2000-01-01-start.md
+++ b/_posts/languages/nodejs/2000-01-01-start.md
@@ -1,7 +1,7 @@
 ---
 title: Node.js
 nav: Introduction
-modified_at: 2017-03-24 00:00:00
+modified_at: 2019-05-03 00:00:00
 tags: nodejs
 index: 1
 ---
@@ -158,8 +158,14 @@ following way:
 }
 ```
 
-* The hook `prebuild` has the following alias: `scalingo-prebuild`
-* The hook `postbuild` has the following alias: `scalingo-postbuild`
+* The hook `prebuild` lets you execute commands before npm/yarn has installed
+  dependencies, so it should not use any of them. It has the following alias:
+  `scalingo-prebuild`.
+* The hook `build` is the standard task to bundle applications in most Node.js
+  apps.
+* The hook `postbuild` triggers tasks unrelated to the build, like notifying
+  some external services or applying migrations. It has the following alias:
+  `scalingo-postbuild`.
 
 {% note %}
 You can disable the build phase for your app by setting the environment


### PR DESCRIPTION
Fix #546

https://documentation-service-pr562.scalingo.io/languages/nodejs/start#nodejs-build-hooks