### PR TITLE
[DOC] Edit sample package.json with node v12 valid values

### DIFF
--- a/_posts/platform/app/2000-01-01-static-files-hosting.md
+++ b/_posts/platform/app/2000-01-01-static-files-hosting.md
@@ -32,8 +32,8 @@ Don't forget to add a `package.json` file in order to add the `express` dependen
 
 ```json
 {
-  "name" : "My Application",
-  "version" : "1.0",
+  "name" : "my-application",
+  "version" : "1.0.0",
   "dependencies" : {
     "express" : "4.x"
   },


### PR DESCRIPTION
I was trying to deploy a static site with the package.json supplied in the doc and I ran into these errors : 

```
 !   Error deploying the application
 !   → Your application has stopped unexpectedly with the following output:

======== BEGIN OUTPUT ========
2020-06-25 12:01:57.665669761 +0000 UTC [web-1] npm ERR! Invalid name: "Test deploy Storybook"`
```
-> The name attribute doesn't allow spaces or capital letters
```
 !   Error deploying the application
 !   → Your application has stopped unexpectedly with the following output:

======== BEGIN OUTPUT ========
2020-06-25 12:04:25.075129456 +0000 UTC [web-1] npm ERR! Invalid version: "1.0"
```
-> The version attribute takes semver valid version: eg. 1.0.0