### PR TITLE
docs(ruby): MRI 3.1.1 is available

### DIFF
--- a/src/_posts/languages/ruby/2000-01-01-start.md
+++ b/src/_posts/languages/ruby/2000-01-01-start.md
@@ -90,7 +90,8 @@ version are also present if your require them for specific tests.
 
 ### MRI
 
-* `3.0.2`
+* `3.1.1`
+* `3.0.3`
 * `2.7.4`
 * `2.6.8`
 * `2.5.9`


### PR DESCRIPTION
Fix #1582