### PR TITLE
docs(changelog): PHP Composer 1.10.26, 2.2.12 and 2.3.5

### DIFF
--- a/src/changelog/buildpacks/_posts/2022-04-13-php-composer-2.3.5.md
+++ b/src/changelog/buildpacks/_posts/2022-04-13-php-composer-2.3.5.md
@@ -1,0 +1,24 @@
+---
+modified_at: 2022-04-13 17:00:00
+title: 'PHP - Release Composer versions 1.10.26, 2.2.12 and 2.3.5'
+github: 'https://github.com/Scalingo/php-buildpack'
+---
+
+Changelogs:
+
+* [Composer 1.10.25](https://github.com/composer/composer/releases/tag/1.10.25)
+* [Composer 1.10.26](https://github.com/composer/composer/releases/tag/1.10.26)
+* [Composer 2.2.5](https://github.com/composer/composer/releases/tag/2.2.5)
+* [Composer 2.2.6](https://github.com/composer/composer/releases/tag/2.2.6)
+* [Composer 2.2.7](https://github.com/composer/composer/releases/tag/2.2.7)
+* [Composer 2.2.8](https://github.com/composer/composer/releases/tag/2.2.8)
+* [Composer 2.2.9](https://github.com/composer/composer/releases/tag/2.2.9)
+* [Composer 2.2.10](https://github.com/composer/composer/releases/tag/2.2.10)
+* [Composer 2.2.11](https://github.com/composer/composer/releases/tag/2.2.11)
+* [Composer 2.2.12](https://github.com/composer/composer/releases/tag/2.2.12)
+* [Composer 2.3.0](https://github.com/composer/composer/releases/tag/2.3.0)
+* [Composer 2.3.1](https://github.com/composer/composer/releases/tag/2.3.1)
+* [Composer 2.3.2](https://github.com/composer/composer/releases/tag/2.3.2)
+* [Composer 2.3.3](https://github.com/composer/composer/releases/tag/2.3.3)
+* [Composer 2.3.4](https://github.com/composer/composer/releases/tag/2.3.4)
+* [Composer 2.3.5](https://github.com/composer/composer/releases/tag/2.3.5)


### PR DESCRIPTION
Tweet:

> [Changelog] Buildpacks - PHP - Support of Composer 2.2.4 https://changelog.scalingo.com #php #composer #changelog #PaaS

Fix https://github.com/Scalingo/php-buildpack/issues/234