### PR TITLE
docs(postgresql): explain idle queries

### DIFF
--- a/_posts/databases/postgresql/2000-01-01-start.md
+++ b/_posts/databases/postgresql/2000-01-01-start.md
@@ -1,7 +1,7 @@
 ---
 title: PostgreSQL
 nav: Introduction
-modified_at: 2021-04-27 00:00:00
+modified_at: 2022-01-25 00:00:00
 tags: databases postgresql addon
 index: 1
 ---
@@ -207,7 +207,6 @@ When this operation finishes, your application is restarted.
 Beware that no downgrade is possible once your database has been upgraded.
 {% endwarning %}
 
-
 ### Container Stats
 
 <table class="mdl-data-table ">
@@ -273,6 +272,14 @@ ALTER DEFAULT PRIVILEGES FOR USER <database> IN SCHEMA public GRANT SELECT ON TA
 ALTER DEFAULT PRIVILEGES FOR USER <database> IN SCHEMA public GRANT SELECT ON SEQUENCES TO <username>
 ```
 
+### Running Queries
+
+The "Running Queries" tab displays the queries being executed on your database. It may be useful to understand the usage of your PostgreSQL database.
+
+Some of these queries are considered "idled" by PostgreSQL. In order to display these queries you need to enable them with the toggle on the "Running Queries" tab. These idle queries should not be considered a _bad thing_. As stated on the PostgreSQL [mailing list](https://postgrespro.com/list/id/CAC6ry0LFHv+eMjpde_3jqfSnG9hg2O6s=9VTwLh2jiYydXSqGg@mail.gmail.com):
+
+> "idle" means the client is not currently executing a query nor in a transaction. If [the start date] is 2 days old, that just means the last query to be executed on that connection was two days ago. [...] It's generally desirable for a connection pool to have a few idle connections so queries don't suffer the latency of establishing a new connection.
+
 ## Backups
 
 Scalingo PostgreSQL databases offer two way of backing up the data.
@@ -321,7 +328,7 @@ You can see the memory usage of your database on the "Metrics" tab of your web d
 
 PostgreSQL tends to use all the available memory if there is enough indices to fill the memory. If there is too many indices to fit into the memory, some of them are stored on the disk. In this situation, queries needing these indices will be slowed down. PostgreSQL first needs to load the indices from the disk into the RAM which takes some time. The memory usage on the "Metrics" tab of your web dashboard would always be at 100% in such situation.
 
-## Client Customization 
+## Client Customization
 
 You can customize the PostgreSQL client by adding a `.psqlrc` in your app directory.
 


### PR DESCRIPTION
https://documentation-service-pr1532.osc-fr1.scalingo.io/databases/postgresql/start#running-queries

I'm not completely convinced by how the quote of the mailing list is displayed. WDYT? Should I paraphrase instead of quoting to improve the display? Or leave it as is?

Fix #1198