### PR TITLE
[Django] Use os.environ which raises a KeyError rather than os.getenv

### DIFF
--- a/_posts/languages/python/django/2000-01-01-start.md
+++ b/_posts/languages/python/django/2000-01-01-start.md
@@ -8,7 +8,7 @@ index: 1
 
 {% include info_tutorial_requirements.md %}
 
-## Initialize your application
+## Initialize Your Application
 
 ```bash
 # Create your project
@@ -27,7 +27,7 @@ pip install django-toolbelt
 django-admin.py startproject myapp .
 ```
 
-## Define the how to start your application
+## Define How To Start Your Application
 
 You have to create a file named `Procfile` at the root of the project
 containing:
@@ -41,7 +41,7 @@ previous command defines it and tells Gunicorn, the applicative HTTP server, to
 display logs on `stdout` to fit the [12-factor](http://12factor.net/)
 principles.
 
-## Python app recognition and dependencies definition.
+## Python App Recognition and Dependencies Definition
 
 The platform will understand that your app is a __Python__ application if it
 contains a `requirements.txt` file at the root of the project. To create it,
@@ -51,7 +51,7 @@ your have to run the following command:
 pip freeze > requirements.txt
 ```
 
-## Create your application and databases on Scalingo
+## Create Your Application and Databases on Scalingo
 
 {% note %}
   You can also use our web dashboard to achieve this operation
@@ -80,7 +80,7 @@ pip install mysqlclient
 pip freeze > requirements.txt
 ```
 
-## Application configuration
+## Application Configuration
 
 The configuration of the application has to be done through the environment
 variables, no credentials should be present statically in the code. It is
@@ -88,7 +88,7 @@ usually a bad practice.
 
 The configuration file in our example is located at `myapp/settings.py`.
 
-### Ensure that the base directory of the application is defined
+### Ensure That the Base Directory of the Application Is Defined
 
 {% note %}
   This instruction may be already set according to your Django version
@@ -102,7 +102,7 @@ import os
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 ```
 
-### Configure the Database access
+### Configure the Database Access
 
 Still in the `myapp/settings.py`, replace:
 
@@ -133,7 +133,7 @@ the application will fallback on your development backend, sqlite3. However, we
 advise you to use the same database in development and in production to ensure
 bug free migrations.
 
-### Static file serving
+### Static File Serving
 
 In your settings configuration file `myapp/settings.py`:
 
@@ -204,7 +204,7 @@ Then change the environment variable of your application with a coma-separated l
 scalingo -a app-name env-set ALLOWED_HOSTS=app-name.osc-fr1.scalingo.io,example.com
 ```
 
-## Save your app with Git
+## Save Your App With Git
 
 ### Setup `.gitignore`
 
@@ -218,7 +218,7 @@ venv
 staticfiles
 ```
 
-### Commit your application
+### Commit Your Application
 
 ```bash
 git init
@@ -226,7 +226,7 @@ git add .
 git commit -m "Init Django application"
 ```
 
-## Deploy your application
+## Deploy Your Application
 
 ```bash
 git remote add scalingo git@ssh.osc-fr1.scalingo.com:myapp.git
@@ -240,7 +240,7 @@ it using our CLI with:
 scalingo --app myapp git-show
 ```
 
-## Access your application
+## Access Your Application
 
 ```bash
 …

--- a/_posts/languages/python/django/2000-01-01-start.md
+++ b/_posts/languages/python/django/2000-01-01-start.md
@@ -1,7 +1,7 @@
 ---
 title: Get Started with Django on Scalingo
 nav: Get Started
-modified_at: 2020-01-31 00:00:00
+modified_at: 2021-01-05 00:00:00
 tags: python django tutorial getting-started-tutorial
 index: 1
 ---
@@ -177,7 +177,7 @@ It will be taken into account during the next deployment of your application.
 By default, Django filter the allowed domain names used to access the application. Without specifying them, you'll get the following error:
 
 ```
-> Invalid HTTP_HOST header: '<domain>'. You may need to add '<domain>' to ALLOWED_HOSTS. 
+> Invalid HTTP_HOST header: '<domain>'. You may need to add '<domain>' to ALLOWED_HOSTS.
 ```
 
 So you need to modify the `settings.py`. Replace this static array:
@@ -191,10 +191,10 @@ By this dynamic block reading the environment:
 ```python
 env_allowed_hosts = []
 try:
-  env_allowed_hosts = os.getenv("ALLOWED_HOSTS").split(",")
+  env_allowed_hosts = os.environ["ALLOWED_HOSTS"].split(",")
 except KeyError:
   pass
-  
+
 ALLOWED_HOSTS = ["localhost"] + env_allowed_hosts
 ```
 


### PR DESCRIPTION
Fix #1153