### PR TITLE
[changelog] Go 1.13.5 and 1.12.14

### DIFF
--- a/_posts/languages/go/2000-01-01-start.md
+++ b/_posts/languages/go/2000-01-01-start.md
@@ -14,7 +14,8 @@ The Go programming language is supported.
 
 #### Officially Supported
 
-* `go1.12.9` (default)
+* `go1.13.5`
+* `go1.12.14` (default)
 * `go1.11.0`
 * `go1.10.3`
 * `go1.9.7`

--- a/changelog/buildpacks/_posts/2019-12-23-go-1.13.5.markdown
+++ b/changelog/buildpacks/_posts/2019-12-23-go-1.13.5.markdown
@@ -1,0 +1,8 @@
+---
+modified_at:	2019-12-23 11:00:00
+title:	'Go - New Versions: 1.13.5 and 1.12.14. 1.12.14 is the new default'
+github: 'https://github.com/Scalingo/go-buildpack'
+---
+
+* Go 1.13.5 [changelog](https://golang.org/doc/devel/release.html#go1.13)
+* Go 1.12.14 [changelog](https://golang.org/doc/devel/release.html#go1.12)


### PR DESCRIPTION
Tweet:
> [Changelog] Buildpacks - Go - New Versions: 1.13.5 and 1.12.14. 1.12.14 is the
> new default. https://changelog.scalingo.com #golang #changelog #PaaS #upgrade