### PR TITLE
Failed push refs: no master error

### DIFF
--- a/_posts/platform/getting-started/2000-01-01-troubleshooting-ssh.md
+++ b/_posts/platform/getting-started/2000-01-01-troubleshooting-ssh.md
@@ -48,7 +48,7 @@ no *commit* (Git name for 'version') has been done on the `master` branch.
 
 ### Solving the problem
 
-You need to make a first commit on the *master* branch to your project:
+You need to make a first commit on the `master` branch of your project:
 
 ```bash
 $ git add .

--- a/_posts/platform/getting-started/2000-01-01-troubleshooting-ssh.md
+++ b/_posts/platform/getting-started/2000-01-01-troubleshooting-ssh.md
@@ -43,7 +43,7 @@ error: failed to push some refs to 'git@scalingo.com:appname.git'
 ```
 
 When we tell you to run `git push scalingo master`, we consider you are already
-using Git for your project. This error mean that there is a Git environment but
+using Git for your project. This error means that there is a Git environment but
 no *commit* (Git name for 'version') has been done on the *master* branch.
 
 ### Solving the problem

--- a/_posts/platform/getting-started/2000-01-01-troubleshooting-ssh.md
+++ b/_posts/platform/getting-started/2000-01-01-troubleshooting-ssh.md
@@ -44,7 +44,7 @@ error: failed to push some refs to 'git@scalingo.com:appname.git'
 
 When we tell you to run `git push scalingo master`, we consider you are already
 using Git for your project. This error means that there is a Git environment but
-no *commit* (Git name for 'version') has been done on the *master* branch.
+no *commit* (Git name for 'version') has been done on the `master` branch.
 
 ### Solving the problem
 

--- a/_posts/platform/getting-started/2000-01-01-troubleshooting-ssh.md
+++ b/_posts/platform/getting-started/2000-01-01-troubleshooting-ssh.md
@@ -56,7 +56,8 @@ $ git commit -m "initial commit"
 $ git push scalingo master
 ```
 
-If the branch named "master" is not existing (sometime default branch is called "main") you need to create one
+If the branch named `master` does not exist (default branch may be named `main`) you need to create one:
+
 ```bash
 git branch master
 git checkout master

--- a/_posts/platform/getting-started/2000-01-01-troubleshooting-ssh.md
+++ b/_posts/platform/getting-started/2000-01-01-troubleshooting-ssh.md
@@ -44,16 +44,22 @@ error: failed to push some refs to 'git@scalingo.com:appname.git'
 
 When we tell you to run `git push scalingo master`, we consider you are already
 using Git for your project. This error mean that there is a Git environment but
-no *commit* (Git name for 'version') has been done.
+no *commit* (Git name for 'version') has been done on the *master* branch.
 
 ### Solving the problem
 
-You need to make a first commit to your project:
+You need to make a first commit on the *master* branch to your project:
 
 ```bash
 $ git add .
 $ git commit -m "initial commit"
 $ git push scalingo master
+```
+
+If the branch named "master" is not existing (sometime default branch is called "main") you need to create one
+```bash
+git branch master
+git checkout master
 ```
 
 ## Invalid SSH key error when adding it to account

--- a/_posts/platform/getting-started/2000-01-01-troubleshooting-ssh.md
+++ b/_posts/platform/getting-started/2000-01-01-troubleshooting-ssh.md
@@ -59,8 +59,7 @@ $ git push scalingo master
 If the branch named `master` does not exist (default branch may be named `main`) you need to create one:
 
 ```bash
-git branch master
-git checkout master
+git checkout -b master
 ```
 
 ## Invalid SSH key error when adding it to account


### PR DESCRIPTION
Adding an indication to think about ensuring the branch name is master (an alternative error that provides the same error message)