### PR TITLE
Add last changelog of the dev doc changelog

### DIFF
--- a/changelog/api/_posts/2020-01-03-notifications-path-deprecation.md
+++ b/changelog/api/_posts/2020-01-03-notifications-path-deprecation.md
@@ -1,0 +1,8 @@
+---
+modified_at: 2020-01-03 10:00:00
+title: 'Notifications API endpoint removal in favor of notifiers'
+---
+
+On Monday, January 6th 2020, the deprecated `/apps/:id/notifications` API
+endpoint will be removed in favor of `/apps/:id/notifiers`
+([doc](https://developers.scalingo.com/notifiers)).


### PR DESCRIPTION
I just imported the last entry of the developers documentation. It's kind of annoying to manually import all the entries...

Related to https://github.com/Scalingo/developers-documentation/pull/81