### PR TITLE
docs(changelog): Meteor 2.1 and 2.2 use Node.js 12.22.x

### DIFF
--- a/changelog/buildpacks/_posts/2021-05-11-meteor-2-nodejs-version.markdown
+++ b/changelog/buildpacks/_posts/2021-05-11-meteor-2-nodejs-version.markdown
@@ -1,0 +1,11 @@
+---
+modified_at: 2021-05-11 14:00:00
+title: 'Meteor - Update default Node.js version'
+github: 'https://github.com/Scalingo/nodejs-buildpack'
+---
+
+
+The default Node.js version for Meteor 2.1 and 2.2 is now 12.22.x.
+
+Meteor changelog:
+* https://docs.meteor.com/changelog.html#v21120210406


### PR DESCRIPTION
Fix https://github.com/Scalingo/nodejs-buildpack/issues/47