### PR TITLE
docs(one-off): default size is M

### DIFF
--- a/_posts/platform/app/2000-01-01-tasks.md
+++ b/_posts/platform/app/2000-01-01-tasks.md
@@ -1,7 +1,7 @@
 ---
 title: Application Tasks - One-Off Containers
 nav: One-Off Containers
-modified_at: 2021-12-23 00:00:00
+modified_at: 2022-01-25 00:00:00
 tags: app jobs tasks
 index: 14
 ---
@@ -34,7 +34,7 @@ simple task. This is achieved with the following command:
 
 ```bash
 $ scalingo --app my-app run bash
-[10:45] Scalingo:my-app ~ $ ls
+[10:45][osc-fr1] Scalingo:my-app ~ $ ls
 app.js  cron.js  node_modules  package.json  package-lock.json  Procfile  public  README.md  scalingo.json  views
 ```
 
@@ -43,16 +43,22 @@ execution of the task, the environment is destroyed. Thus, do not expect any
 created file to show up in your production environment. The production
 environment is immutable.
 
+A one-off container has, by default, access to 512 MiB memory (equivalent to a size M). If your one-off container needs more available memory, you can use the `--size` flag:
+
+```bash
+$ scalingo --app my-app run --size XL /app/my_big_script.sh
+```
+
 A copy of your production environment means that you can access to the same
 environment variables in the one-off and in the production. For example, you can
 connect to your production database with the following commands:
 
 ```bash
 $ scalingo --app my-app run bash
-[10:45] Scalingo:my-app ~ $ dbclient-fetcher mongo
+[10:45][osc-fr1] Scalingo:my-app ~ $ dbclient-fetcher mongo
 ---> Download and extract the database CLI
 [...]
-[10:45] Scalingo:my-app ~ $ mongo $SCALINGO_MONGO_URL
+[10:45][osc-fr1] Scalingo:my-app ~ $ mongo $SCALINGO_MONGO_URL
 ```
 
 You can also add a shell script that is executed at each start of a new
@@ -146,7 +152,7 @@ drwxrwxr-x 1 appsdeck appsdeck    56 Nov 13  2014 vendor
 
 ```bash
 $ scalingo --app my-app run bash
-[10:45] Scalingo ~ $ ls
+[10:45][osc-fr1] Scalingo ~ $ ls
 bin  Godeps  main.go  Procfile  README.md  templates
 ```
 
@@ -158,7 +164,7 @@ bin  Godeps  main.go  Procfile  README.md  templates
 
 ```bash
 $ scalingo --app my-app run --env VAR1=VAL1 --env VAR2=VAL2 bash
-[10:51] Scalingo ~ $ env | grep VAR
+[10:51][osc-fr1] Scalingo ~ $ env | grep VAR
 VAR1=VAL1
 VAR2=VAL2
 ```
@@ -181,14 +187,14 @@ You can't upload files:
 * Uploaded files are located in the directory `/tmp/uploads`
 
 ```bash
-[10:51] Scalingo ~ $ ls /tmp/uploads
+[10:51][osc-fr1] Scalingo ~ $ ls /tmp/uploads
 dump.tar
 ```
 
 * Extract the archive to `/tmp`
 
 ```bash
-[10:51] Scalingo ~ $ tar -C /tmp -xvf /tmp/uploads/dump.tar
+[10:51][osc-fr1] Scalingo ~ $ tar -C /tmp -xvf /tmp/uploads/dump.tar
 /tmp/dump
 /tmp/dump/collection1.bson
 /tmp/dump/collection1.metadata.json
@@ -202,7 +208,7 @@ dump.tar
 * Use these files with a script
 
 ```bash
-[10:51] Scalingo ~ $ /app/script.sh /tmp/dump/*.json
+[10:51][osc-fr1] Scalingo ~ $ /app/script.sh /tmp/dump/*.json
 ```
 
 ### Install the Scalingo CLI
@@ -211,7 +217,7 @@ In order to install the [Scalingo CLI]({% post_url platform/cli/2000-01-01-start
 
 ```bash
 $ scalingo --app my-app run bash
-[10:51] Scalingo ~ $ install-scalingo-cli
+[10:51][osc-fr1] Scalingo ~ $ install-scalingo-cli
 -----> Downloading Scalingo client...  DONE
 -----> Extracting...   DONE
 -----> Install scalingo client to /app/bin


### PR DESCRIPTION
https://documentation-service-pr1526.osc-fr1.scalingo.io/platform/app/tasks#top-of-page

Fix #1487