### PR TITLE
fix(db-access) Fix broken links and wording issues

### DIFF
--- a/src/_posts/platform/databases/2000-01-01-access.md
+++ b/src/_posts/platform/databases/2000-01-01-access.md
@@ -89,7 +89,7 @@ You can access your database on '127.0.0.1:<localport>'
 
 {% warning %}
 If your MongoDB database uses Business plan, you have a replica set. It is not possible to access a
-replica set using the DB tunnel. You should [enable Direct Acess](#direct-access) to your database.
+replica set using the DB tunnel. You should [enable Internet Accessibility](#internet-accessibility) on your database.
 The reason is that the DB tunnel is designed to connect to only one node. On the other hand, MongoDB
 clients require to reach all the instances of the replica set to work.
 {% endwarning %}


### PR DESCRIPTION
Direct access was renamed to Internet Accessibility this change broke the link in this warning block.
This PR fix the link and the wording issue.