### PR TITLE
make autoscaling available upon request instead of private beta 

### DIFF
--- a/_includes/upon_request.md
+++ b/_includes/upon_request.md
@@ -1,0 +1,3 @@
+{% warning %}
+  This feature is currently available upon request. Ask the support to get access to it.
+{% endwarning %}

--- a/_posts/platform/app/2000-01-01-autoscaler.md
+++ b/_posts/platform/app/2000-01-01-autoscaler.md
@@ -5,7 +5,7 @@ modified_at: 2018-04-05 00:00:00
 tags: app scaling metrics autoscaler
 ---
 
-{% include beta_feature.md %}
+{% include upon_request.md %}
 
 {% note %}
   You might want to read first the page about [scaling an application]({% post_url


### PR DESCRIPTION
fix #794

Motivation: as seen by the emails sent by some customers asking to get access to the feature, the "beta" tag is too deceptive. It implies a lack of stability which is not the case here.