### PR TITLE
[changelog] Go 1.14.2, 1.13.10 and 1.12.17

### DIFF
--- a/_posts/languages/go/2000-01-01-start.md
+++ b/_posts/languages/go/2000-01-01-start.md
@@ -1,7 +1,7 @@
 ---
 title: Go
 nav: Introduction
-modified_at: 2018-02-23 00:00:00
+modified_at: 2020-04-28 00:00:00
 tags: go
 index: 1
 ---
@@ -14,11 +14,11 @@ The Go programming language is supported.
 
 #### Officially Supported
 
-* `go1.13.5`
-* `go1.12.14` (default)
-* `go1.11.0`
-* `go1.10.3`
-* `go1.9.7`
+* `go1.14.2`
+* `go1.13.10`
+* `go1.12.17` (default)
+* `go1.11.13`
+* `go1.10.8`
 
 #### Other Versions
 

--- a/changelog/buildpacks/_posts/2020-04-28-go-1.14.2.markdown
+++ b/changelog/buildpacks/_posts/2020-04-28-go-1.14.2.markdown
@@ -1,0 +1,11 @@
+---
+modified_at: 2020-04-28 16:30:00
+title: 'Go - New Versions: 1.14.2, 1.13.10 and 1.12.17. 1.12.17 is the new default'
+github: 'https://github.com/Scalingo/go-buildpack'
+---
+
+Changelogs:
+
+* Go 1.14.2 [changelog](https://golang.org/doc/devel/release.html#go1.14)
+* Go 1.13.10 [changelog](https://golang.org/doc/devel/release.html#go1.13)
+* Go 1.12.17 [changelog](https://golang.org/doc/devel/release.html#go1.12)


### PR DESCRIPTION
Tweet:

> [Changelog] Buildpacks - Go - Support of Go 1.14.2, 1.13.10 and 1.12.17. 1.12.17 is the new default https://changelog.scalingo.com #golang #changelog #PaaS