### PR TITLE
[changelog] CLI 1.17.0

### DIFF
--- a/changelog/cli/_posts/2020-05-15-1-17-0.md
+++ b/changelog/cli/_posts/2020-05-15-1-17-0.md
@@ -1,0 +1,18 @@
+---
+modified_at: 2020-05-15 16:00:00
+title: 'CLI - New version: 1.17.0'
+github: 'https://github.com/Scalingo/cli/releases'
+---
+
+Installation:
+
+[https://cli.scalingo.com](https://cli.scalingo.com)
+
+Changelog:
+
+* Region Migration: Better output for the `migration-follow` command to explain what is happening [#549](https://github.com/Scalingo/cli/pull/549)
+* Region Migration: Retry if it fails to refresh the migration status [#550](https://github.com/Scalingo/cli/pull/550)
+* Region Migration: Add instructions to change local Git URL at the end of the migration [#551](https://github.com/Scalingo/cli/pull/551)
+* Deployment: Send a non 0 exit code when a deployment fails [#563](https://github.com/Scalingo/cli/pull/563)
+* Bugfix: fix support for `addon_updated` and `start_region_migration` event type [#558](https://github.com/Scalingo/cli/pull/558)
+* Bugfix: fix author of `restart` and `edit_variable` when it's an addon [#558](https://github.com/Scalingo/cli/pull/558)


### PR DESCRIPTION
Tweet:

> [Changelog] CLI - Release of version 1.17.0 https://cli.scalingo.com - More news at https://changelog.scalingo.com #cli #paas #changelog #bugfix