### PR TITLE
feat: add ssh node package issue

### DIFF
--- a/_posts/languages/nodejs/2000-01-01-deployment-errors.md
+++ b/_posts/languages/nodejs/2000-01-01-deployment-errors.md
@@ -84,9 +84,9 @@ npm ERR! exited with error code: 128
 -----> Build failed
 ```
 
-This issue happens when in your package.json you're using a git repository instead of an NPM package. If you're doing that, you can only use the `https` format and not the `ssh` one.
+This issue happens when in your package.json you're using a git repository instead of a npm package. If you are doing that, you can only use the `https` format and not the `ssh` one.
 
-These requirements will correctly resolve to HTTPS urls:
+These requirements correctly resolve to HTTPS URLs:
 
 ```json
 "scalingo": "https://git@github.com/scalingo/scalingo.js.git"
@@ -97,7 +97,7 @@ These requirements will correctly resolve to HTTPS urls:
 Do no forget the `git@` part in front of the hostname.
 {% endwarning %}
 
-These requirements will incorrectly resolve to SSH urls:
+These requirements incorrectly resolve to SSH URLs:
 ```json
 "scalingo": "github:scalingo/scalingo.js"
 "scalingo": "https://github.com/scalingo/scalingo.js.git"

--- a/_posts/languages/nodejs/2000-01-01-deployment-errors.md
+++ b/_posts/languages/nodejs/2000-01-01-deployment-errors.md
@@ -65,3 +65,42 @@ var server = app.listen(process.env.PORT || 3000, function () {
 ```
 
 If you face a boot timeout error and use the Next.js framework, please refer to [this specific page](https://doc.scalingo.com/languages/nodejs/start#nextjs).
+
+
+## Host key verification failed
+
+```
+Installing node modules
+npm ERR! Error while executing:
+npm ERR! /usr/bin/git ls-remote -h -t ssh://git@github.com/scalingo/scalingo.js.git
+npm ERR!
+npm ERR! Host key verification failed.
+npm ERR! fatal: Could not read from remote repository.
+npm ERR!
+npm ERR! Please make sure you have the correct access rights
+npm ERR! and the repository exists.
+npm ERR!
+npm ERR! exited with error code: 128
+-----> Build failed
+```
+
+This issue happens when in your package.json you're using a git repository instead of an NPM package. If you're doing that, you can only use the `https` format and not the `ssh` one.
+
+These requirements will correctly resolve to HTTPS urls:
+
+```json
+"scalingo": "https://git@github.com/scalingo/scalingo.js.git"
+"scalingo": "git+https://git@github.com/scalingo/scalingo.js.git"
+```
+
+{% warning %}
+Do no forget the `git@` part in front of the hostname.
+{% endwarning %}
+
+These requirements will incorrectly resolve to SSH urls:
+```json
+"scalingo": "github:scalingo/scalingo.js"
+"scalingo": "https://github.com/scalingo/scalingo.js.git"
+"scalingo": "git+https://github.com/scalingo/scalingo.js.git"
+"scalingo": "git@github.com:Scalingo/scalingo.js.git"
+```


### PR DESCRIPTION
https://documentation-service-pr1544.osc-fr1.scalingo.io/languages/nodejs/deployment-errors#host-key-verification-failed

We already had this page https://www.notion.so/scalingooriginal/Node-js-Build-fail-with-Host-key-verification-failed-6d54223301f14a8fac7a6b93e043de1b

But I don't see why it should only be part of our internal documentation, as it is an issue with npm.