### PR TITLE
[changelog] PostgreSQL 12.5.0-1, 11.10.0-1, 10.15.0-1 and 9.6.20

### DIFF
--- a/changelog/databases/_posts/2020-11-16-postgresql-12.5.0-1.markdown
+++ b/changelog/databases/_posts/2020-11-16-postgresql-12.5.0-1.markdown
@@ -6,9 +6,8 @@ title: 'PostgreSQL - New Scalingo release: 12.5.0-1, 11.10.0-1, 10.15.0-1 and 9.
 New default version: **12.5.0-1**
 
 Changelog:
-- Bump version of PostgreSQL to last minor. It contains a security fix related
-  to a CVE:
-    - [CVE-2020-25694](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-25694)
+- Bump versions of PostgreSQL to last minor. It contains several security fixes related to various CVEs:
+    - [PostgreSQL blog post](https://www.postgresql.org/about/news/postgresql-131-125-1110-1015-9620-and-9524-released-2111/)
 
 Docker images on [Docker Hub](https://hub.docker.com/r/scalingo/postgresql):
 

--- a/changelog/databases/_posts/2020-11-16-postgresql-12.5.0-1.markdown
+++ b/changelog/databases/_posts/2020-11-16-postgresql-12.5.0-1.markdown
@@ -3,7 +3,7 @@ modified_at: 2020-11-16 11:00:00
 title: 'PostgreSQL - New Scalingo release: 12.5.0-1, 11.10.0-1, 10.15.0-1 and 9.6.20'
 ---
 
-New default version: **12.5.0-1**
+New default version: **12.5.0-1**. All databases will automatically be upgraded in the coming days because of the high severity of the CVEs these releases fix.
 
 Changelog:
 - Bump versions of PostgreSQL to last minor. It contains several security fixes related to various CVEs:

--- a/changelog/databases/_posts/2020-11-16-postgresql-12.5.0-1.markdown
+++ b/changelog/databases/_posts/2020-11-16-postgresql-12.5.0-1.markdown
@@ -1,0 +1,18 @@
+---
+modified_at: 2020-11-16 11:00:00
+title: 'PostgreSQL - New Scalingo release: 12.5.0-1, 11.10.0-1, 10.15.0-1 and 9.6.20'
+---
+
+New default version: **12.5.0-1**
+
+Changelog:
+- Bump version of PostgreSQL to last minor. It contains a security fix related
+  to a CVE:
+    - [CVE-2020-25694](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-25694)
+
+Docker images on [Docker Hub](https://hub.docker.com/r/scalingo/postgresql):
+
+* `scalingo/postgresql:12.5.0-1`
+* `scalingo/postgresql:11.10.0-1`
+* `scalingo/postgresql:10.15.0-1`
+* `scalingo/postgresql:9.6.20-1`


### PR DESCRIPTION
Tweet:

> [Changelog] - PostgreSQL - New default version: 12.5.0-1 - https://changelog.scalingo.com #postgresql #changelog #PaaS