### PR TITLE
Update 2000-01-01-deploy-scalingo-from-gitlab.md

### DIFF
--- a/_posts/platform/deployment/continuous-integration/2000-01-01-deploy-scalingo-from-gitlab.md
+++ b/_posts/platform/deployment/continuous-integration/2000-01-01-deploy-scalingo-from-gitlab.md
@@ -38,8 +38,10 @@ deploy:development:
     - develop
   script:
     - gem install dpl --pre
-    - dpl --provider=scalingo --app=$SCALINGO_APP_NAME --api-token=$SCALINGO_API_TOKEN --region=$SCALINGO_REGION
+    - dpl --provider=scalingo --app=$SCALINGO_APP_NAME --api-token=$SCALINGO_API_TOKEN --branch=refs/heads/master
 ```
+
+Specifying the remote branch (```--branch```) is necessary, otherwise you will get an error (```unable to push to unqualified destination: master```).
 
 {% note %}
 It is important to install dpl with the `--pre` flag. This is due to an issue in

--- a/_posts/platform/deployment/continuous-integration/2000-01-01-deploy-scalingo-from-gitlab.md
+++ b/_posts/platform/deployment/continuous-integration/2000-01-01-deploy-scalingo-from-gitlab.md
@@ -38,7 +38,7 @@ deploy:development:
     - develop
   script:
     - gem install dpl --pre
-    - dpl --provider=scalingo --app=$SCALINGO_APP_NAME --api-token=$SCALINGO_API_TOKEN --branch=refs/heads/master
+    - dpl --provider=scalingo --app=$SCALINGO_APP_NAME --api-token=$SCALINGO_API_TOKEN --region=$SCALINGO_REGION --branch=refs/heads/master
 ```
 
 Specifying the remote branch (```--branch```) is necessary, otherwise you will get an error (```unable to push to unqualified destination: master```).


### PR DESCRIPTION
Remove the now-unnecessary --region options and specify the remote branch name to push to when deploying.