### PR TITLE
Domains: clarify a few things about custom certificates

### DIFF
--- a/_posts/platform/app/2000-01-01-ssl.md
+++ b/_posts/platform/app/2000-01-01-ssl.md
@@ -175,21 +175,21 @@ A lot of certificate authorities provide certificate chains or bundles alongside
 your signed certificate (most common is the Certification Authority, but they may
 supply any intermediary certificates).
 
-To upload all ofthose certificates, you have to create one file, with all the
+To upload all those certificates, you have to create one file, with all the
 certificates concatenated in the
 [PEM format](https://en.wikipedia.org/wiki/Privacy-enhanced_Electronic_Mail).
 This is a textual format, so any text editor is able to do it.
 
-#### File formats and conversions
+#### File Formats and Conversions
 
 Your certificates may have been supplied in a binary format: if you
-have a `.cer`, `.crt` or `.der` file, it _should_ be binary, but those
+have a `.cer`, `.crt` or `.der` file, it _should_ be binary. But those
 extensions are sometimes used for PEM files too.
 
 {% note %}
-  Thos file formats (and extensions) are part of a standard called
+  These file formats (and extensions) are part of a standard called
   [X.509](https://en.wikipedia.org/wiki/X.509), which is why your provider
-  may have given you "X509 certificates"; this is the generic name for the
+  may have given you "X509 certificates". This is the generic name for the
   certificates format.
 {% endnote %}
 
@@ -197,14 +197,14 @@ You can check by opening the file with a text editor: if you see
 "BEGIN CERTIFICATE", then it's textual. If this is a binary file, your editor
 should tell you so.
 
-In the latter case, you can convert it text using openssl; the following command
-should work on linux-based OS and macOS:
+In the latter case, you can convert it to text using `openssl`. The following command
+should work on Linux-based OS and macOS:
 
 ```
 openssl x509 -inform DER -in <yourcertificate.crt> -out yourcertificate.pem
 ```
 
-#### Creating the bundle
+#### Creating the Bundle
 
 Create a file (for instance, `certificate.pem`). First add your certificate,
 then append all the intermediate certificates of the certificate chain:

--- a/_posts/platform/app/2000-01-01-ssl.md
+++ b/_posts/platform/app/2000-01-01-ssl.md
@@ -171,7 +171,43 @@ In both cases the modification is applied instantly.
 
 ### How to Upload Certificate Chains
 
-A lot of certificate authorities provide certificate chains or bundles alongside your signed certificate. To upload all those certificates, you have to create one file, with all the certificates concatenated. First add your certificate, then append all the intermediate certificates of the certificate chain.
+A lot of certificate authorities provide certificate chains or bundles alongside
+your signed certificate (most common is the Certification Authority, but they may
+supply any intermediary certificates).
+
+To upload all ofthose certificates, you have to create one file, with all the
+certificates concatenated in the
+[PEM format](https://en.wikipedia.org/wiki/Privacy-enhanced_Electronic_Mail).
+This is a textual format, so any text editor is able to do it.
+
+#### File formats and conversions
+
+Your certificates may have been supplied in a binary format: if you
+have a `.cer`, `.crt` or `.der` file, it _should_ be binary, but those
+extensions are sometimes used for PEM files too.
+
+{% note %}
+  Thos file formats (and extensions) are part of a standard called
+  [X.509](https://en.wikipedia.org/wiki/X.509), which is why your provider
+  may have given you "X509 certificates"; this is the generic name for the
+  certificates format.
+{% endnote %}
+
+You can check by opening the file with a text editor: if you see
+"BEGIN CERTIFICATE", then it's textual. If this is a binary file, your editor
+should tell you so.
+
+In the latter case, you can convert it text using openssl; the following command
+should work on linux-based OS and macOS:
+
+```
+openssl x509 -inform DER -in <yourcertificate.crt> -out yourcertificate.pem
+```
+
+#### Creating the bundle
+
+Create a file (for instance, `certificate.pem`). First add your certificate,
+then append all the intermediate certificates of the certificate chain:
 
 Example:
 


### PR DESCRIPTION
Fix #986 

I used https://en.wikipedia.org/wiki/X.509#Certificate_filename_extensions as a source for my informations, as well as https://stackoverflow.com/questions/642284/do-i-need-to-convert-cer-to-crt-for-apache-ssl-certificates-if-so-how for the convert command.