### PR TITLE
docs(erlang): downgrade some versions

### DIFF
--- a/_posts/languages/erlang/2000-01-01-start.md
+++ b/_posts/languages/erlang/2000-01-01-start.md
@@ -1,7 +1,7 @@
 ---
 title: Erlang
 nav: Introduction
-modified_at: 2020-03-20 00:00:00
+modified_at: 2021-09-14 00:00:00
 tags: erlang
 ---
 
@@ -31,9 +31,8 @@ Currently supported OTP versions depend on the stack:
 
 scalingo-18:
 
-* OTP-22.3.4.18
-* OTP-23.3.4
-* OTP-24.0.1 *
+* OTP-22.3.4.17
+* OTP-23.3.2 *
 
 To select the version for your app:
 


### PR DESCRIPTION
The OTP we use has been dowgraded in https://github.com/HashNuke/heroku-buildpack-elixir-otp-builds/commit/c9d4faf8a2920fd43111a206b77beb6e29a77552. Let's only use the OTP versions described in https://github.com/HashNuke/heroku-buildpack-elixir-otp-builds/blob/master/otp-versions as per our internal documentation. It seems thos not in the `optp-versions` file have been porrly packaged