### PR TITLE
docs(python): add support for Python 3.10.1, 3.9.9, 3.8.12, 3.7.12 and 3.6.15

### DIFF
--- a/_posts/languages/python/2000-01-01-start.md
+++ b/_posts/languages/python/2000-01-01-start.md
@@ -1,7 +1,7 @@
 ---
 title: Python
 nav: Introduction
-modified_at: 2021-09-16 00:00:00
+modified_at: 2022-01-07 00:00:00
 tags: python
 index: 1
 ---
@@ -22,10 +22,11 @@ present at the root of your project, defining the dependencies of your app.
 Python 2.x is only supported on `scalingo-18` stack.
 {% endwarning %}
 
-* 3.9.2
-* 3.8.8
-* 3.7.10
-* 3.6.13
+* 3.10.1
+* 3.9.9
+* 3.8.12
+* 3.7.12
+* 3.6.15
 * 2.7.18
 
 ### Recommended: pipenv
@@ -40,7 +41,7 @@ python_version = "3.7"
 ```
 
 The deployment system will use this information to install the last available
-version respecting this constraint. In the previous example Python `3.7.5`
+version respecting this constraint. In the previous example Python `3.7.11`
 would be installed.
 
 ### Legacy: runtime.txt

--- a/changelog/buildpacks/_posts/2022-01-07-python-3.10.1.md
+++ b/changelog/buildpacks/_posts/2022-01-07-python-3.10.1.md
@@ -1,0 +1,13 @@
+---
+modified_at: 2022-01-07 14:00:00
+title: 'Python - New versions available: 3.10.1, 3.9.9, 3.8.12, 3.7.12 and 3.6.15'
+github: 'https://github.com/Scalingo/python-buildpack'
+---
+
+Changelogs:
+
+* [3.10.1](https://docs.python.org/3.10/whatsnew/changelog.html#python-3-10-1-final)
+* [3.9.9](https://docs.python.org/3.9/whatsnew/changelog.html#python-3-9-9-final)
+* [3.8.12](https://docs.python.org/3.8/whatsnew/changelog.html#python-3-8-12-final)
+* [3.7.12](https://docs.python.org/3.7/whatsnew/changelog.html#python-3-7-12-final)
+* [3.6.15](https://docs.python.org/3.6/whatsnew/changelog.html#python-3-6-15-final)


### PR DESCRIPTION
> [Changelog] Buildpacks - Python - Support of version 3.10.1, 3.9.9, 3.8.12, 3.7.12 and 3.6.15 https://changelog.scalingo.com #python #changelog #PaaS

Related to https://github.com/Scalingo/python-buildpack/pull/53