### PR TITLE
docs(changelog): Redis 6.2.3-1

### DIFF
--- a/changelog/databases/_posts/2021-05-04-redis.6.2.3-1.md
+++ b/changelog/databases/_posts/2021-05-04-redis.6.2.3-1.md
@@ -1,0 +1,16 @@
+---
+modified_at: 2021-05-04 08:30:00
+title: 'Redis - New default version: 6.2.3-1'
+---
+
+New default version: **6.2.3-1**.
+
+This version contains a security fix for a bug which affects all Redis versions 6.0 or newer.
+
+Redis changelog:
+
+* [6.2.3-1](https://raw.githubusercontent.com/redis/redis/6.2/00-RELEASENOTES)
+
+Docker image on [Docker Hub](https://hub.docker.com/r/scalingo/redis):
+
+* `scalingo/redis:6.2.3-1`


### PR DESCRIPTION
Tweet:

> [Changelog] - Redis - New default version: 6.2.3-1 - https://changelog.scalingo.com This release contains a security fix, please upgrade as soon as possible. #redis #changelog #PaaS