### PR TITLE
docs(changelog): Redis 6.2.5-1 and 5.0.13-1

### DIFF
--- a/changelog/databases/_posts/2021-07-27-redis.6.2.5-1.md
+++ b/changelog/databases/_posts/2021-07-27-redis.6.2.5-1.md
@@ -1,0 +1,18 @@
+---
+modified_at: 2021-07-27 12:00:00
+title: 'Redis - New versions: 6.2.5-1 and 5.0.13-1'
+---
+
+New default version: **6.2.5-1**.
+
+This version contains a security fix for a bug which affects all Redis versions 5.0 or newer.
+
+Redis changelog:
+
+* [6.2.5-1](https://raw.githubusercontent.com/redis/redis/6.2/00-RELEASENOTES)
+* [5.0.13-1](https://raw.githubusercontent.com/redis/redis/5.0/00-RELEASENOTES)
+
+Docker image on [Docker Hub](https://hub.docker.com/r/scalingo/redis):
+
+* `scalingo/redis:6.2.5-1`
+* `scalingo/redis:5.0.13-1`


### PR DESCRIPTION
Tweet:

> [Changelog] - Redis - New security release: 6.2.5-1 and 5.0.13-1 - https://changelog.scalingo.com #redis #changelog #PaaS