### PR TITLE
[changelog] PHP 7.4.14 and 7.3.26

### DIFF
--- a/_posts/languages/php/2000-01-01-start.md
+++ b/_posts/languages/php/2000-01-01-start.md
@@ -33,8 +33,8 @@ The following PHP versions are compatible with the platform:
 * **7.0** (up to 7.0.33)
 * **7.1** (up to 7.1.33)
 * **7.2** (up to 7.2.34)
-* **7.3** (up to 7.3.24)
-* **7.4** (up to 7.4.12, stack `scalingo-18` and more recents only)
+* **7.3** (up to 7.3.26)
+* **7.4** (up to 7.4.14, stack `scalingo-18` and more recents only)
 
 ### Select a Version
 

--- a/_posts/languages/php/2000-01-01-start.md
+++ b/_posts/languages/php/2000-01-01-start.md
@@ -34,7 +34,7 @@ The following PHP versions are compatible with the platform:
 * **7.1** (up to 7.1.33)
 * **7.2** (up to 7.2.34)
 * **7.3** (up to 7.3.26)
-* **7.4** (up to 7.4.14, stack `scalingo-18` and more recents only)
+* **7.4** (up to 7.4.14)
 
 ### Select a Version
 

--- a/changelog/buildpacks/_posts/2021-02-03-php-7.4.14.markdown
+++ b/changelog/buildpacks/_posts/2021-02-03-php-7.4.14.markdown
@@ -1,0 +1,10 @@
+---
+modified_at: 2021-02-03 10:00:00
+title: 'PHP - Support of versions 7.4.14 and 7.3.26'
+github: 'https://github.com/Scalingo/php-buildpack'
+---
+
+Changelogs:
+
+* [PHP 7.4.14](https://www.php.net/ChangeLog-7.php#7.4.14)
+* [PHP 7.3.26](https://www.php.net/ChangeLog-7.php#7.3.26)


### PR DESCRIPTION
Tweet:

> [Changelog] Buildpacks - PHP - Support of PHP 7.4.14 and 7.3.26 https://changelog.scalingo.com #php #changelog #PaaS

Fix https://github.com/Scalingo/php-buildpack/issues/177 / [OPSB-189]

[OPSB-189]: https://scalingo.atlassian.net/browse/OPSB-189