### PR TITLE
Add a note to inform that procfiles do not accepte multiple same name rules

### DIFF
--- a/_posts/platform/app/2000-01-01-procfile.md
+++ b/_posts/platform/app/2000-01-01-procfile.md
@@ -35,13 +35,14 @@ The standard syntax is:
 
 ```yaml
 <container type>: <command>
-
-# where container type should contain letters and digits only
-# and command can be any command line which can includes environment variables
 ```
-As a note,`container type` are unique in the `Procfile`. So, you cannot have, for example, two `web` `container type`.
+where container type should contain letters and digits only and command can be any command line which can includes environment variables.
+
+{% note %}
+`container type` are unique in the `Procfile`. So, you cannot have, for example, two `web` `container type`.
 If you have, only the second one will be executed, as if the first did not exist.
 If you want run a command, you may want to look at [Post deploy](https://doc.scalingo.com/platform/app/postdeploy-hook).
+{% endnote %}
 
 When you have more complex commands to run, don't hesitate to write a short start script,
 for instance in `bin/start.sh`:

--- a/_posts/platform/app/2000-01-01-procfile.md
+++ b/_posts/platform/app/2000-01-01-procfile.md
@@ -36,9 +36,12 @@ The standard syntax is:
 ```yaml
 <container type>: <command>
 
-container type: should contain letters and digits only
-command: any command line which can includes environment variables
+# where container type should contain letters and digits only
+# and command can be any command line which can includes environment variables
 ```
+As a note,`container type` are unique in the `Procfile`. So, you cannot have, for example, two `web` `container type`.
+If you have, only the second one will be executed, as if the first did not exist.
+If you want run a command, you may want to look at [Post deploy](https://doc.scalingo.com/platform/app/postdeploy-hook).
 
 When you have more complex commands to run, don't hesitate to write a short start script,
 for instance in `bin/start.sh`:

--- a/_posts/platform/app/2000-01-01-procfile.md
+++ b/_posts/platform/app/2000-01-01-procfile.md
@@ -41,7 +41,7 @@ where container type should contain letters and digits only and command can be a
 {% note %}
 `container type` are unique in the `Procfile`. So, you cannot have, for example, two `web` `container type`.
 If you have, only the second one will be executed, as if the first did not exist.
-If you want run a command, you may want to look at [Post deploy](https://doc.scalingo.com/platform/app/postdeploy-hook).
+If you want to run a command, you may want to look at [Post deploy](https://doc.scalingo.com/platform/app/postdeploy-hook).
 {% endnote %}
 
 When you have more complex commands to run, don't hesitate to write a short start script,


### PR DESCRIPTION
Add a block of text to prevent two targets in a procfile
Code followup: https://github.com/Scalingo/api/issues/1747