### PR TITLE
JS frameworks which needs static files serving

### DIFF
--- a/_posts/languages/nodejs/2000-01-01-start.md
+++ b/_posts/languages/nodejs/2000-01-01-start.md
@@ -197,36 +197,26 @@ languages/meteorjs/2000-01-01-start %})
 
 ## Framework Requiring to Serve Static Files
 
-Some Node.js frameworks build static files and need to serve them.
-
-### React Native Application
-
-A React Native application is a client-side JavaScript application (mostly JavaScript files).
-Deploying one on Scalingo requires a minimal web server such as the one presented [here]({%
-post_url platform/app/2000-01-01-static-files-hosting %}).
-
-### Ionic Application
-
-Just like React Native application, Ionic framework is a client-side JavaScript
-application (mostly JavaScript files). Deploying one on Scalingo requires a
-minimal web server such as the one presented [here]({% post_url
-platform/app/2000-01-01-static-files-hosting %}) to serve the file generated
-during the build phase.
-
-### Ember.js
-
-Your `package.json` must at least specify the following scripts:
+Some Node.js frameworks, such as React Native or Ionic, build static files and
+need a minimal web server to serve them. In order to do so, first update your
+`package.json` to at least specify the following scripts:
 
 ```json
 {
   // …
   "scripts": {
-    "build": "ember build -prod",
+    "build": "<build script>",
     "start": "node server.js",
   },
   // …
 }
 ```
+
+The `build` script depends on the framework you use:
+
+- Ionic: `ionic-app-scripts build`
+- Ember.js: `ember build -prod`
+- GatsbyJS: `gatsby build`
 
 The `server.js` file is a minimal web server such as the one presented [here]({%
 post_url platform/app/2000-01-01-static-files-hosting %}) to serve the file

--- a/_posts/languages/nodejs/2000-01-01-start.md
+++ b/_posts/languages/nodejs/2000-01-01-start.md
@@ -197,8 +197,8 @@ languages/meteorjs/2000-01-01-start %})
 
 ## Framework Requiring to Serve Static Files
 
-Some front-end javascript frameworks, such as React Native, Ember.js, Ionic,
-Next.js, GatsbyJS, build static files and need a minimal web server to serve
+Some front-end javascript frameworks (such as React Native, Ember.js, Ionic,
+Next.js, GatsbyJS) build static files and need a minimal web server to serve
 them. In order to do so, first update your `package.json` to at least 
 specify the following scripts:
 

--- a/_posts/languages/nodejs/2000-01-01-start.md
+++ b/_posts/languages/nodejs/2000-01-01-start.md
@@ -197,9 +197,10 @@ languages/meteorjs/2000-01-01-start %})
 
 ## Framework Requiring to Serve Static Files
 
-Some Node.js frameworks, such as React Native or Ionic, build static files and
-need a minimal web server to serve them. In order to do so, first update your
-`package.json` to at least specify the following scripts:
+Some front-end javascript frameworks, such as React Native, Ember.js, Ionic,
+Next.js, GatsbyJS, build static files and need a minimal web server to serve
+them. In order to do so, first update your `package.json` to at least 
+specify the following scripts:
 
 ```json
 {
@@ -214,9 +215,10 @@ need a minimal web server to serve them. In order to do so, first update your
 
 The `build` script depends on the framework you use:
 
-- Ionic: `ionic-app-scripts build`
-- Ember.js: `ember build -prod`
+- Ember.js: `ember build --environment=production`
 - GatsbyJS: `gatsby build`
+- Ionic: `ionic-app-scripts build`
+- Next.js: `next build`
 
 The `server.js` file is a minimal web server such as the one presented [here]({%
 post_url platform/app/2000-01-01-static-files-hosting %}) to serve the file

--- a/_posts/languages/nodejs/2000-01-01-start.md
+++ b/_posts/languages/nodejs/2000-01-01-start.md
@@ -195,19 +195,42 @@ be considered as a Meteor application.
 See the [Meteor applications documentation]({% post_url
 languages/meteorjs/2000-01-01-start %})
 
-## React Native Application
+## Framework Requiring to Serve Static Files
 
-A React Native application is a client-side Javascript application (mostly Javascript files).
+Some Node.js frameworks build static files and need to serve them.
+
+### React Native Application
+
+A React Native application is a client-side JavaScript application (mostly JavaScript files).
 Deploying one on Scalingo requires a minimal web server such as the one presented [here]({%
 post_url platform/app/2000-01-01-static-files-hosting %}).
 
-## Ionic Application
+### Ionic Application
 
-Just like React Native application, Ionic framework is a client-side Javascript
-application (mostly Javascript files). Deploying one on Scalingo requires a
+Just like React Native application, Ionic framework is a client-side JavaScript
+application (mostly JavaScript files). Deploying one on Scalingo requires a
 minimal web server such as the one presented [here]({% post_url
 platform/app/2000-01-01-static-files-hosting %}) to serve the file generated
 during the build phase.
+
+### Ember.js
+
+Your `package.json` must at least specify the following scripts:
+
+```json
+{
+  // …
+  "scripts": {
+    "build": "ember build -prod",
+    "start": "node server.js",
+  },
+  // …
+}
+```
+
+The `server.js` file is a minimal web server such as the one presented [here]({%
+post_url platform/app/2000-01-01-static-files-hosting %}) to serve the file
+generated during the build phase.
 
 ## Buildpack
 


### PR DESCRIPTION
https://documentation-service-pr633.scalingo.io/languages/nodejs/start#framework-requiring-to-serve-static-files

Fix #590
Fix #631