### PR TITLE
SSH: Switch to ed25519 keys

### DIFF
--- a/_posts/platform/cli/2000-01-01-features.md
+++ b/_posts/platform/cli/2000-01-01-features.md
@@ -23,7 +23,7 @@ scalingo create my-app --remote custom
 
 ```bash
 scalingo keys
-scalingo keys-add "Laptop SSH key" $HOME/.ssh/id_rsa.pub
+scalingo keys-add "Laptop SSH key" $HOME/.ssh/id_ed25519.pub
 scalingo keys-remove "Laptop SSH key"
 ```
 

--- a/_posts/platform/deployment/buildpacks/2000-01-01-ssh-key.md
+++ b/_posts/platform/deployment/buildpacks/2000-01-01-ssh-key.md
@@ -44,7 +44,7 @@ Once the buildpack is configured for your app, set the environment variable
 `SSH_KEY` to include your private key in your app:
 
 ```text
-$ scalingo --app my-app env-set SSH_KEY="$(cat /path/to/your/keys/id_rsa | base64)"
+$ scalingo --app my-app env-set SSH_KEY="$(cat /path/to/your/keys/id_ed25519 | base64)"
 ```
 
 By default the buildpack adds GitHub to the `known_hosts` file. However you can

--- a/_posts/platform/getting-started/2000-01-01-first-steps.md
+++ b/_posts/platform/getting-started/2000-01-01-first-steps.md
@@ -39,7 +39,7 @@ scalingo keys-add [name of the key] [path to the key]
 
 # Example:
 
-scalingo keys-add Laptop ~/.ssh/id_rsa.pub
+scalingo keys-add Laptop ~/.ssh/id_ed25519.pub
 ```
 
 ## Some Tutorials to Start With

--- a/_posts/platform/getting-started/2000-01-01-setup-ssh-linux.md
+++ b/_posts/platform/getting-started/2000-01-01-setup-ssh-linux.md
@@ -11,13 +11,13 @@ index: 3
 ls ~/.ssh
 ```
 
-If the files `id_rsa` and `id_rsa.pub` are in the `~/.ssh` folder, you don't
+If the files `id_ed25519` and `id_ed25519.pub` are in the `~/.ssh` folder, you don't
 need to follow this guide, you already have your SSH key.
 
 ## Create a new SSH key pair
 
 ```bash
-ssh-keygen
+ssh-keygen -t ed25519
 ```
 
 Follow the instructions to generate a new SSH key pair. You will be asked to encrypt
@@ -31,10 +31,10 @@ By default both private and public keys will be located in your `$HOME/.ssh` dir
 To get the content of the public SSH key, you need to run the following command:
 
 ```bash
-$ cat ~/.ssh/id_rsa.pub
+$ cat ~/.ssh/id_ed25519.pub
 ```
 
-The file content should start with `ssh-rsa`
+The file content should start with `ssh-ed25519`
 
 Once you have the public key, go to Scalingo Dashboard [SSH key section](https://dashboard.scalingo.com/account/keys) and
 create a new key with the content of the public key.

--- a/_posts/platform/getting-started/2000-01-01-setup-ssh-macos.md
+++ b/_posts/platform/getting-started/2000-01-01-setup-ssh-macos.md
@@ -11,13 +11,13 @@ index: 4
 ls $HOME/.ssh
 ```
 
-If the files `id_rsa` and `id_rsa.pub` are in the `~/.ssh` folder, you don't
+If the files `id_ed25519` and `id_ed25519.pub` are in the `~/.ssh` folder, you don't
 need to follow this guide, you already have your SSH key.
 
 ## Create a new SSH key pair
 
 ```bash
-ssh-keygen
+ssh-keygen -t ed25519
 ```
 
 Follow the instructions to generate a new SSH key pair. You will be asked to encrypt

--- a/_posts/platform/getting-started/2000-01-01-setup-ssh-windows.md
+++ b/_posts/platform/getting-started/2000-01-01-setup-ssh-windows.md
@@ -38,7 +38,7 @@ To get the content of the public SSH key, you need to run the following command
 in git-bash:
 
 ```bash
-$ cat $HOME/.ssh/id_rsa.pub
+$ cat $HOME/.ssh/id_ed25519.pub
 ```
 
 The file content should start with `ssh-rsa`
@@ -53,7 +53,7 @@ Still in a git-bash terminal run the following command:
 ```bash
 $ ssh.exe -T git@ssh.osc-fr1.scalingo.com
 ```
-or 
+or
 ```bash
 $ ssh.exe -T git@ssh.osc-secnum-fr1.scalingo.com
 ```


### PR DESCRIPTION
Since DSA and RSA are slowly being rolled out of client implementations