### PR TITLE
[changelog] Nginx 1.17.6

### DIFF
--- a/changelog/buildpacks/_posts/2019-12-20-nginx-1.17.6.markdown
+++ b/changelog/buildpacks/_posts/2019-12-20-nginx-1.17.6.markdown
@@ -1,0 +1,9 @@
+---
+modified_at:	2019-12-20 11:00:00
+title:	'Support Nginx 1.17.6'
+github: 'https://github.com/Scalingo/nginx-buildpack'
+---
+
+Default version for Nginx buildpack apps is now: `1.17.6`
+
+Changelog: [https://nginx.org/en/CHANGES](https://nginx.org/en/CHANGES)


### PR DESCRIPTION
Related to https://github.com/Scalingo/nginx-buildpack/issues/9

Tweet:
> [Changelog] Buildpacks - Nginx - Support of Nginx 1.17.6 https://changelog.scalingo.com #nginx #changelog #PaaS