### PR TITLE
[changelog] PHP Composer version is configurable

### DIFF
--- a/changelog/buildpacks/_posts/2020-10-30-php-composer-configurable.markdown
+++ b/changelog/buildpacks/_posts/2020-10-30-php-composer-configurable.markdown
@@ -1,0 +1,7 @@
+---
+modified_at: 2020-10-30 11:30:00
+title: 'PHP - Composer version is now configurable'
+github: 'https://github.com/Scalingo/php-buildpack'
+---
+
+Composer version is now configurable via the `composer.json` file. The documentation is [here](https://doc.scalingo.com/languages/php/start#select-a-composer-version). Scalingo keeps Composer 1 as the default version. It will be changed to Composer 2 by the end of the year 2020.


### PR DESCRIPTION
Tweet:

> [Changelog] Buildpacks - PHP - Composer version is now configurable https://changelog.scalingo.com #php #changelog #PaaS