### PR TITLE
Update curator version

### DIFF
--- a/_posts/platform/getting-started/2000-01-01-getting-started-with-elk.md
+++ b/_posts/platform/getting-started/2000-01-01-getting-started-with-elk.md
@@ -260,8 +260,7 @@ dependencies, create a file named `requirements.txt` at the root of your
 application:
 
 ```
-PyYAML==5.3.1
-elasticsearch-curator==5.8.1
+elasticsearch-curator==5.8.2
 ```
 
 


### PR DESCRIPTION
There is a dependency error problem with version 5.8.1:

https://github.com/elastic/curator/issues/1560
https://github.com/elastic/curator/issues/1496

This is fixed in the new version 5.8.2