### PR TITLE
docs(changelog): PHP 8.0.7, 7.4.20 and 7.3.28

### DIFF
--- a/_posts/languages/php/2000-01-01-start.md
+++ b/_posts/languages/php/2000-01-01-start.md
@@ -1,7 +1,7 @@
 ---
 title: PHP on Scalingo
 nav: Introduction
-modified_at: 2021-05-11 00:00:00
+modified_at: 2021-06-07 00:00:00
 tags: php
 index: 1
 ---
@@ -33,9 +33,9 @@ The following PHP versions are compatible with the platform:
 * **7.0** (up to 7.0.33)
 * **7.1** (up to 7.1.33)
 * **7.2** (up to 7.2.34)
-* **7.3** (up to 7.3.26)
-* **7.4** (up to 7.4.16)
-* **8.0** (up to 8.0.3)
+* **7.3** (up to 7.3.28)
+* **7.4** (up to 7.4.20)
+* **8.0** (up to 8.0.7)
 
 ### Select a Version
 

--- a/changelog/buildpacks/_posts/2021-06-07-php-8.0.7.markdown
+++ b/changelog/buildpacks/_posts/2021-06-07-php-8.0.7.markdown
@@ -1,0 +1,11 @@
+---
+modified_at: 2021-06-07 17:00:00
+title: 'PHP - Support of versions 8.0.7, 7.4.20 and 7.3.28'
+github: 'https://github.com/Scalingo/php-buildpack'
+---
+
+Changelogs:
+
+* [PHP 7.3.28 Changelog](https://www.php.net/ChangeLog-7.php#7.3.28)
+* [PHP 7.4.20 Changelog](https://www.php.net/ChangeLog-7.php#7.4.20)
+* [PHP 8.0.7 Changelog](https://www.php.net/ChangeLog-8.php#8.0.7)


### PR DESCRIPTION
Tweet:

> [Changelog] Buildpacks - PHP - Support of PHP 8.0.7, 7.4.20 and 7.3.28 https://changelog.scalingo.com #php #changelog #PaaS

Fix https://github.com/Scalingo/php-buildpack/issues/201