### PR TITLE
Specifying the PHP version is done via .require.php

### DIFF
--- a/_posts/languages/php/2000-01-01-start.md
+++ b/_posts/languages/php/2000-01-01-start.md
@@ -42,18 +42,22 @@ The following PHP versions are compatible with the platform:
 By default, the **latest stable** version of PHP will be installed, if you need to install
 a precise version it should be mentioned in your `composer.json` file.
 
-Example to get the PHP version `7.4.3` installed:
+Example to install the latest PHP version from the `7.4` branch:
 
 ```
 {
   "require": {
-    "php": "7.4.3"
+    "php": "7.4"
   }
 }
 ```
 
+It installs the version 7.4.3 at the time of writing.
+
 {% note %}
-  You can precise a version directly or use any parent version: for instance `7.0` to get the latest version of the 7.0 version branch.
+You should not specify a precise version such as `7.4.3` or you would miss
+important updates. You should specify `7.4` to install a version `7.4.x` or
+specify `7` to install a version `7.x`.
 {% endnote %}
 
 ## Composer

--- a/_posts/languages/php/2000-01-01-start.md
+++ b/_posts/languages/php/2000-01-01-start.md
@@ -46,10 +46,8 @@ Example to get the PHP version `7.4.3` installed:
 
 ```
 {
-  "config": {
-    "platform": {
-      "php": "7.4.3"
-    }
+  "require": {
+    "php": "7.4.3"
   }
 }
 ```


### PR DESCRIPTION
`.config.platform.php` is not meant for production usage:

https://getcomposer.org/doc/06-config.md#platform

> Lets you fake platform packages (PHP and extensions) so that you can emulate a production env