### PR TITLE
Django getting-started-tutorial - compilemessages section

### DIFF
--- a/_posts/languages/python/django/2000-01-01-start.md
+++ b/_posts/languages/python/django/2000-01-01-start.md
@@ -41,6 +41,29 @@ previous command defines it and tells Gunicorn, the applicative HTTP server, to
 display logs on `stdout` to fit the [12-factor](http://12factor.net/)
 principles.
 
+## Need to compile `.mo` message translation file?
+
+If you are using `compilemessages` command to generate `.mo` file for gettext
+translations, that command need to run before starting gunicorn.
+
+To do that, you could write a short start script, for instance in `bin/start.sh`.
+
+```
+#!/bin/bash
+
+python manage.py compilemessages
+gunicorn core.wsgi_scalingo --log-file -
+```
+
+Then in your `Procfile`, directly call this script:
+
+```
+web: bash bin/start.sh
+```
+
+For more details, check the documentation about [Procfile]({% post_url platform/app/2000-01-01-procfile %}).
+
+
 ## Python App Recognition and Dependencies Definition
 
 The platform will understand that your app is a __Python__ application if it

--- a/_posts/languages/python/django/2000-01-01-start.md
+++ b/_posts/languages/python/django/2000-01-01-start.md
@@ -41,18 +41,18 @@ previous command defines it and tells Gunicorn, the applicative HTTP server, to
 display logs on `stdout` to fit the [12-factor](http://12factor.net/)
 principles.
 
-## Need to compile `.mo` message translation file?
+## Compile `.mo` Message Translation File
 
 If you are using `compilemessages` command to generate `.mo` file for gettext
-translations, that command need to run before starting gunicorn.
+translations, that command needs to run before starting Gunicorn.
 
-To do that, you could write a short start script, for instance in `bin/start.sh`.
+A solution would be to write a short start script (e.g. `bin/start.sh`):
 
-```
+```sh
 #!/bin/bash
 
 python manage.py compilemessages
-gunicorn core.wsgi_scalingo --log-file -
+gunicorn myapp.wsgi --log-file -
 ```
 
 Then in your `Procfile`, directly call this script:


### PR DESCRIPTION
Add a section that explains how to add `compilemessages` command section in django getting-started-tutorial.