### PR TITLE
Remove false information about instructions at the http level

### DIFF
--- a/_posts/platform/deployment/buildpacks/2000-01-01-nginx.md
+++ b/_posts/platform/deployment/buildpacks/2000-01-01-nginx.md
@@ -116,10 +116,3 @@ possible with the `NGINX_INCLUDES` environment variable:
 ```bash
 scalingo --app my-app env-set NGINX_INCLUDES="./conf/nginx-1.conf ./conf/nginx-2.conf"
 ```
-
-## Advanced Informations
-
-The configuration file you have to provide is at the `server` level, if you
-need to add something at the `http` level, please open an
-[issue](https://github.com/Scalingo/nginx-buildpack/issues/new) or a pull
-request and we'll discuss it.


### PR DESCRIPTION
This is no longer true since the introduction of the `servers.conf.erb` configuration file