### PR TITLE
docs(changelog): PostgreSQL 12.7.0-1, 11.12.0-1, 10.17.0-1 and 9.6.22-1

### DIFF
--- a/changelog/databases/_posts/2021-05-19-postgresql-12.7.0-1.md
+++ b/changelog/databases/_posts/2021-05-19-postgresql-12.7.0-1.md
@@ -1,0 +1,17 @@
+---
+modified_at: 2021-05-19 07:30:00
+title: 'PostgreSQL - New Scalingo release: 12.7.0-1, 11.12.0-1, 10.17.0-1 and 9.6.22'
+---
+
+New default version: **12.7.0-1**.
+
+Changelog:
+- Bump versions of PostgreSQL to last minor. It contains three security fixes:
+    - [PostgreSQL blog post](https://www.postgresql.org/about/news/postgresql-133-127-1112-1017-and-9622-released-2210/)
+
+Docker images on [Docker Hub](https://hub.docker.com/r/scalingo/postgresql):
+
+* `scalingo/postgresql:12.7.0-1`
+* `scalingo/postgresql:11.12.0-1`
+* `scalingo/postgresql:10.17.0-1`
+* `scalingo/postgresql:9.6.22-1`


### PR DESCRIPTION
Tweet:

> [Changelog] - PostgreSQL - New default version: 12.7.0-1 - https://changelog.scalingo.com #postgresql #changelog #PaaS

Related to https://github.com/Scalingo/appsdeck-database/issues/1985