### PR TITLE
[changelog] Elasticsearch 5.6.16-1

### DIFF
--- a/changelog/databases/_posts/2019-12-24-elasticsearch-5.6.16-1.markdown
+++ b/changelog/databases/_posts/2019-12-24-elasticsearch-5.6.16-1.markdown
@@ -1,0 +1,15 @@
+---
+modified_at: 2019-12-24 13:00:00
+title: 'Elasticsearch - New version: 5.6.16-1'
+---
+
+New version: **5.6.16-1**
+
+This version is the latest version of the 5.6.x branch which reached end of
+life. You should upgrade as soon as possible to the next major version.
+
+Release Notes: [Elastic website](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/release-notes-5.6.16.html)
+
+Docker Image:
+
+* `scalingo/elasticsearch:5.6.16-1`


### PR DESCRIPTION
Tweet:

> [Changelog] Databases - Elasticsearch - New version is now available: 5.6.16-1. 5.6.x reached end of life, you should upgrade to the next major version https://changelog.scalingo.com #elasticsearch #paas #changelog #update