### PR TITLE
docs(changelog): release OTP 22.3.4.18, 23.3.4 and 24.0.1

### DIFF
--- a/_posts/languages/erlang/2000-01-01-start.md
+++ b/_posts/languages/erlang/2000-01-01-start.md
@@ -29,10 +29,6 @@ for.
 
 Currently supported OTP versions depend on the stack:
 
-scalingo-14:
-
-* OTP-19.1 *
-
 scalingo-18:
 
 * OTP-22.2.7 *

--- a/_posts/languages/erlang/2000-01-01-start.md
+++ b/_posts/languages/erlang/2000-01-01-start.md
@@ -31,7 +31,9 @@ Currently supported OTP versions depend on the stack:
 
 scalingo-18:
 
-* OTP-22.2.7 *
+* OTP-22.3.4.18
+* OTP-23.3.4
+* OTP-24.0.1 *
 
 To select the version for your app:
 

--- a/changelog/buildpacks/_posts/2021-06-01-otp-24.md
+++ b/changelog/buildpacks/_posts/2021-06-01-otp-24.md
@@ -1,0 +1,17 @@
+---
+modified_at: 2021-06-01 11:30:00
+title: 'Erlang - OTP New Default Version 24.0.1'
+github: 'https://github.com/Scalingo/erlang-buildpack'
+---
+
+We updated our Erlang buildpack to add support for a bunch of new versions:
+- 22.3.4.18
+- 23.3.4
+- 24.0.1
+
+OTP 24.0.1 is the new default.
+
+OTP Changelogs:
+- [OTP 24.0.1](https://github.com/erlang/otp/releases/tag/OTP-24.0.1)
+- [OTP 23.3.4](https://github.com/erlang/otp/releases/tag/OTP-23.3.4)
+- [OTP 22.3.4.18](https://github.com/erlang/otp/releases/tag/OTP-22.3.4.18)


### PR DESCRIPTION
Fix https://github.com/Scalingo/erlang-buildpack/issues/10