### PR TITLE
docs(cli): use HTTPS links for Windows installer

### DIFF
--- a/_posts/platform/cli/2000-01-01-start.md
+++ b/_posts/platform/cli/2000-01-01-start.md
@@ -55,8 +55,8 @@ We highly recommend to use [git-bash](https://git-for-windows.github.io/) to hav
 
 Then, you need to download Scalingo command-line tool:
 
-* [Windows 64 bits users](http://cli-dl.scalingo.com/release/scalingo_latest_windows_amd64.zip)
-* [Windows 32 bits users](http://cli-dl.scalingo.com/release/scalingo_latest_windows_386.zip)
+* [Windows 64 bits users](https://cli-dl.scalingo.com/release/scalingo_latest_windows_amd64.zip)
+* [Windows 32 bits users](https://cli-dl.scalingo.com/release/scalingo_latest_windows_386.zip)
 
 Place the `scalingo.exe` file in the path you want, e.g. "C:/Program Files".
 


### PR DESCRIPTION
I confirm that before this change the download didn't work on Chrome whereas it works now.

Fix #1323