### PR TITLE
[changelog] MongoDB 4.0.14-1

### DIFF
--- a/changelog/databases/_posts/2019-12-24-mongo-4.0.14-1.markdown
+++ b/changelog/databases/_posts/2019-12-24-mongo-4.0.14-1.markdown
@@ -1,0 +1,11 @@
+---
+modified_at: 2019-12-24 14:00:00
+title: 'MongoDB - New versions: 4.0.14-1'
+---
+
+Docker Image:
+
+* `scalingo/mongo:4.0.14-1`
+
+MongoDB changelog:
+[https://docs.mongodb.com/manual/release-notes/4.0/#dec-18-2019](https://docs.mongodb.com/manual/release-notes/4.0/#dec-18-2019)

--- a/changelog/databases/_posts/2019-12-30-mongo-4.0.14-1.markdown
+++ b/changelog/databases/_posts/2019-12-30-mongo-4.0.14-1.markdown
@@ -1,5 +1,5 @@
 ---
-modified_at: 2019-12-24 14:00:00
+modified_at: 2019-12-30 16:00:00
 title: 'MongoDB - New versions: 4.0.14-1'
 ---
 


### PR DESCRIPTION
Tweet:
> [Changelog] - Databases - MongoDB - New default version: 4.0.14-1 -
> https://changelog.scalingo.com #mongodb #changelog #PaaS