### PR TITLE
Add node in documentation saying the multi-buildpack is now detected by default, no more need for BUILDPACK_URL

### DIFF
--- a/_posts/platform/deployment/buildpacks/2000-01-01-multi.md
+++ b/_posts/platform/deployment/buildpacks/2000-01-01-multi.md
@@ -11,18 +11,13 @@ You may need to combine several technologies in your project, this buildpack is 
 
 ## Set up this buildpack for your application
 
+If your application containers `.buildpacks` file at its root, our deployment
+system will automatically use this buildpack.
+
 {% note %}
-This buildpack is now automatically detected by our deployment system, if your
-project contains a `.buildpacks` file at its root. Defining `BUILDPACK_URL` is
-not a requirement anymore.
+The environment variable `BUILDPACK_URL` used to be requried to use the
+multi-buildpack but it's not the case anymore, the `.buildpacks` file is enough
 {% endnote %}
-
-By setting the configuration variable `BUILDPACK_URL`, the Scalingo's deployment stack will
-automatically fetch the given buildpack to deploy your application.
-
-```bash
-scalingo env-set BUILDPACK_URL=https://github.com/Scalingo/multi-buildpack.git
-```
 
 ## Choice of the buildpacks to use
 

--- a/_posts/platform/deployment/buildpacks/2000-01-01-multi.md
+++ b/_posts/platform/deployment/buildpacks/2000-01-01-multi.md
@@ -11,7 +11,7 @@ You may need to combine several technologies in your project, this buildpack is 
 
 ## Set up this buildpack for your application
 
-If your application containers `.buildpacks` file at its root, our deployment
+If your application contains a `.buildpacks` file at its root, our deployment
 system will automatically use this buildpack.
 
 {% note %}

--- a/_posts/platform/deployment/buildpacks/2000-01-01-multi.md
+++ b/_posts/platform/deployment/buildpacks/2000-01-01-multi.md
@@ -15,7 +15,7 @@ If your application containers `.buildpacks` file at its root, our deployment
 system will automatically use this buildpack.
 
 {% note %}
-The environment variable `BUILDPACK_URL` used to be requried to use the
+The environment variable `BUILDPACK_URL` used to be required to use the
 multi-buildpack but it's not the case anymore, the `.buildpacks` file is enough
 {% endnote %}
 

--- a/_posts/platform/deployment/buildpacks/2000-01-01-multi.md
+++ b/_posts/platform/deployment/buildpacks/2000-01-01-multi.md
@@ -11,6 +11,12 @@ You may need to combine several technologies in your project, this buildpack is 
 
 ## Set up this buildpack for your application
 
+{% note %}
+This buildpack is now automatically detected by our deployment system, if your
+project contains a `.buildpacks` file at its root. Defining `BUILDPACK_URL` is
+not a requirement anymore.
+{% endnote %}
+
 By setting the configuration variable `BUILDPACK_URL`, the Scalingo's deployment stack will
 automatically fetch the given buildpack to deploy your application.
 


### PR DESCRIPTION
Part of fix for https://github.com/Scalingo/one-stop-shop/issues/28