### PR TITLE
[Search] Always update the window.location even in prod

### DIFF
--- a/app/javascript/js/search.js
+++ b/app/javascript/js/search.js
@@ -22,5 +22,21 @@ if (searchNode !== null) {
       hint: false,
       openOnFocus: true,
     },
+    handleSelected: function(input, event, suggestion, datasetNumber, context) {
+      // We customize the behaviour of the click on a search result in dev and
+      // in review apps.
+      if (context.selectionMethod !== 'click') {
+        return
+      }
+
+      const location = new URL(window.location);
+      const newBaseURL = `${location.protocol}//${location.host}/`;
+      const prodBaseURL = 'https://doc.scalingo.com/'
+
+      // Replace the domain name doc.scalingo.com with the domain name of the
+      // current review app.
+      // In production, it replaces doc.scalingo.com with doc.scalingo.com.
+      window.location = suggestion.url.replace(prodBaseURL, newBaseURL);
+    },
   })
 }


### PR DESCRIPTION
#992 introduced a bug described in (https://github.com/Scalingo/one-stop-shop/issues/145). What I changed is that we actully need to update the `window.location`, even in prod. Otherwise nothing happens when clicking on a search suggestion.

Related to https://github.com/Scalingo/one-stop-shop/issues/145