### PR TITLE
[changelog] PostgreSQL 12.2.0-2 and Elasticsearch 6.8.6-2

### DIFF
--- a/changelog/databases/_posts/2020-04-16-elasticsearch-6.8.6-2.markdown
+++ b/changelog/databases/_posts/2020-04-16-elasticsearch-6.8.6-2.markdown
@@ -1,0 +1,13 @@
+---
+modified_at: 2020-04-16 16:30:00
+title: 'Elasticsearch - New Scalingo release: 6.8.6-2'
+---
+
+New default version: **6.8.6-2**
+
+Changelog:
+- Fix the development mode to let you use the Docker image in a development setup
+
+Docker image on [Docker Hub](https://hub.docker.com/r/scalingo/elasticsearch):
+
+* `scalingo/elasticsearch:6.8.6-2`

--- a/changelog/databases/_posts/2020-04-16-postgresql-12.2.0-2.markdown
+++ b/changelog/databases/_posts/2020-04-16-postgresql-12.2.0-2.markdown
@@ -1,0 +1,13 @@
+---
+modified_at: 2020-04-16 11:00:00
+title: 'PostgreSQL - New Scalingo release: 12.2.0-2'
+---
+
+New default version: **12.2.0-2**
+
+Changelog:
+- Fix the development mode to let you use the Docker image in a development setup
+
+Docker image on [Docker Hub](https://hub.docker.com/r/scalingo/postgresql):
+
+* `scalingo/postgresql:12.2.0-2`


### PR DESCRIPTION
Tweets:

> [Changelog] - Databases - PostgreSQL - New default version: 12.2.0-2 - https://changelog.scalingo.com #postgresql #changelog #PaaS

> [Changelog] - Databases - Elasticsearch - New default version: 6.8.6-2 - https://changelog.scalingo.com #postgresql #changelog #PaaS