### PR TITLE
release(jdk): Add JDK 17 LTS support

### DIFF
--- a/_posts/languages/java/2000-01-01-start.md
+++ b/_posts/languages/java/2000-01-01-start.md
@@ -1,7 +1,7 @@
 ---
 title: Java on Scalingo
 nav: Introduction
-modified_at: 2021-09-14 00:00:00
+modified_at: 2021-09-16 00:00:00
 tags: java
 index: 1
 ---
@@ -22,6 +22,7 @@ The default JDK version installed is: `1.8`.
 * 14  `14.0.2`
 * 15  `15.0.4`
 * 16  `16.0.2`
+* 17  `17.0.0` (LTS)
 
 ## Frameworks
 

--- a/changelog/buildpacks/_posts/2021-09-16-java-openjdk-17.markdown
+++ b/changelog/buildpacks/_posts/2021-09-16-java-openjdk-17.markdown
@@ -1,0 +1,9 @@
+---
+modified_at: 2021-09-16 10:00:00
+title: 'Java - Support for OpenJDK 17 (LTS)'
+github: 'https://github.com/Scalingo/buildpack-jvm-common'
+---
+
+This update of the buildpack brings new major OpenJDK version:
+
+* 17.0.0 (LTS)


### PR DESCRIPTION
Related to https://github.com/Scalingo/buildpack-jvm-common/pull/29

Tweet:
```
[Changelog] Buildpacks - Java - Support for JDK 17 LTS https://changelog.scalingo.com #java #java17 #jdk #changelog #PaaS
```