### PR TITLE
docs(changelog): CLI v1.22.1

### DIFF
--- a/changelog/cli/_posts/2022-01-17-1-22-1.md
+++ b/changelog/cli/_posts/2022-01-17-1-22-1.md
@@ -1,0 +1,18 @@
+---
+modified_at: 2022-01-17 18:30:00
+title: 'CLI - New version: 1.22.1'
+github: 'https://github.com/Scalingo/cli/releases'
+---
+
+Installation:
+
+[https://cli.scalingo.com](https://cli.scalingo.com)
+
+Changelog:
+
+* feat(logs): allow to filter logs to only show router logs [#707](https://github.com/Scalingo/cli/pull/707)
+* fix(install): disable CLI update checker [#710](https://github.com/Scalingo/cli/pull/710)
+* fix(run): display an error message for detached one-off with uploaded files [#712](https://github.com/Scalingo/cli/pull/712)
+* fix(run): --region flag in help message [#713](https://github.com/Scalingo/cli/pull/713)
+* build(deps): bump github.com/cheggaaa/pb from 1.0.29 to 3.0.8
+* build(deps): bump github.com/briandowns/spinner from 1.16.0 to 1.18.0


### PR DESCRIPTION
Tweet:

> [Changelog] CLI - Release of version 1.22.1 https://cli.scalingo.com - More news at https://changelog.scalingo.com #cli #paas #changelog #bugfix