### PR TITLE
[changelog] PostgreSQL 12.2.0-1, 11.7.0-1, 10.12.0-1 and 9.6.17-1

### DIFF
--- a/changelog/databases/_posts/2020-02-14-postgresql-12.2.0.markdown
+++ b/changelog/databases/_posts/2020-02-14-postgresql-12.2.0.markdown
@@ -1,0 +1,18 @@
+---
+modified_at: 2020-02-14 11:00:00
+title: 'PostgreSQL - Security release: 12.2.0-1, 11.7.0-1, 10.12.0-1 and 9.6.17-1'
+---
+
+PostgreSQL changelog:
+
+* [12.2](https://www.postgresql.org/docs/12/release-12-2.html)
+* [11.7](https://www.postgresql.org/docs/11/release-11-7.html)
+* [10.12](https://www.postgresql.org/docs/10/release-10-12.html)
+* [9.6.17](https://www.postgresql.org/docs/9.6/release-9-6-17.html)
+
+Docker images on [Docker Hub](https://hub.docker.com/r/scalingo/postgresql):
+
+* `scalingo/postgresql:12.2.0-1`
+* `scalingo/postgresql:11.7.0-1`
+* `scalingo/postgresql:10.12.0-1`
+* `scalingo/postgresql:9.6.17-1`


### PR DESCRIPTION
Tweet:

> [Changelog] - Databases - PostgreSQL - New versions: 9.6.17, 10.12, 11.7 and 12.2 - https://changelog.scalingo.com #postgresql #changelog #PaaS