### PR TITLE
Fix typo line 80: missing plural for 'requirement'

### DIFF
--- a/_posts/languages/python/django/2000-01-01-start.md
+++ b/_posts/languages/python/django/2000-01-01-start.md
@@ -77,7 +77,7 @@ it by the MySQL driver.
 ```bash
 pip uninstall psycopg2
 pip install mysqlclient
-pip freeze > requirement.txt
+pip freeze > requirements.txt
 ```
 
 ## Application configuration


### PR DESCRIPTION
replace 'pip freeze > requirement.txt'
with
'pip freeze > requirements.txt'