### PR TITLE
[changelog] Ruby 2.7.1, 2.6.6, 2.5.8, 2.4.10

### DIFF
--- a/changelog/buildpacks/_posts/2020-04-01-ruby-2.7.1.md
+++ b/changelog/buildpacks/_posts/2020-04-01-ruby-2.7.1.md
@@ -1,0 +1,12 @@
+---
+modified_at: 2020-04-01 00:00:00
+title: 'Ruby - New versions available: 2.7.1, 2.6.6, 2.5.8, 2.4.10'
+github: 'https://github.com/Scalingo/ruby-buildpack'
+---
+
+Changelogs:
+
+* [2.7.1](https://www.ruby-lang.org/en/news/2020/03/31/ruby-2-7-1-released/)
+* [2.6.6](https://www.ruby-lang.org/en/news/2020/03/31/ruby-2-6-6-released/)
+* [2.5.8](https://www.ruby-lang.org/en/news/2020/03/31/ruby-2-5-8-released/)
+* [2.4.10](https://www.ruby-lang.org/en/news/2020/03/31/ruby-2-4-10-released/)


### PR DESCRIPTION
Tweet:

> [Changelog] Buildpacks - Ruby - Support of Ruby 2.7.1, 2.6.6, 2.5.8 and 2.4.10 https://changelog.scalingo.com #php #changelog #PaaS