### PR TITLE
docs(Ruby): announce Ruby 3.0.0 release

### DIFF
--- a/_posts/languages/ruby/2000-01-01-start.md
+++ b/_posts/languages/ruby/2000-01-01-start.md
@@ -100,8 +100,6 @@ version are also present if your require them for specific tests.
 * `2.6.6`
 * `2.5.8`
 * `2.4.10`
-* `2.3.8`  (stack `scalingo-14` only)
-* `2.2.10` (stack `scalingo-14` only)
 
 ## Ruby Application Web Server
 

--- a/_posts/languages/ruby/2000-01-01-start.md
+++ b/_posts/languages/ruby/2000-01-01-start.md
@@ -96,7 +96,8 @@ version are also present if your require them for specific tests.
 
 ### MRI
 
-* `2.7.1`
+* `3.0.0`
+* `2.7.2`
 * `2.6.6`
 * `2.5.8`
 * `2.4.10`

--- a/changelog/buildpacks/_posts/2021-02-03-ruby-3.0.0.md
+++ b/changelog/buildpacks/_posts/2021-02-03-ruby-3.0.0.md
@@ -1,0 +1,9 @@
+---
+modified_at: 2021-02-03 10:00:00
+title: 'Ruby - New major version available: 3.0.0'
+github: 'https://github.com/Scalingo/ruby-buildpack'
+---
+
+Changelog:
+
+* [3.0.0](https://www.ruby-lang.org/en/news/2020/12/25/ruby-3-0-0-released/)


### PR DESCRIPTION
Tweet:

> [Changelog] Buildpacks - Ruby - New major version support - Support of Ruby 3.0.0 https://changelog.scalingo.com #ruby #changelog #PaaS

Fix [OPSB-225]

[OPSB-225]: https://scalingo.atlassian.net/browse/OPSB-225