### PR TITLE
docs(changelog): Elasticsearch 6.8.17

### DIFF
--- a/changelog/databases/_posts/2021-07-08-elasticsearch-6.8.17-1.md
+++ b/changelog/databases/_posts/2021-07-08-elasticsearch-6.8.17-1.md
@@ -1,0 +1,20 @@
+---
+modified_at: 2021-07-08 11:00:00
+title: 'Elasticsearch - New Scalingo release: 6.8.17-1'
+---
+
+New default version: **6.8.17-1**
+
+Changelogs:
+- [Elasticsearch 6.8.10](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/release-notes-6.8.10.html)
+- [Elasticsearch 6.8.11](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/release-notes-6.8.11.html)
+- [Elasticsearch 6.8.12](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/release-notes-6.8.12.html)
+- [Elasticsearch 6.8.13](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/release-notes-6.8.13.html)
+- [Elasticsearch 6.8.14](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/release-notes-6.8.14.html)
+- [Elasticsearch 6.8.15](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/release-notes-6.8.15.html)
+- [Elasticsearch 6.8.16](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/release-notes-6.8.16.html)
+- [Elasticsearch 6.8.17](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/release-notes-6.8.17.html)
+
+Docker image on [Docker Hub](https://hub.docker.com/r/scalingo/elasticsearch):
+
+* `scalingo/elasticsearch:6.8.17-1`


### PR DESCRIPTION
Tweet:

> [Changelog] - Elasticsearch - New default version: 6.8.17-1 - https://changelog.scalingo.com #elasticsearch #changelog #PaaS