### PR TITLE
docs(changelog): PostgreSQL 13.6.0-3

### DIFF
--- a/src/_posts/databases/postgresql/2000-01-01-extensions.md
+++ b/src/_posts/databases/postgresql/2000-01-01-extensions.md
@@ -111,7 +111,7 @@ PostGIS extension requires at least a "Starter 512M" plan to work.
 		</tr>
 		<tr>
 			<td>pg_repack</td>
-			<td>1.4.6</td>
+			<td>1.4.7</td>
 			<td>lets you remove bloat from tables and indexes, and optionally restore the physical order of clustered indexes. Unlike CLUSTER and VACUUM FULL it works online</td>
 		</tr>
 		<tr>

--- a/src/changelog/databases/_posts/2022-02-24-postgresql-13.6.0-3.md
+++ b/src/changelog/databases/_posts/2022-02-24-postgresql-13.6.0-3.md
@@ -1,5 +1,5 @@
 ---
-modified_at: 2022-02-24 11:00:00
+modified_at: 2022-02-24 10:00:00
 title: 'PostgreSQL - New versions: 13.6.0-1 and 13.6.0-3'
 ---
 
@@ -8,7 +8,7 @@ We are happy to release two new PostgreSQL versions:
 - 13.6.0-1 is the first version with TimescaleDB Open-source available. It includes TimescaleDB 2.4.1.
 - 13.6.0-3 includes TimescaleDB 2.6.0. This is the new default version.
 
-More information in the [documentation page](https://doc.scalingo.com/databases/postgresql/timescaledb/intro).
+More information in the [documentation page]({% post_url databases/postgresql/timescaledb/2000-01-01-intro %}).
 
 Changelogs:
 - [PostgreSQL 13.4](https://www.postgresql.org/docs/13/release-13-4.html)

--- a/src/changelog/databases/_posts/2022-02-24-postgresql-13.6.0-3.md
+++ b/src/changelog/databases/_posts/2022-02-24-postgresql-13.6.0-3.md
@@ -1,0 +1,21 @@
+---
+modified_at: 2022-02-24 11:00:00
+title: 'PostgreSQL - New versions: 13.6.0-1 and 13.6.0-3'
+---
+
+We are happy to release two new PostgreSQL versions:
+
+- 13.6.0-1 is the first version with TimescaleDB Open-source available. It includes TimescaleDB 2.4.1.
+- 13.6.0-3 includes TimescaleDB 2.6.0. This is the new default version.
+
+More information in the [documentation page](https://doc.scalingo.com/databases/postgresql/timescaledb/intro).
+
+Changelogs:
+- [PostgreSQL 13.4](https://www.postgresql.org/docs/13/release-13-4.html)
+- [PostgreSQL 13.5](https://www.postgresql.org/docs/13/release-13-5.html)
+- [PostgreSQL 13.6](https://www.postgresql.org/docs/13/release-13-6.html)
+
+Docker images on [Docker Hub](https://hub.docker.com/r/scalingo/postgresql):
+
+* `scalingo/postgresql:13.6.0-1`
+* `scalingo/postgresql:13.6.0-3`


### PR DESCRIPTION
Tweet:

> [Changelog] - PostgreSQL - New default version: 13.6.0-3 with TimescaleDB inside 🎉  - https://changelog.scalingo.com #postgresql #changelog #PaaS