### PR TITLE
[changelog] PostgreSQL 12.2.0-3

### DIFF
--- a/changelog/databases/_posts/2020-04-17-postgresql-12.2.0-3.markdown
+++ b/changelog/databases/_posts/2020-04-17-postgresql-12.2.0-3.markdown
@@ -1,0 +1,13 @@
+---
+modified_at: 2020-04-17 14:00:00
+title: 'PostgreSQL - New Scalingo release: 12.2.0-3'
+---
+
+New default version: **12.2.0-3**
+
+Changelog:
+- Fix the development mode to let you use the Docker image in a development setup
+
+Docker image on [Docker Hub](https://hub.docker.com/r/scalingo/postgresql):
+
+* `scalingo/postgresql:12.2.0-3`


### PR DESCRIPTION
> [Changelog] - Databases - PostgreSQL - New default version: 12.2.0-3 - https://changelog.scalingo.com #postgresql #changelog #PaaS

Related to https://github.com/Scalingo/one-stop-shop/issues/89