### PR TITLE
docs(ffmpeg): spell ffprobe -> FFprobe

### DIFF
--- a/src/_posts/platform/app/2000-01-01-ffmpeg.md
+++ b/src/_posts/platform/app/2000-01-01-ffmpeg.md
@@ -4,11 +4,11 @@ modified_at: 2022-03-09 00:00:00
 tags: app build runtime ffmpeg ffprobe
 ---
 
-[FFmpeg](https://ffmpeg.org/) is a software to manipulate audio and video files. ffprobe is a software to gather information from multimedia streams and prints it in human- and machine-readable fashion.
+[FFmpeg](https://ffmpeg.org/) is a software to manipulate audio and video files. FFprobe is a software to gather information from multimedia streams and prints it in human- and machine-readable fashion.
 
-## Install FFmpeg and ffprobe on a Scalingo Application
+## Install FFmpeg and FFprobe on a Scalingo Application
 
-To install FFmpeg and ffprobe on a Scalingo application, you need to make use of [the APT buildpack]({% post_url platform/deployment/buildpacks/2000-01-01-apt %}). This buildpack should be used as part of a [multi-buildpack]({% post_url platform/deployment/buildpacks/2000-01-01-multi %}).
+To install FFmpeg and FFprobe on a Scalingo application, you need to make use of [the APT buildpack]({% post_url platform/deployment/buildpacks/2000-01-01-apt %}). This buildpack should be used as part of a [multi-buildpack]({% post_url platform/deployment/buildpacks/2000-01-01-multi %}).
 
 ```bash
 $ echo "https://github.com/Scalingo/apt-buildpack" > .buildpacks
@@ -31,7 +31,7 @@ scalingo --app biniou env-set LD_LIBRARY_PATH='$LD_LIBRARY_PATH:/app/.apt/usr/li
 
 Commit these files, and redeploy your application.
 
-You can make sure that FFmpeg and ffprobe are installed by running a one-off container:
+You can make sure that FFmpeg and FFprobe are installed by running a one-off container:
 
 ```
 $ scalingo --app my-app run bash


### PR DESCRIPTION
The lower case spelling is probably for the executable

Related to https://github.com/Scalingo/ffmpeg-buildpack/issues/4