### PR TITLE
Correct git command for deploying a previous version

### DIFF
--- a/_posts/platform/deployment/2000-01-01-deploy-with-git.md
+++ b/_posts/platform/deployment/2000-01-01-deploy-with-git.md
@@ -45,7 +45,7 @@ If you want to deploy a version of your code that is not the current head of
 master, you first need to get the commit ID with `git log`. Then:
 
 ```bash
-git push --force scalingo <commit ID>:master
+git push --force scalingo <commit ID>:refs/heads/master
 ```
 
 


### PR DESCRIPTION
`git push --force scalingo <commit ID>:master` failes with "error: The destination you provided is not a full refname". `git push --force scalingo <commit ID>:refs/heads/master` works though.

