### PR TITLE
[Outgoing IP] Typo + reorder

### DIFF
--- a/_posts/platform/internals/2000-01-01-network.md
+++ b/_posts/platform/internals/2000-01-01-network.md
@@ -47,7 +47,7 @@ resolved by **egress.osc-fr1.scalingo.com**, currently:
 - 171.33.105.206
 
 The list of IPs can change in the future, if you need the exhaustive list of the possible
-output IPs, please refer to our provider documentation.
+output IPs, please refer to our provider documentation
 [here](https://wiki.outscale.net/display/EN/3DS+OUTSCALE+Public+IP+Addresses).
 Our `osc-fr1` region is hosted on Outscale `eu-west-2` region.
 

--- a/_posts/platform/internals/2000-01-01-network.md
+++ b/_posts/platform/internals/2000-01-01-network.md
@@ -32,13 +32,6 @@ hidden behind a firewall. You may also be interested by our VPN addons:
 [Scalingo OpenVPN](https://scalingo.com/addons/scalingo-openvpn) and [Scalingo
 VPN IPSec](https://scalingo.com/addons/scalingo-vpn-ipsec).
 
-### agora-fr1 Region
-
-All outgoing traffic from Scalingo hosted applications comes from the following
-range of IP addresses:
-
-- 185.60.151.0/26.
-
 ### osc-fr1 Region
 
 All outgoing traffic from Scalingo hosted applications comes from the IP addresses
@@ -51,6 +44,12 @@ output IPs, please refer to our provider documentation
 [here](https://wiki.outscale.net/display/EN/3DS+OUTSCALE+Public+IP+Addresses).
 Our `osc-fr1` region is hosted on Outscale `eu-west-2` region.
 
+### agora-fr1 Region
+
+All outgoing traffic from Scalingo hosted applications comes from the following
+range of IP addresses:
+
+- 185.60.151.0/26.
 
 ### osc-secnum-fr1 Region
 


### PR DESCRIPTION
I fixed a typo, and reordered the outgoing IPs information to have osc-fr1 first