### PR TITLE
Docker Image addon uses the API token and not API key

### DIFF
--- a/_posts/addons/scalingo-docker-image/2000-01-01-start.md
+++ b/_posts/addons/scalingo-docker-image/2000-01-01-start.md
@@ -40,12 +40,13 @@ to download the image of a given deployment.
 
 ```bash
 $ docker login registry.scalingo.com
-Username: <scalingo username>
-Password: <scalingo API key>
-Email:    <scalingo email>
+Username: <Scalingo username>
+Password: <Scalingo API token>
+Email:    <Scalingo email>
 ```
 
-The API key is available on [your profile](https://my.scalingo.com/profile), copy it from there.
+The API token must be created on [your
+profile](https://my.scalingo.com/profile), copy it from there.
 
 
 ### Download Your Image

--- a/_posts/addons/scalingo-docker-image/2000-01-01-start.md
+++ b/_posts/addons/scalingo-docker-image/2000-01-01-start.md
@@ -12,14 +12,14 @@ Thanks to this addon, you'll be able to get back the **Docker Images** that have
 
 Each time you push code to Scalingo, a *build* is triggered resulting in the construction of a Docker Image. When this build phase is successful we try to *deploy* this **Docker Image** by trying to run it on our cloud. This addon lets you download every Docker Image that has been built by Scalingo.
 
-## Use cases
+## Use Cases
 
 Because the Docker image is the exact same one we are running in our cloud, you can use it to debug your production code or as a **pledge of reversibility**.
 
 You can also use Scalingo as a **Docker Integration Platform**. You push your code from one side and get a
 generic Docker Image on the other. You can then use Scalingo for your staging environments and run the final Docker image on your own private cloud or the one from your customers. It's especially useful when your customers ask to run your application in their own environments for various reasons (Big Co wanting to control their infrastructure, legal reasons like in the MedTech world for instance).
 
-## Setup of the addon
+## Setup of the Addon
 
 Provision the addon for your application from our web dashboard or with our CLI:
 
@@ -27,7 +27,7 @@ Provision the addon for your application from our web dashboard or with our CLI:
 $ scalingo addons-add scalingo-docker-image base-plan
 ```
 
-## Usage of the addon
+## Usage of the Addon
 
 Once the addon has been provisioned, the deployments panel of your app dashboard
 will change, a **Docker logo** will be present. Click on it to get the instructions
@@ -36,7 +36,7 @@ to download the image of a given deployment.
 {% assign img_url = "https://cdn.scalingo.com/documentation/docker-image-addon/dashboard-example.png" %}
 {% include mdl_img.html %}
 
-### Login to your application registry
+### Login to Your Application Registry
 
 ```bash
 $ docker login registry.scalingo.com
@@ -48,7 +48,7 @@ Email:    <scalingo email>
 The API key is available on [your profile](https://my.scalingo.com/profile), copy it from there.
 
 
-### Download your image
+### Download Your Image
 
 ```bash
 $ docker pull registry.scalingo.com/my-app:0123456789abcdef
@@ -65,7 +65,7 @@ b7c87d00e3ba: Downloading 31.84 MB/362.9 MB
 f1ac1758a0cb: Waiting
 ```
 
-### Run your app
+### Run Your App
 
 The entrypoint of the image is a script located at `/start`. Its usage is:
 


### PR DESCRIPTION
Fix #579