### PR TITLE
docs(changelog): Composer 1.10.24 and 2.2.0

### DIFF
--- a/_posts/languages/php/2000-01-01-start.md
+++ b/_posts/languages/php/2000-01-01-start.md
@@ -141,8 +141,8 @@ You can select the Composer version to install for your application deployment b
 
 Scalingo supports the following versions of Composer:
 
-- 1.10.23
-- 2.1.14
+- 1.10.24
+- 2.2.0
 
 ## Native PHP Extensions
 

--- a/changelog/buildpacks/_posts/2021-12-22-php-composer-2.2.0.md
+++ b/changelog/buildpacks/_posts/2021-12-22-php-composer-2.2.0.md
@@ -1,0 +1,12 @@
+---
+modified_at: 2021-12-22 16:00:00
+title: 'PHP - Release Composer version 2.2.0 and 1.10.24'
+github: 'https://github.com/Scalingo/php-buildpack'
+---
+
+Read the [Composer 2.2 Release Announcement](https://blog.packagist.com/composer-2-2) for more details on the release highlights.
+
+Changelogs:
+
+* [Composer 1.10.24](https://github.com/composer/composer/releases/tag/1.10.24)
+* [Composer 2.2.0](https://github.com/composer/composer/releases/tag/2.2.0)


### PR DESCRIPTION
Related to https://github.com/Scalingo/php-buildpack/issues/226

Tweet:

> [Changelog] Buildpacks - PHP - Support of Composer 2.2.0 https://changelog.scalingo.com #php #composer #changelog #PaaS