### PR TITLE
[changelog] MongoDB 4.0.16-1

### DIFF
--- a/changelog/databases/_posts/2020-02-03-mongo-4.0.16-1.markdown
+++ b/changelog/databases/_posts/2020-02-03-mongo-4.0.16-1.markdown
@@ -1,0 +1,15 @@
+---
+modified_at: 2020-02-04 11:00:00
+title: 'MongoDB - New versions: 4.0.16-1, 3.6.17-1 and 3.4.24-1'
+---
+
+Docker Images:
+
+* `scalingo/mongo:4.0.16-1`
+* `scalingo/mongo:3.6.17-1`
+* `scalingo/mongo:3.4.24-1`
+
+MongoDB changelog:
+* [https://docs.mongodb.com/manual/release-notes/4.0-changelog/#id1](https://docs.mongodb.com/manual/release-notes/4.0-changelog/#id1)
+* [https://docs.mongodb.com/manual/release-notes/3.6/#jan-27-2020](https://docs.mongodb.com/manual/release-notes/3.6/#jan-27-2020)
+* [https://docs.mongodb.com/manual/release-notes/3.4/#jan-27-2020](https://docs.mongodb.com/manual/release-notes/3.4/#jan-27-2020)


### PR DESCRIPTION
Tweet:

> [Changelog] - Databases - MongoDB - New default version: 4.0.16-1 - https://changelog.scalingo.com #mongodb #changelog #PaaS