### PR TITLE
Add gRPC section in TCP-Gateway docs

### DIFF
--- a/_posts/addons/tcp-gateway/2000-01-01-start.md
+++ b/_posts/addons/tcp-gateway/2000-01-01-start.md
@@ -94,6 +94,20 @@ to those containers. Our load balancer distributes connections during the TCP
 handshake. When established, the communication is always routed to the same
 server.
 
+## gRPC
+
+As described in [the routing documentation]({% post_url
+platform/internals/2000-01-01-routing %}), application nodes cannot receive
+HTTP/2 traffic. Thus, you need to deploy your application on the TCP Gateway:
+
+```
+tcp: <run your grpc app>
+```
+
+Your gRPC server will be accessible at the address in `TCP_URL`.
+
+Don’t forget to remove unused web / worker nodes on your app.
+
 ## Rate Limiting
 
 There's no rate limiting in place. It may be put in place later.


### PR DESCRIPTION
I recently managed to deploy a gRPC server on your infra with the help of @ksol on Intercom. I figured it’d be great to document that it’s possible and the few gotchas to know about.

In the paragraph, I am referencing informations from  https://github.com/Scalingo/documentation/pull/973. You might want to wait for it to be merged before merging this one.