### PR TITLE
feat(dependabot): execute monthly (instead of weekly)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,12 +6,10 @@ updates:
       - dependency-type: "all"
     versioning-strategy: lockfile-only
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "monthly"
   - package-ecosystem: "npm"
     directory: "/"
     allow:
       - dependency-type: "all"
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "monthly"


### PR DESCRIPTION
Following a discussion on Slack, we want to execute Dependabot monthly instead of weekly to lighten the work.