### PR TITLE
docs(java): JDK 16 support

### DIFF
--- a/_posts/languages/java/2000-01-01-start.md
+++ b/_posts/languages/java/2000-01-01-start.md
@@ -1,7 +1,7 @@
 ---
 title: Java on Scalingo
 nav: Introduction
-modified_at: 2021-04-12 00:00:00
+modified_at: 2021-09-14 00:00:00
 tags: java
 index: 1
 ---
@@ -10,15 +10,18 @@ Java is officially supported on Scalingo
 
 ## Versions
 
-* 1.7 `1.7.0_272`
-* 1.8 `1.8.0_262`
+The default JDK version installed is: `1.8`.
+
+* 1.7 `1.7.0_312`
+* 1.8 `1.8.0_302` (LTS)
 * 9   `9.0.4`
 * 10  `10.0.2`
-* 11  `11.0.8`
+* 11  `11.0.12` (LTS)
 * 12  `12.0.2`
-* 13  `13.0.4`
+* 13  `13.0.8`
 * 14  `14.0.2`
-* 15  `15.0.0`
+* 15  `15.0.4`
+* 16  `16.0.2`
 
 ## Frameworks
 

--- a/changelog/buildpacks/_posts/2021-09-14-java-openjdk-16.markdown
+++ b/changelog/buildpacks/_posts/2021-09-14-java-openjdk-16.markdown
@@ -1,0 +1,14 @@
+---
+modified_at: 2021-09-14 10:00:00
+title: 'Java - Support for OpenJDK 16'
+github: 'https://github.com/Scalingo/buildpack-jvm-common'
+---
+
+This update of the buildpack brings new OpenJDK versions:
+
+* 1.7.0_312
+* 1.8.0_302 (LTS)
+* 11.0.12 (LTS)
+* 13.0.8
+* 15.0.4
+* 16.0.2


### PR DESCRIPTION
Related to https://github.com/Scalingo/buildpack-jvm-common/pull/27

Tweet:
```
[Changelog] Buildpacks - Java - Support for JDK 16 https://changelog.scalingo.com #java #jdk #changelog #PaaS
```