### PR TITLE
docs(changelog): add support for Python 3.9.2, 3.8.8, 3.7.10 and 3.6.13

### DIFF
--- a/_posts/languages/python/2000-01-01-start.md
+++ b/_posts/languages/python/2000-01-01-start.md
@@ -1,7 +1,7 @@
 ---
 title: Python
 nav: Introduction
-modified_at: 2017-11-16 00:00:00
+modified_at: 2021-03-01 00:00:00
 tags: python
 index: 1
 ---
@@ -71,8 +71,8 @@ configure your application to bind the port defined by the environment variable 
 
 ## Supported Versions
 
-* 3.8.2 (stack `scalingo-18` only)
-* 3.7.5 (stack `scalingo-18` only)
+* 3.8.2
+* 3.7.5
 * 3.6.9
 * 2.7.17
 

--- a/_posts/languages/python/2000-01-01-start.md
+++ b/_posts/languages/python/2000-01-01-start.md
@@ -71,10 +71,11 @@ configure your application to bind the port defined by the environment variable 
 
 ## Supported Versions
 
-* 3.8.2
-* 3.7.5
-* 3.6.9
-* 2.7.17
+* 3.9.2
+* 3.8.8
+* 3.7.10
+* 3.6.13
+* 2.7.18
 
 ## Specific Python Buildpack Hooks
 

--- a/changelog/buildpacks/_posts/2021-03-01-python.markdown
+++ b/changelog/buildpacks/_posts/2021-03-01-python.markdown
@@ -1,0 +1,12 @@
+---
+modified_at: 2021-03-01 08:50:00
+title: 'Python - New versions available: 3.9.2, 3.8.8, 3.7.10 and 3.6.13'
+github: 'https://github.com/Scalingo/python-buildpack'
+---
+
+Changelogs:
+
+* [3.9.2](https://docs.python.org/3/whatsnew/changelog.html#python-3-9-2-final)
+* [3.8.8](https://docs.python.org/3.8/whatsnew/changelog.html#python-3-8-8-final)
+* [3.7.10](https://docs.python.org/3.7/whatsnew/changelog.html#python-3-7-10-final)
+* [3.6.13](https://docs.python.org/3.6/whatsnew/changelog.html#python-3-6-13-final)


### PR DESCRIPTION
Tweet:

> [Changelog] Buildpacks - Python - Support of Python 3.9.2, 3.8.8, 3.7.10 and 3.6.13 https://changelog.scalingo.com #python #changelog #PaaS

Related to https://github.com/Scalingo/python-buildpack/issues/14