### PR TITLE
Removing mention of composer 1.X deprecation for 2020

### DIFF
--- a/_posts/languages/php/2000-01-01-start.md
+++ b/_posts/languages/php/2000-01-01-start.md
@@ -112,8 +112,6 @@ installed, please set the following environment variable:
 
 {% warning %}
 Composer 1 is End of Life since the 24th of October 2020 and will soon be deprecated. See [this announcement](https://blog.packagist.com/composer-2-0-is-now-available/#4-what-s-next) from Composer about the release of Composer 2.
-
-Composer 2 will become the default on Scalingo by the end of 2020.
 {% endwarning %}
 
 You can select the Composer version to install for your application deployment by specifying it in your `composer.json`:


### PR DESCRIPTION
We did not deprecated composer 1.x before the end of 2020.