### PR TITLE
[changelog] PostgreSQL 10.14.0-2

### DIFF
--- a/changelog/databases/_posts/2020-09-22-postgresql-10.14.0-2.markdown
+++ b/changelog/databases/_posts/2020-09-22-postgresql-10.14.0-2.markdown
@@ -1,0 +1,11 @@
+---
+modified_at: 2020-09-22 11:00:00
+title: 'PostgreSQL - New Scalingo release: 10.14.0-2'
+---
+
+Changelog:
+- Fix an issue in Scalingo image when upgrading from 10.4.0-2 to 10.14.0-1
+
+Docker image on [Docker Hub](https://hub.docker.com/r/scalingo/postgresql):
+
+* `scalingo/postgresql:10.14.0-2`


### PR DESCRIPTION
Tweet:

> [Changelog] - PostgreSQL - New version: 10.14.0-2 - https://changelog.scalingo.com #postgresql #changelog #PaaS