### PR TITLE
release(go): Support for Go 1.17

### DIFF
--- a/_posts/languages/go/2000-01-01-start.md
+++ b/_posts/languages/go/2000-01-01-start.md
@@ -1,7 +1,7 @@
 ---
 title: Go
 nav: Introduction
-modified_at: 2021-06-18 00:00:00
+modified_at: 2021-12-08 00:00:00
 tags: go
 index: 1
 ---
@@ -14,10 +14,11 @@ The Go programming language is supported.
 
 #### Officially Supported
 
-* `go1.16.1`
-* `go1.15.9`
-* `go1.14.2`
-* `go1.13.10`
+* `go1.17.3`
+* `go1.16.10`
+* `go1.15.10`
+* `go1.14.15`
+* `go1.13.15`
 * `go1.12.17` (default)
 * `go1.11.13`
 * `go1.10.8`

--- a/changelog/buildpacks/_posts/2021-12-08-go-1.17.md
+++ b/changelog/buildpacks/_posts/2021-12-08-go-1.17.md
@@ -1,0 +1,9 @@
+---
+modified_at: 2021-12-08 18:00:00
+title:	'Go - New Versions: 1.17.3, 1.16.10 and 1.15.10'
+github: 'https://github.com/Scalingo/go-buildpack'
+---
+
+* Go 1.17.3 [changelog](https://go.dev/doc/devel/release#go1.17)
+* Go 1.16.10 [changelog](https://go.dev/doc/devel/release#go1.16)
+* Go 1.15.10 [changelog](https://go.dev/doc/devel/release#go1.15)


### PR DESCRIPTION
Related to https://github.com/Scalingo/go-buildpack/pull/15

I have included `go1.14.15` and `go1.13.15` (which is not part of the release) to the documentation that have been forgotten at a previous time

Tweet:
> [Changelog] Buildpacks - Go - Support of Go 1.17.3, 1.16.10 and 1.15.10 https://changelog.scalingo.com #golang #changelog #PaaS