### PR TITLE
GMP is now accessible for PHP 8

### DIFF
--- a/_posts/languages/php/2000-01-01-start.md
+++ b/_posts/languages/php/2000-01-01-start.md
@@ -190,7 +190,7 @@ These extensions will be installed dynamically if required in the `composer.json
 * Image manipulation with ImageMagick: [`imagick`](https://www.php.net/manual/en/book.imagick.php)
 * Memcached driver: [`memcached`](https://www.php.net/manual/en/book.memcached.php)
 * Event : [`event`](https://www.php.net/manual/en/book.event.php)
-* GMP Multiple Precisions math functions: [`gmp`](https://www.php.net/manual/en/book.gmp.php), incompatible with PHP 8.0 and above
+* GMP Multiple Precisions math functions: [`gmp`](https://www.php.net/manual/en/book.gmp.php)
 * FTP Client: [`ftp`](https://www.php.net/manual/book.ftp.php)
 * IMAP: [`imap`](https://www.php.net/manual/en/book.imap.php)
 * Tidy: [`tidy`](https://www.php.net/manual/en/book.tidy.php)


### PR DESCRIPTION
Since we've rebuilt all dependencies of PHP, the `gmp` extension now build successfuly for PHP 8

It seems it was a problem of version of the `libgmp` which got updated now.