### PR TITLE
Deploy an archive using the CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ docker pull scalingo/scalingo-18:latest
 docker run --rm scalingo/scalingo-18:latest bash -c 'dpkg -l | grep "^ii" | awk '\'' { printf "|%30s | %30s |\n", $2, $3} '\'' ' > _includes/scalingo_18_stack_packages.md
 ```
 
-## Running locally
+## Running Locally
 
 To install dependencies locally:
 

--- a/_posts/platform/deployment/2000-01-01-deploy-from-archive.md
+++ b/_posts/platform/deployment/2000-01-01-deploy-from-archive.md
@@ -2,104 +2,68 @@
 title: Deploy Directly from an Archive
 nav: Deploy from Archive
 modified_at: 2020-02-18 00:00:00
-tags: source deploy
+tags: source deploy archive
 index: 6
 ---
 
-Another way to deploy your application is to directly create a deployment from
-a code archive. This article explains how to use our API to achieve this operation
-to update your application.
+One way to deploy your application is to directly create a deployment from a
+code archive. This article explains how to use this feature using Scalingo
+command line tool.
 
-## The Workflow
+{% include info_command_line_tool.md %}
 
-1. To deploy an application without Git or GitHub, you need to archive your
-   application code in a `tar.gz` archive format.
-2. The archive has to be uploaded somewhere accessible in order to let the
-   platform fetch the code during the deployment process. You can either upload
-   it yourself directly or use the [`Sources`
-   resource](https://developers.scalingo.com/sources.html) of the API.
-3. From the created source, a property named `download_url` should be used in
-   order to create a new [`Deployment`
-   resource](https://developers.scalingo.com/deployments.html#trigger-manually-a-deployment-from-an-archive)
-   for your application.
+## Usage of the `deploy` Command
 
-That's it the deployment is starting, once finished with success it will
-replace the current containers with the new version of the code.
+To deploy an application without Git or GitHub, you need to archive your
+application code in a `tar.gz` archive format. The archive must contain the
+source code at the root of the archive (i.e. not in a subfolder).
 
-## Create a `Deployment` Resource With API
+For example, if your archive is named `my-app.tar.gz`, its content should look
+like:
 
-To deploy your archive, you have to make a POST request on `https://api.scalingo.com/v1/apps/[:app]/deployments`:
-
-```bash
-curl -H "Accept: application/json" -H "Content-Type: application/json" -u ":$AUTH_TOKEN" \
-  -X POST https://api.scalingo.com/v1/apps/[:app]/deployments -d \
-    '{
-      "deployment": {
-        "git_ref": "v0.0.2",
-        "download_url": "https://github.com/Scalingo/sample-go-martini/archive/master.tar.gz"
-      }
-    }'
+```sh
+$ tar -ztvf master.tar.gz
+-rw-rw-r-- root/root       277 2019-12-02 18:26 README.md
+-rw-rw-r-- root/root       167 2019-12-02 18:26 composer.json
+-rw-rw-r-- root/root         3 2019-12-02 18:26 composer.lock
+-rw-rw-r-- root/root        19 2019-12-02 18:26 index.php
 ```
 
-* The `AUTH_TOKEN` is a token authenticating the request, you can find tokens
-  on your [dashboard](https://my.scalingo.com/profile) or from our API.
-  Information are available
-  [here](https://developers.scalingo.com/index.html#authentication).
+And you can deploy it using Scalingo CLI:
 
-* Replace `[:app]` by your application name which must be created in the first
-  place. You can do that on our platform
-  [my.scalingo.com](https://my.scalingo.com), [with our CLI]({% post_url
-  platform/cli/2000-01-01-start %}#features) or [by using directly our API
-  ](https://developers.scalingo.com/apps.html#create-an-application).
-
-* The `git_ref` is optional. This attribute must provide any string identifying
-  your archive.
-* The `download_url` is the link where our platform can download your archive.
-
-## Follow the Deployment Process
-
-You can see your deployment progress and output in [your
-dashboard](https://my.scalingo.com), in the 'Deployments' section of your
-application, or using the `deployments-follow` command of [our command line
-tool](http://cli.scalingo.com).
-
-## Create a Source for the Archive
-
-If the code archive has to be uploaded from your workstation, you can optionally
-create a `Source` resource using the API. The source let you upload temporarily
-code archives to trigger deployments with them.
-
-### Create a Source
-
-To create a source, you will have to make a POST request on
-`https://api.scalingo.com/v1/sources`.
-
-```bash
-curl -H "Accept: application/json" -H "Content-Type: application/json" -u :$AUTH_TOKEN \
-  -X POST https://api.scalingo.com/v1/sources -d ''
+```sh
+$ scalingo --app my-app deploy my-app.tar.gz
+-----> Deploying tarball archive: master.tar.gz
+-----> Uploading archive…
+       Deployment started, streaming output:
+[LOG] <-- Start deployment of my-app -->
+[LOG] Fetching source code
+[...]
+[STATUS] New status: pushing
+[LOG]  Build complete, shipping your container...
+[STATUS] New status: pushing →  starting
+[LOG]  Waiting for your application to boot...
+[LOG] <-- https://my-app.osc-fr1.scalingo.io -->
+[STATUS] New status: starting →  success
 ```
 
-The response will look like:
+{% note %}
+Protip: If you want to create an archive from a Git repository and deploy it to
+Scalingo, here is a clever one-liner:
 
-```json
-{
-  "upload_url": "https://api.scalingo.com/v1/sources/123e4567-e89b-12d3-a456-426655440000?token=dc958153c3cd32659ffad5deeda9405d",
-  "download_url": "https://api.scalingo.com/v1/sources/123e4567-e89b-12d3-a456-426655440000?token=9df650a60014571abff0ee4e2d06a8fc"
-}
 ```
-
-The source provide two important URL:
-
-* a `upload_url`: used to upload your code on the source.
-* a `download_url`: used to download the archive from the source.
-
-### Upload on the Source
-
-To upload your data on the source, you have to make a PUT request on the source
-`upload_url`.
-
-```bash
-curl -L -X PUT --upload-file ./archive.tar.gz 'https://api.scalingo.com/v1/sources/123e4567-e89b-12d3-a456-426655440000?token=dc958153c3cd32659ffad5deeda9405d'
+$ git archive --prefix=master/ master > master.tar && \
 ```
+```
+  gzip master.tar && \
+```
+```
+  scalingo --app my-app deploy master.tar.gz
+```
+{% endnote %}
 
-More information [here](https://developers.scalingo.com/sources.html).
+### And After?
+
+See [Deployment Environment]({% post_url platform/app/2000-01-01-environment
+%}#build-environment) to configure your application and [Procfile]({% post_url
+platform/app/2000-01-01-procfile %}).

--- a/_posts/platform/deployment/2000-01-01-deploy-from-archive.md
+++ b/_posts/platform/deployment/2000-01-01-deploy-from-archive.md
@@ -1,6 +1,6 @@
 ---
 title: Deploy Directly from an Archive
-nav: Archive/Tarball
+nav: Deploy from Archive
 modified_at: 2020-02-18 00:00:00
 tags: source deploy
 index: 6

--- a/_posts/platform/deployment/2000-01-01-deploy-from-archive.md
+++ b/_posts/platform/deployment/2000-01-01-deploy-from-archive.md
@@ -1,7 +1,7 @@
 ---
 title: Deploy Directly from an Archive
 nav: Archive/Tarball
-modified_at: 2017-09-11 00:00:00
+modified_at: 2020-02-18 00:00:00
 tags: source deploy
 index: 6
 ---
@@ -26,7 +26,7 @@ to update your application.
 That's it the deployment is starting, once finished with success it will
 replace the current containers with the new version of the code.
 
-## Create a `Deployment` resource with API
+## Create a `Deployment` Resource With API
 
 To deploy your archive, you have to make a POST request on `https://api.scalingo.com/v1/apps/[:app]/deployments`:
 
@@ -56,7 +56,7 @@ curl -H "Accept: application/json" -H "Content-Type: application/json" -u ":$AUT
   your archive.
 * The `download_url` is the link where our platform can download your archive.
 
-## Follow the deployment process
+## Follow the Deployment Process
 
 You can see your deployment progress and output in [your
 dashboard](https://my.scalingo.com), in the 'Deployments' section of your

--- a/_posts/platform/deployment/2000-01-01-deploy-from-archive.md
+++ b/_posts/platform/deployment/2000-01-01-deploy-from-archive.md
@@ -16,17 +16,18 @@ command line tool.
 
 To deploy an application without Git or GitHub, you need to archive your
 application code in a `tar.gz` archive format. The archive must contain the
-source code at the root of the archive (i.e. not in a subfolder).
+source code in a subfolder at the root of the archive.
 
 For example, if your archive is named `my-app.tar.gz`, its content should look
 like:
 
 ```sh
 $ tar -ztvf my-app.tar.gz
--rw-rw-r-- root/root       277 2019-12-02 18:26 README.md
--rw-rw-r-- root/root       167 2019-12-02 18:26 composer.json
--rw-rw-r-- root/root         3 2019-12-02 18:26 composer.lock
--rw-rw-r-- root/root        19 2019-12-02 18:26 index.php
+drwxrwxr-x root/root         0 2019-12-02 18:26 master/
+-rw-rw-r-- root/root       277 2019-12-02 18:26 master/README.md
+-rw-rw-r-- root/root       167 2019-12-02 18:26 master/composer.json
+-rw-rw-r-- root/root         3 2019-12-02 18:26 master/composer.lock
+-rw-rw-r-- root/root        19 2019-12-02 18:26 master/index.php
 ```
 
 And you can deploy it using Scalingo CLI:

--- a/_posts/platform/deployment/2000-01-01-deploy-from-archive.md
+++ b/_posts/platform/deployment/2000-01-01-deploy-from-archive.md
@@ -22,7 +22,7 @@ For example, if your archive is named `my-app.tar.gz`, its content should look
 like:
 
 ```sh
-$ tar -ztvf master.tar.gz
+$ tar -ztvf my-app.tar.gz
 -rw-rw-r-- root/root       277 2019-12-02 18:26 README.md
 -rw-rw-r-- root/root       167 2019-12-02 18:26 composer.json
 -rw-rw-r-- root/root         3 2019-12-02 18:26 composer.lock

--- a/_posts/platform/deployment/2000-01-01-deploy-java-jar-war.md
+++ b/_posts/platform/deployment/2000-01-01-deploy-java-jar-war.md
@@ -16,6 +16,9 @@ execute the application test suites against it. Instead of building a second
 time the application code, the JAR and WAR archives generated during the build
 can be directly deployed on Scalingo.
 
+This deployment method currently only supports Tomcat server to execute your
+archive.
+
 ## Install Scalingo CLI
 
 JAR and WAR archives can be deployed using the platform command line interface, first

--- a/_posts/platform/deployment/2000-01-01-deploy-java-jar-war.md
+++ b/_posts/platform/deployment/2000-01-01-deploy-java-jar-war.md
@@ -1,7 +1,7 @@
 ---
 title: Deployment of JAR and WAR archives
-nav: JAR and WAR archives
-modified_at: 2018-02-09 00:00:00
+nav: Deploy JAR/WAR
+modified_at: 2020-02-18 00:00:00
 index: 5
 tags: deployment, java, jar, war
 ---


### PR DESCRIPTION
The page was really outdated, we have the Scalingo CLI to handle archive deployments now:

https://documentation-service-pr837.scalingo.io/platform/deployment/deploy-from-archive

Fix #836