### PR TITLE
Second attempt at improving the Scalingo CLI SEO in Algolia search bar

### DIFF
--- a/_posts/platform/cli/2000-01-01-start.md
+++ b/_posts/platform/cli/2000-01-01-start.md
@@ -1,7 +1,7 @@
 ---
 title: Command Line Interface (CLI)
 nav: Install
-modified_at: 2020-05-15 00:00:00
+modified_at: 2020-05-19 00:00:00
 tags: cli interface app
 index: 1
 oses:
@@ -11,6 +11,8 @@ oses:
   - FreeBSD
   - OpenBSD
 ---
+
+## Instal Scalingo CLI
 
 We provide a command line interface (CLI) tool to interact with the platform.
 This page describes how to install Scalingo CLI tool.

--- a/_posts/platform/deployment/2000-01-01-deploy-java-jar-war.md
+++ b/_posts/platform/deployment/2000-01-01-deploy-java-jar-war.md
@@ -1,7 +1,7 @@
 ---
 title: Deployment of JAR and WAR archives
 nav: Deploy JAR/WAR
-modified_at: 2020-02-18 00:00:00
+modified_at: 2020-05-19 00:00:00
 index: 5
 tags: deployment, java, jar, war
 ---
@@ -19,10 +19,7 @@ can be directly deployed on Scalingo.
 This deployment method currently only supports Tomcat server to execute your
 archive.
 
-## Install Scalingo CLI
-
-JAR and WAR archives can be deployed using the platform command line interface, first
-step is to install it: [CLI Documentation]({% post_url platform/cli/2000-01-01-start %})
+{% include info_command_line_tool.md %}
 
 ## Usage of the `deploy` command
 


### PR DESCRIPTION
- Remove the title "Install Scalingo CLI" from "Deploy JAR/WAR" page (https://doc.scalingo.com/platform/deployment/deploy-java-jar-war#install-scalingo-cli)
- Add a title "Install Scalingo CLI" on the CLI page https://doc.scalingo.com/platform/cli/start

Related to #419