### PR TITLE
docs(changelog): release CLI 1.20.1

### DIFF
--- a/changelog/cli/_posts/2021-04-16-1-20-1.md
+++ b/changelog/cli/_posts/2021-04-16-1-20-1.md
@@ -1,0 +1,14 @@
+---
+modified_at: 2021-04-16 14:00:00
+title: 'CLI - New version: 1.20.1'
+github: 'https://github.com/Scalingo/cli/releases'
+---
+
+Installation:
+
+[https://cli.scalingo.com](https://cli.scalingo.com)
+
+Changelog:
+
+* fix(backup_download): no log on stdout when using '--output -' flag [#646](https://github.com/Scalingo/cli/pull/646)
+* `deployment-logs` displays the last deployment logs if none is provided [#647](https://github.com/Scalingo/cli/pull/647)


### PR DESCRIPTION
Tweet:

> [Changelog] CLI - Release of version 1.20.1 https://cli.scalingo.com - More news at https://changelog.scalingo.com #cli #paas #changelog #bugfix