### PR TITLE
docs(docker-addon): Clarify that the prefix 'app-' must be used before the application name in the full URL

### DIFF
--- a/_posts/addons/scalingo-docker-image/2000-01-01-start.md
+++ b/_posts/addons/scalingo-docker-image/2000-01-01-start.md
@@ -58,9 +58,13 @@ profile](https://my.scalingo.com/profile), copy it from there.
 
 ### Download Your Image
 
+{% note %}
+  Be sure to always have the prefix `app-` before the application name in the full URL.
+{% endnote %}
+
 ```bash
-$ docker pull $DOCKER_REGISTRY_URL/my-app:0123456789abcdef
-0123456789abcdef: Pulling from my-app
+$ docker pull $DOCKER_REGISTRY_URL/app-my-app:0123456789abcdef
+0123456789abcdef: Pulling from app-my-app
 6599cadaf950: Downloading 59.99 MB/65.69 MB
 23eda618d451: Download complete
 f0be3084efe9: Download complete
@@ -91,7 +95,7 @@ docker run -it \
   -e PORT=4000 \
   --publish 4000:4000 \
   --user appsdeck \
-  $DOCKER_REGISTRY_URL/my-app:0123456789abcdef /start web
+  $DOCKER_REGISTRY_URL/app-my-app:0123456789abcdef /start web
 ```
 
 In this case no environment variable has been set, you need to add the environment variables required by your
@@ -106,7 +110,7 @@ docker run -it \
   -e MAIL_URL=smtp://user:password@mailprovider.com:587 \
   --publish 4000:4000 \
   --user appsdeck \
-  $DOCKER_REGISTRY_URL/my-app:0123456789abcdef /start web
+  $DOCKER_REGISTRY_URL/app-my-app:0123456789abcdef /start web
 ```
 
 {% note %}


### PR DESCRIPTION
Related to a customer issue. Don't work without `app-` prefix.

Examples given in the documentation are not right and can be misleading.