### PR TITLE
Explain SCALINGO_MYSQL_URL format

### DIFF
--- a/_posts/databases/mysql/2000-01-01-start.md
+++ b/_posts/databases/mysql/2000-01-01-start.md
@@ -262,7 +262,7 @@ databases/mysql/2000-01-01-dump-restore %}) guide.
 A phpMyAdmin instance is available at
 [https://phpmyadmin.scalingo.io](https://phpmyadmin.scalingo.io). The server, username and
 password fields must be filled with the information in your `SCALINGO_MYSQL_URL` environment
-variable. Note that the *server* input should be in the form *host:port*.
+variable. Its format is: `mysql://<db user>:<db password>@<host>:<port>/<stuff>`. Note that the *server* input should be in the form *host:port*.
 
 ### Adminer
 


### PR DESCRIPTION
I suggest explaining SCALINGO_MYSQL_URL format in the phpMyAdmin section of the doc.  This is useful for parsing database connection credentials.