### PR TITLE
[changelog] PostgreSQL 12.4.0-1, 11.9.0-1, 10.14.0-1 and 9.6.19

### DIFF
--- a/changelog/databases/_posts/2020-08-28-postgresql-12.4.0-1.markdown
+++ b/changelog/databases/_posts/2020-08-28-postgresql-12.4.0-1.markdown
@@ -1,0 +1,19 @@
+---
+modified_at: 2020-08-28 14:00:00
+title: 'PostgreSQL - New Scalingo release: 12.4.0-1, 11.9.0-1, 10.14.0-1 and 9.6.19'
+---
+
+New default version: **12.4.0-1**
+
+Changelog:
+- Bump version of PostgreSQL to last minor. It contains a security fix related
+  to a couple of CVE:
+    - [CVE-2020-14349](https://nvd.nist.gov/vuln/detail/CVE-2020-14349)
+    - [CVE-2020-14350](https://nvd.nist.gov/vuln/detail/CVE-2020-14350)
+
+Docker images on [Docker Hub](https://hub.docker.com/r/scalingo/postgresql):
+
+* `scalingo/postgresql:12.4.0-1`
+* `scalingo/postgresql:11.9.0-1`
+* `scalingo/postgresql:10.14.0-1`
+* `scalingo/postgresql:9.6.19-1`


### PR DESCRIPTION
Tweet:

> [Changelog] - PostgreSQL - New default version: 12.4.0-1 - https://changelog.scalingo.com #postgresql #changelog #PaaS