### PR TITLE
Remove dependabot for js deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,11 +9,3 @@ updates:
       interval: "monthly"
     reviewers:
       - "ksol"
-  - package-ecosystem: "npm"
-    directory: "/"
-    allow:
-      - dependency-type: "all"
-    schedule:
-      interval: "monthly"
-    reviewers:
-      - "ksol"


### PR DESCRIPTION
We'd be better off catching up this ecosystem by hand first, dependabot is not well suited for catching up months/years of lateness. It is more error-prone / env-breaking prone than anything else at the moment