### PR TITLE
Use a valid CIDR format

### DIFF
--- a/_posts/platform/internals/2000-01-01-network.md
+++ b/_posts/platform/internals/2000-01-01-network.md
@@ -44,11 +44,11 @@ range of IP addresses:
 All outgoing traffic from Scalingo hosted applications comes from the following
 ranges of IP addresses:
 
-- 5.104.96/21
-- 46.231.144/21
-- 109.232.232/21
-- 185.21.192/22
-- 171.33.64/18
+- 5.104.96.0/21
+- 46.231.144.0/21
+- 109.232.232.0/21
+- 185.21.192.0/22
+- 171.33.64.0/18
 - 148.253.64.0/18
 
 This information comes from our provider wiki page and might be out of date.


### PR DESCRIPTION
Some IT support don't know .0 is not a significative information