### PR TITLE
[changelog] PHP 7.4.2, 7.3.14 and 7.2.27

### DIFF
--- a/_posts/languages/php/2000-01-01-start.md
+++ b/_posts/languages/php/2000-01-01-start.md
@@ -33,9 +33,9 @@ The following PHP versions are compatible with the platform:
 * **5.6** (up to 5.6.40)
 * **7.0** (up to 7.0.33)
 * **7.1** (up to 7.1.33)
-* **7.2** (up to 7.2.26)
-* **7.3** (up to 7.3.13)
-* **7.4** (up to 7.4.1)
+* **7.2** (up to 7.2.27)
+* **7.3** (up to 7.3.14)
+* **7.4** (up to 7.4.2)
 
 ### Select a Version
 

--- a/changelog/buildpacks/_posts/2020-01-27-php-7.4.2.markdown
+++ b/changelog/buildpacks/_posts/2020-01-27-php-7.4.2.markdown
@@ -1,0 +1,11 @@
+---
+modified_at: 2020-01-27 16:00:00
+title: 'PHP - Support of version 7.4.2, 7.3.14 and 7.2.27'
+github: 'https://github.com/Scalingo/php-buildpack'
+---
+
+Changelogs:
+
+* [https://www.php.net/ChangeLog-7.php#7.4.2](https://www.php.net/ChangeLog-7.php#7.4.2)
+* [https://www.php.net/ChangeLog-7.php#7.3.14](https://www.php.net/ChangeLog-7.php#7.3.14)
+* [https://www.php.net/ChangeLog-7.php#7.2.27](https://www.php.net/ChangeLog-7.php#7.2.27)


### PR DESCRIPTION
Tweet:
> [Changelog] Buildpacks - PHP - Support of PHP 7.4.2, 7.3.14 and 7.2.27 https://changelog.scalingo.com #php #changelog #PaaS

Fix Scalingo/php-buildpack#124