### PR TITLE
[changelog] scalingo-14:v32 and scalingo-18:v11

### DIFF
--- a/changelog/base_image/_posts/2019-12-24-scalingo-14-v32-scalingo-18-v11.markdown
+++ b/changelog/base_image/_posts/2019-12-24-scalingo-14-v32-scalingo-18-v11.markdown
@@ -1,0 +1,16 @@
+---
+modified_at: 2019-12-24 11:30:00
+title: 'Stacks now include hg and bzr'
+---
+
+`hg` and `bzr` are CLI tools respectively for `Mercurial` and `Bazaar`
+repository. Both tools are useful to handle application dependencies hosted on
+such repositories.
+
+`scalingo-14` and `scalingo-18` stacks have been updated. Images are available
+on their respectivy Docker Hub repository:
+
+* `scalingo-14`:
+[https://hub.docker.com/r/scalingo/builder](https://hub.docker.com/r/scalingo/builder)
+* `scalingo-18`:
+[https://hub.docker.com/r/scalingo/builder-18](https://hub.docker.com/r/scalingo/builder-18)


### PR DESCRIPTION
Tweet:

> [Changelog] Stacks - Both stacks include Bazaar and Mercurial CLI tools. https://changelog.scalingo.com #stacks #changelog #PaaS #upgrade