### PR TITLE
docs(changelog): New Relic support with PHP 8

### DIFF
--- a/changelog/buildpacks/_posts/2021-05-11-php-8-new-relic.md
+++ b/changelog/buildpacks/_posts/2021-05-11-php-8-new-relic.md
@@ -1,0 +1,19 @@
+---
+modified_at: 2021-05-11 12:00:00
+title: 'PHP - Add support for New Relic with PHP 8'
+github: 'https://github.com/Scalingo/php-buildpack'
+---
+
+New Relic support with PHP 8 has been added.
+
+To enable it, add the following requirement in your `composer.json`:
+
+```
+{
+  "extra": {
+    "paas": {
+      "new-relic": "true"
+    }
+  }
+}
+```


### PR DESCRIPTION
Tweet:

> [Changelog] Buildpacks - PHP - Support for New Relic with PHP 8 https://changelog.scalingo.com #php #changelog #PaaS

Related to https://github.com/Scalingo/php-buildpack/issues/194