### PR TITLE
docs(changelog): Go 1.18

### DIFF
--- a/src/_posts/languages/go/2000-01-01-start.md
+++ b/src/_posts/languages/go/2000-01-01-start.md
@@ -1,7 +1,7 @@
 ---
 title: Go
 nav: Introduction
-modified_at: 2021-12-08 00:00:00
+modified_at: 2022-03-16 00:00:00
 tags: go
 index: 1
 ---
@@ -14,9 +14,10 @@ The Go programming language is supported.
 
 #### Officially Supported
 
-* `go1.17.3`
-* `go1.16.10`
-* `go1.15.10`
+* `go1.18`
+* `go1.17.8`
+* `go1.16.15`
+* `go1.15.15`
 * `go1.14.15`
 * `go1.13.15`
 * `go1.12.17` (default)

--- a/src/changelog/buildpacks/_posts/2022-03-16-go-1.18.md
+++ b/src/changelog/buildpacks/_posts/2022-03-16-go-1.18.md
@@ -1,0 +1,10 @@
+---
+modified_at: 2022-03-16 15:30:00
+title: 'Go - New Versions: 1.18, 1.17.8, 1.16.15 and 1.15.15'
+github: 'https://github.com/Scalingo/go-buildpack'
+---
+
+* Go 1.18 [changelog](https://go.dev/doc/devel/release#go1.18)
+* Go 1.17.8 [changelog](https://go.dev/doc/devel/release#go1.17)
+* Go 1.16.15 [changelog](https://go.dev/doc/devel/release#go1.16)
+* Go 1.15.15 [changelog](https://go.dev/doc/devel/release#go1.15)


### PR DESCRIPTION
Tweet:

> [Changelog] Buildpacks - Go - Support of Go 1.18, 1.17.8, 1.16.15 and 1.15.15 https://changelog.scalingo.com #golang #changelog #PaaS