### PR TITLE
docs(changelog): Ruby and Node.js updates

### DIFF
--- a/src/changelog/buildpacks/_posts/2022-03-18-nodejs-16.md
+++ b/src/changelog/buildpacks/_posts/2022-03-18-nodejs-16.md
@@ -1,0 +1,10 @@
+---
+modified_at: 2022-03-18 12:00:00
+title: 'Node.js: 16 is the new default version'
+github: 'https://github.com/Scalingo/nodejs-buildpack'
+---
+
+We have updated our Node.js buildpack. Noticeable changes:
+
+- the default Node.js version is now the latest from the `16` branch (Node.js LTS)
+- the default npm version is now the latest from the `8` branch

--- a/src/changelog/buildpacks/_posts/2022-03-18-ruby.md
+++ b/src/changelog/buildpacks/_posts/2022-03-18-ruby.md
@@ -1,0 +1,16 @@
+---
+modified_at: 2022-03-18 12:00:00
+title: 'Ruby - New default version is 3.0.3'
+github: 'https://github.com/Scalingo/ruby-buildpack'
+---
+
+The default Ruby version installed is now 3.0.3.
+Ruby 3.1.1 is now available.
+
+Changelogs:
+
+* [3.0.1](https://www.ruby-lang.org/en/news/2021/04/05/ruby-3-0-1-released/)
+* [3.0.2](https://www.ruby-lang.org/en/news/2021/07/07/ruby-3-0-2-released/)
+* [3.0.3](https://www.ruby-lang.org/en/news/2021/11/24/ruby-3-0-3-released/)
+* [3.1.0](https://www.ruby-lang.org/en/news/2021/12/25/ruby-3-1-0-released/)
+* [3.1.1](https://www.ruby-lang.org/en/news/2022/02/18/ruby-3-1-1-released/)


### PR DESCRIPTION
Tweets:

> [Changelog] Buildpacks - Node.js - New default version is 16.x https://changelog.scalingo.com #Node.js #changelog #PaaS

> [Changelog] Buildpacks - Ruby - Support of Ruby 3.1.1 and 3.0.3 https://changelog.scalingo.com #ruby #changelog #PaaS

Related to  Scalingo/ruby-buildpack#38 and Scalingo/nodejs-buildpack#54