### PR TITLE
docs(nginx): add proxy_redirect to split traffic between 2 APIs

### DIFF
--- a/src/_posts/platform/deployment/buildpacks/2000-01-01-nginx.md
+++ b/src/_posts/platform/deployment/buildpacks/2000-01-01-nginx.md
@@ -1,7 +1,7 @@
 ---
 title: Nginx Buildpack for Custom Reverse Proxy
 nav: Nginx Buildpack
-modified_at: 2020-07-27 00:00:00
+modified_at: 2022-01-25 00:00:00
 tags: buildpacks build nginx
 ---
 
@@ -66,10 +66,12 @@ Scalingo applications depending on the path:
 ```nginx
 location /api/v1 {
   proxy_pass <%= ENV["API_V1_BACKEND"] %>;
+  proxy_redirect <%= ENV["API_V1_BACKEND"] %>/api/v1 https://<%= ENV["APP"] %>.<%= ENV["REGION_NAME"] %>.scalingo.io/api/v1;
 }
 
 location /api/v2 {
   proxy_pass <%= ENV["API_V2_BACKEND"] %>;
+  proxy_redirect <%= ENV["API_V2_BACKEND"] %>/api/v2 https://<%= ENV["APP"] %>.<%= ENV["REGION_NAME"] %>.scalingo.io/api/v2;
 }
 ```
 

--- a/src/_posts/platform/deployment/buildpacks/2000-01-01-nginx.md
+++ b/src/_posts/platform/deployment/buildpacks/2000-01-01-nginx.md
@@ -1,7 +1,7 @@
 ---
 title: Nginx Buildpack for Custom Reverse Proxy
 nav: Nginx Buildpack
-modified_at: 2022-01-25 00:00:00
+modified_at: 2022-02-18 00:00:00
 tags: buildpacks build nginx
 ---
 
@@ -66,13 +66,20 @@ Scalingo applications depending on the path:
 ```nginx
 location /api/v1 {
   proxy_pass <%= ENV["API_V1_BACKEND"] %>;
-  proxy_redirect <%= ENV["API_V1_BACKEND"] %>/api/v1 https://<%= ENV["APP"] %>.<%= ENV["REGION_NAME"] %>.scalingo.io/api/v1;
+  proxy_redirect default;
 }
 
 location /api/v2 {
   proxy_pass <%= ENV["API_V2_BACKEND"] %>;
-  proxy_redirect <%= ENV["API_V2_BACKEND"] %>/api/v2 https://<%= ENV["APP"] %>.<%= ENV["REGION_NAME"] %>.scalingo.io/api/v2;
+  proxy_redirect default;
 }
+```
+
+You need to define the two environment variables `API_V1_BACKEND` and `API_V2_BACKEND` with the domain name of the applications. For instance:
+
+```
+scalingo env-set API_V1_BACKEND=https://my-app-1.osc-fr1.scalingo.io
+scalingo env-set API_V2_BACKEND=https://my-app-2.osc-fr1.scalingo.io
 ```
 
 This configuration must be written in the `nginx.conf.erb` file at the root of


### PR DESCRIPTION
I'm not completely sure that it's what you meant in the related issue @brandon-welsch. Do you confirm it fixes the issue?

Fix #1408