### PR TITLE
Let's display the reality, the read timeout is 60s for at least 3-4 years

### DIFF
--- a/_posts/platform/internals/2000-01-01-routing.md
+++ b/_posts/platform/internals/2000-01-01-routing.md
@@ -73,16 +73,16 @@ a deeper insight of its implementation.
 
 ## Timeouts
 
-Your application has to accept the connection within the 30 seconds and has 30
-seconds to send the first data to the client in the 30 seconds. If one of these
+Your application has to accept the connection within the 60 seconds and has 30
+seconds to send the first data to the client in the 60 seconds. If one of these
 conditions is not respected, our servers will return a `504 Gateway Timeout`
 error to the end user:
 
-* Connection timeout: 30s
-* Read timeout: 30s
+* Connection timeout: 60s
+* Read timeout: 60s
 
 These rules also apply to the long running connections like websockets. Ensure
-your application is sending at least one ping every 29 seconds to keep the connection
+your application is sending at least one ping every 59 seconds to keep the connection
 open, otherwise it will be stopped.
 
 ## Requests Queue


### PR DESCRIPTION


Internal reference: https://github.com/Scalingo/scalingo-openresty/blob/master/nginx-prod.conf#L93