### PR TITLE
docs(changelog): PostgreSQL 12.9.0-1, 11.14.0-1, 10.19.0-1 and 9.6.24-1

### DIFF
--- a/_posts/databases/postgresql/2000-01-01-extensions.md
+++ b/_posts/databases/postgresql/2000-01-01-extensions.md
@@ -116,7 +116,7 @@ PostGIS extension requires at least a "Starter 512M" plan to work.
 		</tr>
 		<tr>
 			<td>pg_stat_statements</td>
-			<td>1.7</td>
+			<td>1.8</td>
 			<td>track execution statistics of all SQL statements executed</td>
 		</tr>
 		<tr>

--- a/changelog/databases/_posts/2022-01-18-postgresql-12.9.0-1.md
+++ b/changelog/databases/_posts/2022-01-18-postgresql-12.9.0-1.md
@@ -1,0 +1,17 @@
+---
+modified_at: 2022-01-18 17:00:00
+title: 'PostgreSQL - New releases: 12.9.0-1, 11.14.0-1, 10.19.0-1 and 9.6.24-1'
+---
+
+PostgreSQL version 9.6.24-1 is the latest version of the 9.6 branch. It is end of life since 2021/11/11. PostgreSQL versioning policy is available [here](https://www.postgresql.org/support/versioning).
+
+Changelogs:
+- [PostgreSQL 12.8](https://www.postgresql.org/docs/12/release-12-8.html)
+- [PostgreSQL 12.9](https://www.postgresql.org/docs/12/release-12-9.html)
+
+Docker images on [Docker Hub](https://hub.docker.com/r/scalingo/postgresql):
+
+* `scalingo/postgresql:12.9.0-1`
+* `scalingo/postgresql:11.14.0-1`
+* `scalingo/postgresql:10.19.0-1`
+* `scalingo/postgresql:9.6.24-1`


### PR DESCRIPTION
Tweet:

> [Changelog] - PostgreSQL - New versions: 12.9.0-1, 11.14.0-1, 10.19.0-1 and 9.6.24-1 - https://changelog.scalingo.com #postgresql #changelog #PaaS

Second tweet in the same thread:

> PostgreSQL version 9.6.24-1 is the latest version of the 9.6 branch. It is end of life since 2021/11/11.