### PR TITLE
docs(changelog): MySQL 8.0.26-1

### DIFF
--- a/changelog/databases/_posts/2021-10-18-mysql-8.0.26-1.md
+++ b/changelog/databases/_posts/2021-10-18-mysql-8.0.26-1.md
@@ -1,0 +1,15 @@
+---
+modified_at: 2021-10-19 11:00:00
+title: 'MySQL - New versions: 8.0.26-1'
+---
+
+New version: **8.0.26-1**
+
+Changelog:
+* [MySQL 8.0.24](https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-24.html)
+* [MySQL 8.0.25](https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-25.html)
+* [MySQL 8.0.26](https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-26.html)
+
+Docker image on [Docker Hub](https://hub.docker.com/r/scalingo/mysql):
+
+* `scalingo/mysql:8.0.26-1`


### PR DESCRIPTION
Tweet:
> [Changelog] - MySQL - New default version: 8.0.26-1 - https://changelog.scalingo.com #mysql #changelog #PaaS