### PR TITLE
[changelog] Redis 5.0.8-1

### DIFF
--- a/changelog/databases/_posts/2020-03-24-redis.5.0.8-1.markdown
+++ b/changelog/databases/_posts/2020-03-24-redis.5.0.8-1.markdown
@@ -1,0 +1,9 @@
+---
+modified_at: 2020-03-24 08:00:00
+title: 'Redis - New version: 5.0.8-1'
+---
+
+Docker image is now [`scalingo/redis:5.0.8-1`](https://hub.docker.com/r/scalingo/redis/)
+
+Redis CHANGELOG:
+[https://raw.githubusercontent.com/antirez/redis/5.0/00-RELEASENOTES](https://raw.githubusercontent.com/antirez/redis/5.0/00-RELEASENOTES)


### PR DESCRIPTION
Tweet:
> [Changelog] - Databases - Redis - New default version: 5.0.8-1 - https://changelog.scalingo.com #redis #changelog #PaaS