### PR TITLE
[changelog] Node.js buildpack update

### DIFF
--- a/changelog/buildpacks/_posts/2020-08-06-default-meteor-nodejs.markdown
+++ b/changelog/buildpacks/_posts/2020-08-06-default-meteor-nodejs.markdown
@@ -1,0 +1,8 @@
+---
+modified_at: 2020-08-06 16:00:00
+title: 'Node.js: Meteor 1.9 and 1.10 uses Node.js 12 as default'
+github: 'https://github.com/Scalingo/nodejs-buildpack'
+---
+
+We have updated our Node.js buildpack. The most noticeable change is the use of
+Node.js 12 as default version for Meteor 1.9 and 1.10.

--- a/changelog/buildpacks/_posts/2020-08-06-default-meteor-nodejs.markdown
+++ b/changelog/buildpacks/_posts/2020-08-06-default-meteor-nodejs.markdown
@@ -1,6 +1,6 @@
 ---
 modified_at: 2020-08-06 16:00:00
-title: 'Node.js: Meteor 1.9 and 1.10 uses Node.js 12 as default'
+title: 'Node.js: Meteor 1.9 and 1.10 use Node.js 12 as default'
 github: 'https://github.com/Scalingo/nodejs-buildpack'
 ---
 


### PR DESCRIPTION
Tweet:

> [Changelog] Buildpacks - Node.js - Node.js 12 by default for Meteor 1.9 and 1.10 https://changelog.scalingo.com #Node.js #changelog #PaaS