### PR TITLE
docs(redis-cli): mention it's impossible to use if Force TLS is enabled

### DIFF
--- a/_posts/platform/databases/2000-01-01-access.md
+++ b/_posts/platform/databases/2000-01-01-access.md
@@ -50,6 +50,10 @@ you can download various CLI tools for all databases available at Scalingo:
 
 {% include dbclient_fetcher.md %}
 
+{% warning %}
+The `redis-cli` can NOT be used if Force TLS is enabled on the Redis database. It results in an error message `I/O error`.
+{% endwarning %}
+
 ## Connect to the Database
 
 By default, databases hosted on Scalingo are not directly available on the Internet.


### PR DESCRIPTION
https://documentation-service-pr1531.osc-fr1.scalingo.io/platform/databases/access#manually-install-the-databases-cli-in-one-off

Fix #1407