### PR TITLE
Changelog entry announcing the default support for the multi-buildpack

### DIFF
--- a/changelog/buildpacks/_posts/2020-04-24-multi-buildpack.markdown
+++ b/changelog/buildpacks/_posts/2020-04-24-multi-buildpack.markdown
@@ -1,0 +1,9 @@
+---
+modified_at:	2020-04-24 11:00:00
+title:	'Default detection of multi-buildpack'
+github: 'https://github.com/Scalingo/multi-buildpack'
+---
+
+The [multi-buildpacks]({% post_url platform/deployment/buildpacks/2000-01-01-multi %}) is now automatically detected if you have a `.buildpacks` file at the root of your project.
+
+It means the environment variable `BUILDPACK_URL` is not required anymore to activate it.


### PR DESCRIPTION
Part of fix for https://github.com/Scalingo/one-stop-shop/issues/28