### PR TITLE
docs(changelog): release CLI 1.20.2

### DIFF
--- a/changelog/cli/_posts/2021-05-27-1-20-2.md
+++ b/changelog/cli/_posts/2021-05-27-1-20-2.md
@@ -1,0 +1,15 @@
+---
+modified_at: 2021-05-27 17:15:00
+title: 'CLI - New version: 1.20.2'
+github: 'https://github.com/Scalingo/cli/releases'
+---
+
+Installation:
+
+[https://cli.scalingo.com](https://cli.scalingo.com)
+
+Changelog:
+
+* fix(logs) Buffer logs to prevent requests from timing out [#659](https://github.com/Scalingo/cli/pull/659)
+* feat(integration-link-create): better catch 401 from SCM API [#651](https://github.com/Scalingo/cli/pull/651)
+* bump github.com/fatih/color from 1.10.0 to 1.11.0 [#654](https://github.com/Scalingo/cli/pull/654)


### PR DESCRIPTION
https://github.com/Scalingo/cli/releases/tag/1.20.2

Tweet:

> [Changelog] CLI - Release of version 1.20.2 https://cli.scalingo.com - More news at https://changelog.scalingo.com #cli #paas #changelog #bugfix