### PR TITLE
PHP: Do not add another / location

### DIFF
--- a/_posts/languages/php/2000-01-01-ips-filtering.md
+++ b/_posts/languages/php/2000-01-01-ips-filtering.md
@@ -25,11 +25,9 @@ Edit the file `nginx-ips-filtering.conf` in this directory with the following
 content:
 
 ```bash
-location / {
-    allow <ip1>;
-    allow <ip2>;
-    deny all;
-}
+allow <ip1>;
+allow <ip2>;
+deny all;
 ```
 
 Last thing you need to do is to instruct Scalingo's deployment process to use


### PR DESCRIPTION
The current way worked well for application without a framework but would fail for Symfony apps.
Since the allow and deny instructions are allowed on a server block, it might be better to put it there since it will have the same result without the potential conflict.