### PR TITLE
docs: replace links to Outscale doc to target the new doc

### DIFF
--- a/_posts/platform/app/2000-01-01-filesystem.md
+++ b/_posts/platform/app/2000-01-01-filesystem.md
@@ -1,6 +1,6 @@
 ---
 title: File System and File Storage
-modified_at: 2017-01-03 00:00:00
+modified_at: 2021-11-30 00:00:00
 tags: app runtime file system disk storage
 index: 1
 ---
@@ -32,7 +32,7 @@ will be lost when the app is restarted.
 If you need to store files in a persistent manner, the good practice is to use
 an external storage service solution like:
 
-* [Outscale OSU](https://wiki.outscale.net/display/EN/About+OSU) (S3 compatible API)
+* [Outscale OOS](https://docs.outscale.com/en/userguide/About-Object-Storage.html) (S3 compatible API)
 * Amazon S3
 * Google Cloud Storage
 * Azure Blob Storage

--- a/_posts/platform/internals/2000-01-01-network.md
+++ b/_posts/platform/internals/2000-01-01-network.md
@@ -1,6 +1,6 @@
 ---
 title: Network
-modified_at: 2019-07-08 00:00:00
+modified_at: 2021-11-30 00:00:00
 tags: internals network
 ---
 
@@ -41,7 +41,7 @@ resolved by **egress.osc-fr1.scalingo.com**, currently:
 
 The list of IPs can change in the future, if you need the exhaustive list of the possible
 output IPs, please refer to our provider documentation
-[here](https://wiki.outscale.net/display/EN/3DS+OUTSCALE+Public+IP+Addresses).
+[here](https://docs.outscale.com/en/userguide/OUTSCALE-Public-IP-Addresses.html).
 Our `osc-fr1` region is hosted on Outscale `eu-west-2` region.
 
 ### osc-secnum-fr1 Region
@@ -53,7 +53,7 @@ resolved by **egress.osc-secnum-fr1.scalingo.com**, currently:
 
 The list of IPs can change in the future, if you need the exhaustive list of the possible
 output IPs, please refer to our provider documentation
-[here](https://wiki.outscale.net/display/EN/3DS+OUTSCALE+Public+IP+Addresses).
+[here](https://docs.outscale.com/en/userguide/OUTSCALE-Public-IP-Addresses.html).
 Our `osc-secnum-fr1` region is hosted on Outscale `cloudgouv-eu-west-1` region.
 
 


### PR DESCRIPTION
Fix #1462