### PR TITLE
docs(changelog): release CLI 1.20.0

### DIFF
--- a/changelog/cli/_posts/2021-04-01-1-20-0.md
+++ b/changelog/cli/_posts/2021-04-01-1-20-0.md
@@ -1,0 +1,40 @@
+---
+modified_at: 2021-04-01 10:30:00
+title: 'CLI - New version: 1.20.0'
+github: 'https://github.com/Scalingo/cli/releases'
+---
+
+Installation:
+
+[https://cli.scalingo.com](https://cli.scalingo.com)
+
+Changelog:
+
+* Add `env-get` command to retrieve the value of a specific environment variable [#643](https://github.com/Scalingo/cli/pull/643)
+* Error messages are outputted on stderr [#639](https://github.com/Scalingo/cli/pull/639)
+* Automatically prefix the integration URL with https if none is provided [#642](https://github.com/Scalingo/cli/pull/642)
+* `backups-download` downloads the most recent backup if none is specified [#636](https://github.com/Scalingo/cli/pull/636)
+* Add `deployment-cache-delete` as an alias to `deployment-delete-cache` [#635](https://github.com/Scalingo/cli/pull/635)
+* `one-off-stop` command to stop a running one-off container [#633](https://github.com/Scalingo/cli/pull/633)
+* `ps` command returns the list of application's containers [#632](https://github.com/Scalingo/cli/pull/632)
+* `ps` command is renamed `scale` [#631](https://github.com/Scalingo/cli/pull/631)
+* Show the addon status on `scalingo addons` [#604](https://github.com/Scalingo/cli/pull/604)
+* Add informative error in case of container type error when scaling an application
+  [602](https://github.com/Scalingo/cli/pull/602)
+* Update various dependencies:
+  - github.com/fatih/color
+  - github.com/briandowns/spinner
+  - github.com/gosuri/uilive
+  - github.com/stretchr/testify
+  - github.com/urfave/cli
+  - gopkg.in/AlecAivazis/survey.v1
+  - github.com/cheggaaa/pb
+  - gopkg.in/src-d/go-git.v4
+  - github.com/Scalingo/go-scalingo/v4
+  - github.com/ScaleFT/sshkeys
+  - github.com/heroku/hk
+  - github.com/howeyc/gopass
+  - github.com/olekukonko/tablewriter
+  - golang.org/x/crypto
+  - golang.org/x/net
+* Update Scalingo internal dependencies to the Go Modules version [#613](https://github.com/Scalingo/cli/pull/613)


### PR DESCRIPTION
Tweet:

> [Changelog] CLI - Release of version 1.20.0 https://cli.scalingo.com - More news at https://changelog.scalingo.com #cli #paas #changelog
