### PR TITLE
docs(ruby): Update default Bundler versions

### DIFF
--- a/src/_posts/languages/ruby/2000-01-01-start.md
+++ b/src/_posts/languages/ruby/2000-01-01-start.md
@@ -52,8 +52,8 @@ automatically be set by the platform:
 
 Our deployment system is automatically using the latest available bundler version.
 
-* Bundler 1: **1.15.2**
-* Bundler 2: **2.0.2**
+* Bundler 1: **1.17.3**
+* Bundler 2: **2.3.10**
 
 If your application fails to boot with the following error logs:
 

--- a/src/changelog/buildpacks/_posts/2022-04-06-ruby-bundler.md
+++ b/src/changelog/buildpacks/_posts/2022-04-06-ruby-bundler.md
@@ -1,0 +1,9 @@
+---
+modified_at: 2022-04-06 16:00:00
+title: 'Ruby - New Bundler default versions'
+github: 'https://github.com/Scalingo/ruby-buildpack'
+---
+
+New default versions of Bundler are available:
+* Bundler 1: **1.17.3**
+* Bundler 2: **2.3.10**


### PR DESCRIPTION
Bundler versions: https://github.com/Scalingo/ruby-buildpack/blob/9e2d66620eed80bb2f8720c82add5fbc234fe063/lib/language_pack/helpers/bundler_wrapper.rb#L39-L40