### PR TITLE
[changelog] PHP 7.4.3, 7.3.15 and 7.2.28

### DIFF
--- a/_posts/languages/php/2000-01-01-start.md
+++ b/_posts/languages/php/2000-01-01-start.md
@@ -1,7 +1,7 @@
 ---
 title: PHP on Scalingo
 nav: Introduction
-modified_at: 2020-01-16 00:00:00
+modified_at: 2020-03-02 00:00:00
 tags: php
 index: 1
 ---
@@ -33,22 +33,22 @@ The following PHP versions are compatible with the platform:
 * **5.6** (up to 5.6.40)
 * **7.0** (up to 7.0.33)
 * **7.1** (up to 7.1.33)
-* **7.2** (up to 7.2.27)
-* **7.3** (up to 7.3.14)
-* **7.4** (up to 7.4.2)
+* **7.2** (up to 7.2.28)
+* **7.3** (up to 7.3.15)
+* **7.4** (up to 7.4.3)
 
 ### Select a Version
 
 By default, the **latest stable** version of PHP will be installed, if you need to install
 a precise version it should be mentioned in your `composer.json` file.
 
-Example to get the PHP version `7.3.12` installed:
+Example to get the PHP version `7.4.3` installed:
 
 ```
 {
   "config": {
     "platform": {
-      "php": "7.3.12"
+      "php": "7.4.3"
     }
   }
 }

--- a/changelog/buildpacks/_posts/2020-03-02-php-7.4.3.markdown
+++ b/changelog/buildpacks/_posts/2020-03-02-php-7.4.3.markdown
@@ -1,0 +1,11 @@
+---
+modified_at: 2020-03-02 10:00:00
+title: 'PHP - Support of version 7.4.3, 7.3.15 and 7.2.28'
+github: 'https://github.com/Scalingo/php-buildpack'
+---
+
+Changelogs:
+
+* [https://www.php.net/ChangeLog-7.php#7.4.3](https://www.php.net/ChangeLog-7.php#7.4.3)
+* [https://www.php.net/ChangeLog-7.php#7.3.15](https://www.php.net/ChangeLog-7.php#7.3.15)
+* [https://www.php.net/ChangeLog-7.php#7.2.28](https://www.php.net/ChangeLog-7.php#7.2.28)


### PR DESCRIPTION
Tweet:

> [Changelog] Buildpacks - PHP - Support of PHP 7.4.3, 7.3.15 and 7.2.28 https://changelog.scalingo.com #php #changelog #PaaS