### PR TITLE
docs(changelog): Composer 2.x is the new default

### DIFF
--- a/_posts/languages/php/2000-01-01-start.md
+++ b/_posts/languages/php/2000-01-01-start.md
@@ -1,7 +1,7 @@
 ---
 title: PHP on Scalingo
 nav: Introduction
-modified_at: 2021-04-16 00:00:00
+modified_at: 2021-05-11 00:00:00
 tags: php
 index: 1
 ---
@@ -110,10 +110,6 @@ installed, please set the following environment variable:
 
 ### Select a Composer Version
 
-{% warning %}
-Composer 1 is End of Life since the 24th of October 2020 and will soon be deprecated. See [this announcement](https://blog.packagist.com/composer-2-0-is-now-available/#4-what-s-next) from Composer about the release of Composer 2.
-{% endwarning %}
-
 You can select the Composer version to install for your application deployment by specifying it in your `composer.json`:
 
 ```json
@@ -121,7 +117,7 @@ You can select the Composer version to install for your application deployment b
   "extra": {
     "paas": {
       "engines": {
-        "composer": "2.x"
+        "composer": "1.x"
       }
     }
   }

--- a/changelog/buildpacks/_posts/2021-05-11-php-composer-2-default.markdown
+++ b/changelog/buildpacks/_posts/2021-05-11-php-composer-2-default.markdown
@@ -1,0 +1,23 @@
+---
+modified_at: 2021-05-11 10:00:00
+title: 'PHP - Composer default version is 2.x'
+github: 'https://github.com/Scalingo/php-buildpack'
+---
+
+Composer 1 is end of life since the 24th of October 2020. Starting today, Composer 2 is the new default for PHP applications. See [this announcement](https://blog.packagist.com/composer-2-0-is-now-available/#4-what-s-next) from Composer about the release of Composer 2.
+
+If your application still requires Composer 1, you can select it by updating the `composer.json`:
+
+```json
+{
+  "extra": {
+    "paas": {
+      "engines": {
+        "composer": "1.x"
+      }
+    }
+  }
+}
+```
+
+More information in our [documentation page](https://doc.scalingo.com/languages/php/start#select-a-composer-version).


### PR DESCRIPTION
Related to https://github.com/Scalingo/php-buildpack/issues/168