### PR TITLE
docs(changelog): new PHP Composer and APCU versions

### DIFF
--- a/changelog/buildpacks/_posts/2022-01-12-php-apcu-ext-5.1.21.md
+++ b/changelog/buildpacks/_posts/2022-01-12-php-apcu-ext-5.1.21.md
@@ -1,0 +1,9 @@
+---
+modified_at: 2022-01-12 17:00:00
+title: 'PHP - Support of extension `apcu` version 5.1.21'
+github: 'https://github.com/Scalingo/php-buildpack'
+---
+
+Changelog:
+
+* [APCU 5.1.21](https://github.com/krakjoe/apcu/releases/tag/v5.1.21)

--- a/changelog/buildpacks/_posts/2022-01-12-php-composer-2.2.4.md
+++ b/changelog/buildpacks/_posts/2022-01-12-php-composer-2.2.4.md
@@ -1,0 +1,11 @@
+---
+modified_at: 2022-01-12 17:00:00
+title: 'PHP - Release Composer version 2.2.4'
+github: 'https://github.com/Scalingo/php-buildpack'
+---
+
+Changelogs:
+
+* [Composer 2.2.2](https://github.com/composer/composer/releases/tag/2.2.2)
+* [Composer 2.2.3](https://github.com/composer/composer/releases/tag/2.2.3)
+* [Composer 2.2.4](https://github.com/composer/composer/releases/tag/2.2.4)


### PR DESCRIPTION
f51e38fc fix https://github.com/Scalingo/php-buildpack/issues/230

b14b9c66 fix https://github.com/Scalingo/php-buildpack/issues/228

Tweets

> [Changelog] Buildpacks - PHP - Support of Composer 2.2.4 https://changelog.scalingo.com #php #composer #changelog #PaaS

> [Changelog] Buildpacks - PHP - Support of extension APCU version 5.1.21 https://changelog.scalingo.com #php #PaaS #update #changelog