### PR TITLE
docs(changelog): PHP 8.1.0, 8.0.13, 7.4.26 and 7.3.33

### DIFF
--- a/_posts/languages/php/2000-01-01-start.md
+++ b/_posts/languages/php/2000-01-01-start.md
@@ -142,7 +142,7 @@ You can select the Composer version to install for your application deployment b
 Scalingo supports the following versions of Composer:
 
 - 1.10.21
-- 2.1.9
+- 2.1.14
 
 ## Native PHP Extensions
 

--- a/_posts/languages/php/2000-01-01-start.md
+++ b/_posts/languages/php/2000-01-01-start.md
@@ -1,7 +1,7 @@
 ---
 title: PHP on Scalingo
 nav: Introduction
-modified_at: 2021-10-27 17:00:00
+modified_at: 2021-11-30 17:00:00
 tags: php
 index: 1
 ---
@@ -33,9 +33,10 @@ The following PHP versions are compatible with the platform:
 * **7.0** (up to 7.0.33, only for scalingo-18)
 * **7.1** (up to 7.1.33, only for scalingo-18)
 * **7.2** (up to 7.2.34, only for scalingo-18)
-* **7.3** (up to 7.3.31, only for scalingo-18)
-* **7.4** (up to 7.4.25)
-* **8.0** (up to 8.0.12)
+* **7.3** (up to 7.3.33, only for scalingo-18)
+* **7.4** (up to 7.4.26)
+* **8.0** (up to 8.0.13)
+* **8.1** (up to 8.1.0)
 
 ### Select a Version
 

--- a/_posts/languages/php/2000-01-01-start.md
+++ b/_posts/languages/php/2000-01-01-start.md
@@ -141,7 +141,7 @@ You can select the Composer version to install for your application deployment b
 
 Scalingo supports the following versions of Composer:
 
-- 1.10.21
+- 1.10.23
 - 2.1.14
 
 ## Native PHP Extensions

--- a/changelog/buildpacks/_posts/2021-11-30-php-8.1.0.md
+++ b/changelog/buildpacks/_posts/2021-11-30-php-8.1.0.md
@@ -1,0 +1,12 @@
+---
+modified_at: 2021-11-30 17:00:00
+title: 'PHP - Support of versions 8.1.0, 8.0.13, 7.4.26 and 7.3.33'
+github: 'https://github.com/Scalingo/php-buildpack'
+---
+
+Changelogs:
+
+* [PHP 8.1.0 Changelog](https://www.php.net/ChangeLog-8.php#8.1.0)
+* [PHP 8.0.12 Changelog](https://www.php.net/ChangeLog-8.php#8.0.13)
+* [PHP 7.4.25 Changelog](https://www.php.net/ChangeLog-7.php#7.4.26)
+* [PHP 7.3.31 Changelog](https://www.php.net/ChangeLog-7.php#7.3.33)

--- a/changelog/buildpacks/_posts/2021-11-30-php-composer-2.1.14.md
+++ b/changelog/buildpacks/_posts/2021-11-30-php-composer-2.1.14.md
@@ -1,0 +1,12 @@
+---
+modified_at: 2021-11-30 17:00:00
+title: 'PHP - Release Composer version 2.1.14'
+github: 'https://github.com/Scalingo/php-buildpack'
+---
+
+Changelogs:
+
+* [Composer 2.1.10](https://github.com/composer/composer/releases/tag/2.1.10)
+* [Composer 2.1.11](https://github.com/composer/composer/releases/tag/2.1.11)
+* [Composer 2.1.12](https://github.com/composer/composer/releases/tag/2.1.12)
+* [Composer 2.1.14](https://github.com/composer/composer/releases/tag/2.1.14)


### PR DESCRIPTION
> [Changelog] Buildpacks - PHP - Support of PHP 8.1.0 https://changelog.scalingo.com #php #changelog #PaaS

Related to https://github.com/Scalingo/php-buildpack/issues/222 and https://github.com/Scalingo/php-buildpack/issues/224