### PR TITLE
feat(dev-setup) Fix development setup followign dependabot breakage

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+--ignore-engines true

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN cd /opt && \
     apt-get update && apt-get install sudo && apt-get clean &&\
     sed -i s+secure_path=.*+secure_path="$PATH"+ /etc/sudoers
 
-ENV PATH "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/node_modules/.bin:/usr/src/app/node_modules/.bin:/usr/src/app/vendor/.bundle/ruby/2.5.0/bin:/opt/node/bin"
+ENV PATH "/opt/node/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/node_modules/.bin:/usr/src/app/node_modules/.bin:/usr/src/app/vendor/.bundle/ruby/3.0.0/bin"
 
 RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
   echo 'LANG="en_US.UTF-8"'>/etc/default/locale && \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,3 +28,5 @@ services:
     environment:
       NODE_ENV: "development"
       RAILS_ENV: "development"
+      BUNDLE_BIN: "/usr/src/app/vendor/.bundle/ruby/3.0.0/bin"
+      BUNDLE_PATH: "/usr/src/app/vendor/.bundle/ruby/3.0.0"


### PR DESCRIPTION
* Add `.yarnrc` to ignore dependency package.json engines constraint
* Ensure the PATH in the docker setup is good since apt package yarn
  include nodejs 10 but we want to be explicit on the version
* Fix docker-compose.yml to ensure webpacker is getting the gems from
  the right directory for ruby 3