### PR TITLE
Update ruby versions to match currently supported version, remove jruby

### DIFF
--- a/_posts/languages/ruby/2000-01-01-start.md
+++ b/_posts/languages/ruby/2000-01-01-start.md
@@ -1,7 +1,7 @@
 ---
 title: Ruby
 nav: Introduction
-modified_at: 2021-01-05 00:00:00
+modified_at: 2021-41-05 00:00:00
 tags: ruby
 index: 1
 ---
@@ -77,16 +77,10 @@ $ git push scalingo master
 If your need to install a custom version of Ruby, you can achieve that by
 specifying it in your Gemfile:
 
-### Ruby MRI 2.5.5
+### Ruby MRI 2.7.3
 
 ```ruby
-ruby "2.5.5"
-```
-
-### JRuby 2.0.0
-
-```ruby
-ruby "2.0.0", :engine => "jruby", :engine_version => "1.7.20"
+ruby "2.7.3"
 ```
 
 ## List of the Compatible Runtimes
@@ -96,10 +90,10 @@ version are also present if your require them for specific tests.
 
 ### MRI
 
-* `3.0.0`
-* `2.7.2`
-* `2.6.6`
-* `2.5.8`
+* `3.0.1`
+* `2.7.3`
+* `2.6.7`
+* `2.5.9`
 * `2.4.10`
 
 ## Ruby Application Web Server
@@ -155,3 +149,4 @@ end
 
 Thus you can change the global settings by modifying the environment
 variables `WEB_CONCURRENCY` and `MAX_THREAD` and restarting your app.
+ 

--- a/_posts/languages/ruby/2000-01-01-start.md
+++ b/_posts/languages/ruby/2000-01-01-start.md
@@ -1,7 +1,7 @@
 ---
 title: Ruby
 nav: Introduction
-modified_at: 2021-41-05 00:00:00
+modified_at: 2021-05-31 00:00:00
 tags: ruby
 index: 1
 ---


### PR DESCRIPTION
JRuby was never used/tested, thus we don't support it officially.