### PR TITLE
Unsupported erlang OTP-24.*

### DIFF
--- a/_posts/languages/elixir/2000-01-01-start.md
+++ b/_posts/languages/elixir/2000-01-01-start.md
@@ -36,7 +36,8 @@ The configuration applied by default is
 {% note %}
 You should always specify your Elixir and OTP target versions. The buildpack
 defaults are several versions back and may not work with your application
-if you are up to date.
+if you are up to date. Also note erlang OTP-24.* versions are not currently 
+supported using this buildpack (most recent supported version: OTP-23.3.2).
 {% endnote %}
 
 ## Phoenix Web Framework


### PR DESCRIPTION
Adding a note on unsupported OTP-24.*  (on scalingo-18) at the moment. The working versions on this stack are listed [there](https://github.com/HashNuke/heroku-buildpack-elixir-otp-builds/blob/master/otp-versions). They are aware of the issue (related to builds), no fix yet (if ever since the *-20 stacks from Heroku and Gigalixir are supporting those versions).