### PR TITLE
[changelog] MySQL 5.7.32-1 and 8.0.22

### DIFF
--- a/changelog/databases/_posts/2020-11-20-mysql-5.7.32-1.markdown
+++ b/changelog/databases/_posts/2020-11-20-mysql-5.7.32-1.markdown
@@ -1,0 +1,15 @@
+---
+modified_at: 2020-11-20 11:30:00
+title: 'MySQL - New version: 5.7.32-1 and 8.0.22-1'
+---
+
+New default version: **5.7.32-1**
+
+Changelog:
+* [MySQL 8.0.22](https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-22.html)
+* [MySQL 5.7.32](https://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-5-7-32.html)
+
+Docker images on [Docker Hub](https://hub.docker.com/r/scalingo/mysql):
+
+* `scalingo/mysql:8.0.22-1`
+* `scalingo/mysql:5.7.32-1`


### PR DESCRIPTION
Tweet:

> [Changelog] - MySQL - New default version: 5.7.32-1 - https://changelog.scalingo.com #mysql #changelog #PaaS