### PR TITLE
Move WordPress page to Getting Started section

### DIFF
--- a/_posts/platform/getting-started/2000-01-01-getting-started-with-wordpress.md
+++ b/_posts/platform/getting-started/2000-01-01-getting-started-with-wordpress.md
@@ -1,9 +1,8 @@
 ---
-title: Deploying WordPress on Scalingo
-nav: WordPress
-modified_at: 2020-09-17 00:00:00
+title: Getting Started with WordPres on Scalingo
+modified_at: 2020-09-25 00:00:00
 tags: php, http, framework, wordpress, deployment
-index: 99
+index: 14
 ---
 
 ## Detection

--- a/redirections.yml
+++ b/redirections.yml
@@ -563,6 +563,9 @@
   -
     old: "/platform/app/github-integration"
     new: "/platform/app/scm-integration"
+  -
+    old: "/languages/php/wordpress"
+    new: "/platform/getting-started/getting-started-with-wordpress"
 obsolete:
   - "/how-to-migrate-from-cloudcontrol/"
   - "/how-to-migrate-from-shelly-cloud/"


### PR DESCRIPTION
Redirection: https://documentation-service-pr1071.osc-fr1.scalingo.io/languages/php/wordpress
New link: https://documentation-service-pr1071.osc-fr1.scalingo.io/platform/getting-started/getting-started-with-wordpress


Fix #983