### PR TITLE
docs(region-endpoints): Some refactoring to not have duplicated regions information everywhere

### DIFF
--- a/src/_includes/adminer_endpoints.md
+++ b/src/_includes/adminer_endpoints.md
@@ -1,0 +1,10 @@
+* osc-fr1:
+  Available at [https://adminer.osc-fr1.scalingo.com](https://adminer.osc-fr1.scalingo.com)
+
+* osc-secnum-fr1:
+  Not available for security reasons: only trusted users are allowed to deploy
+  applications in this region. Adminer would be a way to reach internal
+  databases without being authorized beforehand.
+  
+  Follow [these instructions]({% post_url platform/databases/2000-01-01-access %})
+  to connect directly to your database.

--- a/src/_includes/api_endpoints.md
+++ b/src/_includes/api_endpoints.md
@@ -1,0 +1,4 @@
+* osc-fr1:
+  [https://api.osc-fr1.scalingo.com](https://api.osc-fr1.scalingo.com)
+* osc-secnum-fr1:
+  [https://api.osc-secnum-fr1.scalingo.com](https://api.osc-secnum-fr1.scalingo.com)

--- a/src/_includes/db_api_endpoints.md
+++ b/src/_includes/db_api_endpoints.md
@@ -1,0 +1,4 @@
+* osc-fr1:
+  [https://db-api.osc-fr1.scalingo.com](https://db-api.osc-fr1.scalingo.com)
+* osc-secnum-fr1:
+  [https://db-api.osc-secnum-fr1.scalingo.com](https://db-api.osc-secnum-fr1.scalingo.com)

--- a/src/_includes/db_ca_endpoints.md
+++ b/src/_includes/db_ca_endpoints.md
@@ -1,0 +1,4 @@
+The Certificate Authority for databases hosted on Scalingo is
+downloadable here:
+* osc-fr1: https://db-api.osc-fr1.scalingo.com/api/ca_certificate
+* osc-secnum-fr1: https://db-api.osc-secnum-fr1.scalingo.com/api/ca_certificate

--- a/src/_includes/phpmyadmin_endpoints.md
+++ b/src/_includes/phpmyadmin_endpoints.md
@@ -1,0 +1,10 @@
+* osc-fr1:
+  Available at [https://phpmyadmin.osc-fr1.scalingo.com](https://phpmyadmin.osc-fr1.scalingo.com)
+
+* osc-secnum-fr1:
+  Not available for security reasons: only trusted users are allowed to deploy
+  applications in this region. phpMyAdmin would be a way to reach internal
+  databases without being authorized beforehand.
+
+  Follow [these instructions]({% post_url platform/databases/2000-01-01-access %})
+  to connect directly to your MySQL database.

--- a/src/_includes/ssh_endpoints.md
+++ b/src/_includes/ssh_endpoints.md
@@ -1,0 +1,6 @@
+* osc-fr1: `ssh.osc-fr1.scalingo.com`
+* osc-secnum-fr1: `ssh.osc-secnum-fr1.scalingo.com`
+
+{% note %}
+The `SSH Port` used is always 22.
+{% endnote %}

--- a/src/_includes/ssh_urls.md
+++ b/src/_includes/ssh_urls.md
@@ -1,6 +1,0 @@
-- 3DS Outscale Paris:
-  - SSH Hostname: ssh.osc-fr1.scalingo.com
-  - SSH Port: 22
-- 3DS Outscale Paris SecNumCloud:
-  - SSH Hostname: ssh.osc-secnum-fr1.scalingo.com
-  - SSH Port: 22

--- a/src/_posts/databases/elasticsearch/2000-01-01-start.md
+++ b/src/_posts/databases/elasticsearch/2000-01-01-start.md
@@ -1,7 +1,7 @@
 ---
 title: Elasticsearch
 nav: Introduction
-modified_at: 2022-01-26 00:00:00
+modified_at: 2022-04-28 00:00:00
 tags: databases elasticsearch addon
 ---
 
@@ -81,7 +81,7 @@ You can get environment variables from the dashboard or the command line interfa
 $ scalingo -a my-app env | grep ELASTIC
 
 ELASTICSEARCH_URL=$SCALINGO_ELASTICSEARCH_URL
-SCALINGO_ELASTICSEARCH_URL=http://my-app-3030:MpIxXstskccB3Ab2iwKH@my-app-3030.elasticsearch.dbs.appsdeck.eu:30995
+SCALINGO_ELASTICSEARCH_URL=http://my-app-3030:MpIxXstskccB3Ab2iwKH@my-app-3030.elasticsearch.a.osc-fr1.scalingo-dbs.com:30995
 ```
 
 ## Remote access your database
@@ -102,7 +102,7 @@ scalingo --app <application name> run curl http://<user>:<password>@<host>:<port
 **Example**
 
 If my application's name is 'my-app' and it has the environment variable
-`SCALINGO_ELASTICSEARCH_URL = "http://my-app-123:H_grwjqBteMMrVye442Zw6@my-app-123.elasticsearch.dbs.scalingo.com:30000/my-app-123"`
+`SCALINGO_ELASTICSEARCH_URL = "http://my-app-123:H_grwjqBteMMrVye442Zw6@my-app-123.elasticsearch.a.osc-fr1.scalingo-dbs.com:30000/my-app-123"`
 
 You can run:
 

--- a/src/_posts/databases/influxdb/2000-01-01-start.md
+++ b/src/_posts/databases/influxdb/2000-01-01-start.md
@@ -1,7 +1,7 @@
 ---
 title: InfluxDB
 nav: Introduction
-modified_at: 2017-09-13 00:00:00
+modified_at: 2022-04-28 00:00:00
 tags: databases influxdb addon
 index: 1
 ---
@@ -68,7 +68,7 @@ You can get environment variables from the dashboard or the command-line interfa
 $ scalingo --app my-app env
 
 INFLUX_URL=$SCALINGO_INFLUX_URL
-SCALINGO_INFLUX_URL=http://sample_influxdb_3707:RCtlmiQDXuXosYJ4mIOP@my-app-3707.influxdb.dbs.appsdeck.eu:31061/sample_influxdb_3707
+SCALINGO_INFLUX_URL=http://sample_influxdb_3707:RCtlmiQDXuXosYJ4mIOP@my-app-3707.influxdb.a.osc-fr1.scalingo-dbs.com:31061/sample_influxdb_3707
 ```
 
 ## Remote access your database

--- a/src/_posts/databases/mongodb/2000-01-01-compass.md
+++ b/src/_posts/databases/mongodb/2000-01-01-compass.md
@@ -1,7 +1,7 @@
 ---
 title: Access Your MongoDB Database With Compass
 nav: Compass
-modified_at: 2020-06-16 00:00:00
+modified_at: 2022-04-28 00:00:00
 tags: databases mongodb compass tunnel
 index: 4
 ---
@@ -24,12 +24,12 @@ The connection data can be found in the `MONGO_URL` environment variable of your
 
 ```
 $ scalingo --app my-app env | grep MONGO_URL
-MONGO_URL=mongodb://sample-node-meanjs-7093:EsEjseivpacatVoogfijbiapgadTyg@c393a9e3-42fe-4e33-9e6c-8ee815e9af88.sample-node-meanjs-7093.mongodb.dbs.scalingo.com:31312/sample-node-meanjs-7093
+MONGO_URL=mongodb://sample-node-meanjs-7093:EsEjseivpacatVoogfijbiapgadTyg@c393a9e3-42fe-4e33-9e6c-8ee815e9af88.sample-node-meanjs-7093.mongodb.a.osc-fr1.scalingo-dbs.com:31312/sample-node-meanjs-7093
 ```
 
 In this case:
 
-* Hostname: c393a9e3-42fe-4e33-9e6c-8ee815e9af88.sample-node-meanjs-7093.mongodb.dbs.scalingo.com
+* Hostname: c393a9e3-42fe-4e33-9e6c-8ee815e9af88.sample-node-meanjs-7093.mongodb.a.osc-fr1.scalingo-dbs.com
 * Port: 31312
 * User: sample-node-meanjs-7093
 * Password: EsEjseivpacatVoogfijbiapgadTyg
@@ -47,22 +47,23 @@ is your private SSH key you uploaded on your Scalingo profile.
 The "SSH Hostname" and "SSH Port" depends on the region your database is
 deployed on:
 
-{% include ssh_urls.md %}
+{% include ssh_endpoints.md %}
 
 ### Connection with TLS
 
-As a replacement to using an encrypted tunnel to connect to your database, you can make it available
-on the internet from your database dashboard. You must first [force
-TLS]({% post_url databases/mongodb/2000-01-01-start %}#force-tls-connections) connections.
+As a replacement to using an encrypted tunnel to connect to your database,
+you can make it available on the internet from your database dashboard.
+You must first activate
+[Force TLS]({% post_url databases/mongodb/2000-01-01-start %}#force-tls-connections)
+connections.
 
-This is done in Compass by selecting "Server Validation" in the "SSL" section of the "Connect to
-Host" form:
+This is done in Compass by selecting "Server Validation" in the "SSL" section
+of the "Connect to Host" form:
 
 {% assign img_url = "https://cdn.scalingo.com/documentation/compass/ssl_configuration.png" %}
 {% include mdl_img.html %}
 
-The "Certificate Authority" is downloadable
-[here](https://db-api.osc-fr1.scalingo.com/api/ca_certificate).
+{% include db_ca_endpoints.md %}
 
 {% warning %}
 If your plan has a single node replica, you might see the error `topology type:

--- a/src/_posts/databases/mongodb/2000-01-01-dump-restore.md
+++ b/src/_posts/databases/mongodb/2000-01-01-dump-restore.md
@@ -1,7 +1,7 @@
 ---
 title: How to dump and restore my MongoDB database on Scalingo
 nav: Dump and Restore
-modified_at: 2022-03-11 00:00:00
+modified_at: 2022-04-28 00:00:00
 tags: databases mongodb mongo tunnel dump restore
 index: 2
 ---
@@ -44,7 +44,7 @@ There are two ways to access your database from your local workstation:
 ```bash
 $ scalingo --app my-app db-tunnel SCALINGO_MONGO_URL
 
-Building tunnel to my-db.mongo.dbs.scalingo.com:30000
+Building tunnel to my-db.mongo.a.osc-fr1.scalingo-dbs.com:30000
 You can access your database on:
 127.0.0.1:10000
 ```
@@ -146,7 +146,7 @@ $ scalingo --app my-app run bash
 $ scalingo --app my-app run bash
 
 [00:00] Scalingo ~ $ dbclient-fetcher mongo
-[00:00] Scalingo ~ $ mongodump --username user --password pass --host my-db.mongo.dbs.scalingo.com --port 30000 --db my-db
+[00:00] Scalingo ~ $ mongodump --username user --password pass --host my-db.mongo.a.osc-fr1.scalingo-dbs.com --port 30000 --db my-db
 
 # Do something with the dump, i.e send it with FTP or to an external server
 ```

--- a/src/_posts/databases/mongodb/2000-01-01-robo3t.md
+++ b/src/_posts/databases/mongodb/2000-01-01-robo3t.md
@@ -1,7 +1,7 @@
 ---
 title: Access Your MongoDB Database With Robo 3T
 nav: Robo 3T
-modified_at: 2020-06-16 00:00:00
+modified_at: 2022-04-28 00:00:00
 tags: databases mongodb robomongo robo3t tunnel
 index: 3
 ---
@@ -27,12 +27,12 @@ application.
 
 ```
 $ scalingo env | grep MONGO_URL
-MONGO_URL=mongodb://sample-node-meanjs-7093:EsEjseivpacatVoogfijbiapgadTyg@c393a9e3-42fe-4e33-9e6c-8ee815e9af88.sample-node-meanjs-7093.mongodb.dbs.scalingo.com:31312/sample-node-meanjs-7093
+MONGO_URL=mongodb://sample-node-meanjs-7093:EsEjseivpacatVoogfijbiapgadTyg@c393a9e3-42fe-4e33-9e6c-8ee815e9af88.sample-node-meanjs-7093.mongodb.a.osc-fr1.scalingo-dbs.com:31312/sample-node-meanjs-7093
 ```
 
 In this case:
 
-* Hostname: c393a9e3-42fe-4e33-9e6c-8ee815e9af88.sample-node-meanjs-7093.mongodb.dbs.scalingo.com
+* Hostname: c393a9e3-42fe-4e33-9e6c-8ee815e9af88.sample-node-meanjs-7093.mongodb.a.osc-fr1.scalingo-dbs.com
 * Port: 31312
 * User: sample-node-meanjs-7093
 * Password: EsEjseivpacatVoogfijbiapgadTyg
@@ -59,7 +59,7 @@ uploaded on your Scalingo profile.
 The "SSH Hostname" and "SSH Port" depends on the region your database is
 deployed on:
 
-{% include ssh_urls.md %}
+{% include ssh_endpoints.md %}
 
 Validate the configuration and click on connect, that's it.
 
@@ -78,5 +78,4 @@ This is done in Robo 3T under the "SSL" tab:
 {% assign img_url = "https://cdn.scalingo.com/documentation/robomongo/ssl_connection.png" %}
 {% include mdl_img.html %}
 
-The "Certificate Authority" is downloadable
-[here](https://db-api.osc-fr1.scalingo.com/api/ca_certificate).
+{% include db_ca_endpoints.md %}

--- a/src/_posts/databases/mongodb/2000-01-01-start.md
+++ b/src/_posts/databases/mongodb/2000-01-01-start.md
@@ -1,7 +1,7 @@
 ---
 title: MongoDB
 nav: Introduction
-modified_at: 2020-09-25 00:00:00
+modified_at: 2022-04-28 00:00:00
 tags: databases mongodb addon
 index: 1
 ---
@@ -78,7 +78,7 @@ You can get those variables from the Dashboard or the command-line interface.
 $ scalingo --app my-app env | grep MONGO
 
 MONGO_URL=$SCALINGO_MONGO_URL
-SCALINGO_MONGO_URL=mongodb://my-app-3030:2rj5FYoiKRFp8eZhpMz7@my-app-3030.mongo.dbs.appsdeck.eu:30949/my-app-3030
+SCALINGO_MONGO_URL=mongodb://my-app-3030:2rj5FYoiKRFp8eZhpMz7@my-app-3030.mongo.a.osc-fr1.scalingo-dbs.com:30949/my-app-3030
 ```
 
 ## Remote access your database

--- a/src/_posts/databases/mysql/2000-01-01-dump-restore.md
+++ b/src/_posts/databases/mysql/2000-01-01-dump-restore.md
@@ -1,7 +1,7 @@
 ---
 title: How to dump and restore my MySQL database on Scalingo
 nav: Dump and Restore
-modified_at: 2020-11-13 00:00:00
+modified_at: 2022-04-28 00:00:00
 tags: databases mysql tunnel
 index: 2
 ---
@@ -85,12 +85,12 @@ $ scalingo --app my-app run bash
 $ scalingo --app my-app run bash
 
 [00:00] Scalingo ~ $ dbclient-fetcher mysql
-[00:00] Scalingo ~ $ mysqldump -u user --password=pass -h my-db.mysql.dbs.scalingo.com -P 30000 my-db > /tmp/dumped_db.sql
+[00:00] Scalingo ~ $ mysqldump -u user --password=pass -h my-db.mysql.a.osc-fr1.scalingo-dbs.com -P 30000 my-db > /tmp/dumped_db.sql
 ...
 
 # Do something with the dump, i.e.e send through FTP or to an external server
 
-[00:00] Scalingo ~ $ mysql -u my-db --password=pass -h my-db.mysql.dbs.scalingo.com -P 30000 my-db < /tmp/dumped_db.sql
+[00:00] Scalingo ~ $ mysql -u my-db --password=pass -h my-db.mysql.a.osc-fr1.scalingo-dbs.com -P 30000 my-db < /tmp/dumped_db.sql
 ...
 [00:00] Scalingo ~ $ exit
 exit

--- a/src/_posts/databases/mysql/2000-01-01-start.md
+++ b/src/_posts/databases/mysql/2000-01-01-start.md
@@ -1,7 +1,7 @@
 ---
 title: MySQL
 nav: Introduction
-modified_at: 2020-09-04 00:00:00
+modified_at: 2022-04-28 00:00:00
 tags: databases mysql addon
 index: 1
 ---
@@ -19,7 +19,7 @@ it later.
 
 ### Through the Dashboard
 
-1. Go to your app on [Scalingo Dashboard](https://my.scalingo.com/apps)
+1. Go to your app on the [Scalingo Dashboard](https://dashboard.scalingo.com)
 2. Click on **Addons** tab
 3. Select the addon you want to add
 4. In the dialog select the database plan you need
@@ -74,7 +74,7 @@ You can get environment variables from the dashboard or the command line interfa
 
 ### From the Dashboard
 
-1. Go to your app on [Scalingo Dashboard](https://my.scalingo.com/apps)
+1. Go to your app on the [Scalingo Dashboard](https://dashboard.scalingo.com)
 2. Click on **Environment** tab
 3. `SCALINGO_MYSQL_URL` is displayed
 
@@ -87,7 +87,7 @@ You can get environment variables from the dashboard or the command line interfa
 $ scalingo --app my-app env | grep MYSQL
 
 DATABASE_URL=$SCALINGO_MYSQL_URL
-SCALINGO_MYSQL_URL=mysql://my_app_3030:CaUrq1MdUkAzCSEq-1Fg@my-app-3030.mysql.dbs.scalingo.com:30999/my_app_3030
+SCALINGO_MYSQL_URL=mysql://my_app_3030:CaUrq1MdUkAzCSEq-1Fg@my-app-3030.mysql.a.osc-fr1.scalingo-dbs.com:30999/my_app_3030
 ```
 
 ### Ruby on Rails Specific
@@ -153,7 +153,7 @@ after the operation is successful, the related app will be restarted.
 
 ### From the Dashboard
 
-1. Go to your app on [Scalingo Dashboard](https://my.scalingo.com/apps)
+1. Go to your app on the [Scalingo Dashboard](https://dashboard.scalingo.com)
 2. Click on **Addons** tab
 3. Select the addon you want to change
 4. In the dialog select the plan you want to upgrade/downgrade to
@@ -267,7 +267,7 @@ If your database has multiple nodes, the dump is done on the secondary node.
 
 Automated backups are listed in the database specific dashboard.
 
-1. Go to your app on [Scalingo Dashboard](https://my.scalingo.com/apps)
+1. Go to your app on the [Scalingo Dashboard](https://dashboard.scalingo.com)
 2. Click on **Addons** tab
 3. Click **Link to dashboard** which will take you to the **MySQL dashboard**
 4. Click on **Backups** tab
@@ -292,18 +292,7 @@ databases/mysql/2000-01-01-dump-restore %}) guide.
 
 The application is available on the platform to use alongside your databases:
 
-#### Region `osc-fr1`
-
-Available at [https://phpmyadmin.osc-fr1.scalingo.com](https://phpmyadmin.osc-fr1.scalingo.com).
-
-#### Region `osc-secnum-fr1`
-
-Not available for security reasons: only trusted users are allowed to deploy
-applications in this region. phpMyAdmin would be a way to reach internal databases
-without being authorized beforehand.
-
-Follow [these instructions]({% post_url platform/databases/2000-01-01-access %})
-to connect directly to your MySQL database.
+{% include phpmyadmin_endpoints.md %}
 
 #### How to login?
 

--- a/src/_posts/databases/mysql/2000-01-01-workbench.md
+++ b/src/_posts/databases/mysql/2000-01-01-workbench.md
@@ -1,7 +1,7 @@
 ---
 title: Access your MySQL database with Workbench
 nav: MySQL Workbench
-modified_at: 2019-08-01 00:00:00
+modified_at: 2022-04-28 00:00:00
 tags: databases mysql workbench tunnel
 index: 3
 ---
@@ -25,12 +25,12 @@ variable of your application.
 
 ```
 $ scalingo env | grep SCALINGO_MYSQL_URL
-SCALINGO_MYSQL_URL=mysql://my_app_3030:CaUrq1MdUkAzCSEq-1Fg@my-app-3030.mysql.dbs.scalingo.com:30999/my_app_3030
+SCALINGO_MYSQL_URL=mysql://my_app_3030:CaUrq1MdUkAzCSEq-1Fg@my-app-3030.mysql.a.osc-fr1.scalingo-dbs.com:30999/my_app_3030
 ```
 
 In this case:
 
-* Hostname: my-app-3030.mysql.dbs.scalingo.com
+* Hostname: my-app-3030.mysql.a.osc-fr1.scalingo-dbs.com
 * Port: 30999
 * User: my_app_3030
 * Password: CaUrq1MdUkAzCSEq-1Fg
@@ -52,4 +52,4 @@ The "SSH Username" is always `git`.
 The "SSH Hostname" and "SSH Port" depends on the region your database is
 deployed on:
 
-{% include ssh_urls.md %}
+{% include ssh_endpoints.md %}

--- a/src/_posts/databases/postgresql/2000-01-01-start.md
+++ b/src/_posts/databases/postgresql/2000-01-01-start.md
@@ -1,7 +1,7 @@
 ---
 title: PostgreSQL
 nav: Introduction
-modified_at: 2022-01-25 00:00:00
+modified_at: 2022-04-28 00:00:00
 tags: databases postgresql addon
 index: 1
 ---
@@ -86,7 +86,7 @@ You can get environment variables from the dashboard or the command line interfa
 $ scalingo --app my-app env | grep POSTGRESQL
 
 DATABASE_URL=$SCALINGO_POSTGRESQL_URL
-SCALINGO_POSTGRESQL_URL=postgres://example_app_3030:ptojfrxzRi-lDfDYyahe@my-app-3030.postgresql.dbs.appsdeck.eu:31000/example_app_3030
+SCALINGO_POSTGRESQL_URL=postgres://example_app_3030:ptojfrxzRi-lDfDYyahe@my-app-3030.postgresql.a.osc-fr1.scalingo-dbs.com:31000/example_app_3030
 ```
 
 ## Remote Access Your Database

--- a/src/_posts/databases/redis/2000-01-01-start.md
+++ b/src/_posts/databases/redis/2000-01-01-start.md
@@ -1,7 +1,7 @@
 ---
 title: Redis
 nav: Introduction
-modified_at: 2020-02-26 00:00:00
+modified_at: 2022-04-28 00:00:00
 tags: databases redis addon
 index: 1
 ---
@@ -81,7 +81,7 @@ You can get environment variables from the dashboard or the command line interfa
 $ scalingo --app my-app env | grep REDIS
 
 REDIS_URL=$SCALINGO_REDIS_URL
-SCALINGO_REDIS_URL=redis://my-app-3030:l2ebPNwe-IWVJmV8OlLX@my-app-3030.redis.dbs.appsdeck.eu:30996
+SCALINGO_REDIS_URL=redis://my-app-3030:l2ebPNwe-IWVJmV8OlLX@my-app-3030.redis.a.osc-fr1.scalingo-dbs.com:30996
 ```
 
 ## Remote Access Your Database

--- a/src/_posts/platform/databases/2000-01-01-access.md
+++ b/src/_posts/platform/databases/2000-01-01-access.md
@@ -1,6 +1,6 @@
 ---
 title: Access Your Database
-modified_at: 2020-06-16 00:00:00
+modified_at: 2022-04-28 00:00:00
 tags: databases
 index: 1
 ---
@@ -33,6 +33,9 @@ scalingo --app my-app mongo-console
 
 # Open a console using the `redis-cli` client
 scalingo --app my-app redis-console
+
+# Open a console using the `InfluxDB shell` client
+scalingo --app my-app influxdb-console
 ```
 
 ### Manually install the databases CLI in one-off
@@ -127,13 +130,13 @@ Our command line tool handles it in a single command, but you might want to use
 the tunnel without it. With the standard OpenSSH client, the way to build the
 tunnel is:
 
-```
+```bash
 ssh -L <local port>:<database host>:<database port> git@<SSH hostname>:<SSH port> -N
 ```
 
 The SSH hostname and port depend on the region of your application:
 
-{% include ssh_urls.md %}
+{% include ssh_endpoints.md %}
 
 The database host and database port can be found in the environment variable
 representing the connection string of your database instance. Get it from the
@@ -154,13 +157,13 @@ Example:
 If the app is in the region `osc-fr1` and if the environment variable is the following:
 
 ```
-SCALINGO_POSTGRESQL_URL=postgresql://user:secret@my-db.postgresql.dbs.appsdeck.eu:30000/my-db
+SCALINGO_POSTGRESQL_URL=postgresql://user:secret@my-db.postgresql.a.osc-fr1.scalingo-dbs.com:30000/my-db
 ```
 
 The command to run is:
 
-```
-ssh -L 10000:my-db.postgresql.dbs.appsdeck.eu:30000 git@ssh.osc-fr1.scalingo.com -N
+```bash
+ssh -L 10000:my-db.postgresql.a.osc-fr1.scalingo-dbs.com:30000 git@ssh.osc-fr1.scalingo.com -N
 ```
 
 Then you connect on `localhost:10000` to reach your Scalingo database. (You'll still need to authenticate to the

--- a/src/_posts/platform/databases/2000-01-01-adminer.md
+++ b/src/_posts/platform/databases/2000-01-01-adminer.md
@@ -1,7 +1,7 @@
 ---
 title: Adminer
 nav: Adminer
-modified_at: 2020-03-31 00:00:00
+modified_at: 2022-04-28 00:00:00
 tags: databases addon adminer
 ---
 
@@ -11,18 +11,7 @@ databases.
 
 The application is available on the platform to use alongside your databases:
 
-### Region `osc-fr1`
-
-Available at [https://adminer.osc-fr1.scalingo.com](https://adminer.osc-fr1.scalingo.com).
-
-### Region `osc-secnum-fr1`
-
-Not available for security reasons: only trusted users are allowed to deploy
-applications in this region. Adminer would be a way to reach internal databases
-without being authorized beforehand.
-
-Follow [these instructions]({% post_url platform/databases/2000-01-01-access %})
-to connect directly to your database.
+{% include adminer_endpoints.md %}
 
 ## How to use Adminer
 
@@ -36,13 +25,13 @@ SCALINGO_<DB type>_URL=<scheme>://<username>:<password>@<server host>:<server po
 For example, if your variable is:
 
 ```
-SCALINGO_POSTGRESQL_URL=postgres://app_5942:random_password@b11e65b8-b36a-4369-bcf6-73b6b9439e84.app-5942.postgresql.dbs.scalingo.com:31313/app_5942?sslmode=prefer
+SCALINGO_POSTGRESQL_URL=postgres://app_5942:random_password@b11e65b8-b36a-4369-bcf6-73b6b9439e84.app-5942.postgresql.a.osc-fr1.scalingo-dbs.com:31313/app_5942?sslmode=prefer
 ```
 
 You need to fill the Adminer form with these values:
 
 - System: `PostgreSQL`,
-- Server: `b11e65b8-b36a-4369-bcf6-73b6b9439e84.app-5942.postgresql.dbs.scalingo.com:31313`,
+- Server: `b11e65b8-b36a-4369-bcf6-73b6b9439e84.app-5942.postgresql.a.osc-fr1.scalingo-dbs.com:31313`,
 - Username: `app_5942`,
 - Password: `random_password`,
 - Database: `app_5942`.

--- a/src/_posts/platform/deployment/continuous-integration/2000-01-01-deploy-scalingo-from-bitbucket.md
+++ b/src/_posts/platform/deployment/continuous-integration/2000-01-01-deploy-scalingo-from-bitbucket.md
@@ -1,7 +1,7 @@
 ---
 title: Deploy to Scalingo from Bitbucket
 nav: Deploy from Bitbucket
-modified_at: 2020-04-29 00:00:00
+modified_at: 2022-04-26 00:00:00
 tags: ci deployment build bitbucket
 index: 25
 ---
@@ -46,7 +46,7 @@ scalingo --app my-app git-show
 
 To deploy to Scalingo from Bitbucket, you'll have to add the public key
 generated for Bitbucket Pipelines to the [SSH Keys
-page](https://my.scalingo.com/keys) on Scalingo dashboard.
+page](https://dashboard.scalingo.com/account/keys) on the Scalingo Dashboard.
 
 {% note %}
 You can create a dedicated user only for deployment from Bitbucket. You would

--- a/src/_posts/platform/deployment/continuous-integration/2000-01-01-deploy-scalingo-from-semaphore-ci.md
+++ b/src/_posts/platform/deployment/continuous-integration/2000-01-01-deploy-scalingo-from-semaphore-ci.md
@@ -1,7 +1,7 @@
 ---
 title: Deploy to Scalingo from Semaphore
 nav: Deploy from Semaphore
-modified_at: 2020-04-29 00:00:00
+modified_at: 2022-04-26 00:00:00
 tags: ci deployment build semaphore-ci
 index: 23
 ---
@@ -21,7 +21,7 @@ ssh-keyscan -H -ssh.osc-fr1.scalingo.com >> ~/.ssh/known_hosts
 
 The SSH port and host actually depend on the region of your application:
 
-{% include ssh_urls.md %}
+{% include ssh_endpoints.md %}
 
 ```bash
 # Push the branch you've setup on Semaphore
@@ -39,6 +39,6 @@ scalingo --app my-app git-show
 
 To deploy to Scalingo from Semaphore, you'll have to add your private key to the
 Semaphore interface. You will also need to add the public key to the [SSH Keys
-page](https://my.scalingo.com/keys) on Scalingo dashboard.
+page](https://dashboard.scalingo.com/account/keys) on the Scalingo Dashboard.
 
 We recommend to generate a new key pair for integrating Semaphore with Scalingo.

--- a/src/_posts/platform/internals/2000-01-01-regions.md
+++ b/src/_posts/platform/internals/2000-01-01-regions.md
@@ -1,6 +1,6 @@
 ---
 title: Regions
-modified_at: 2020-08-03 00:00:00
+modified_at: 2022-04-28 00:00:00
 tags: internals regions
 index: 10
 ---
@@ -8,41 +8,41 @@ index: 10
 Scalingo is available on multiple regions. Here is the list of publicly
 available regions:
 
-| Name  | Provider | API Endpoint | Dashboard | Database API Endpoint |
-| ------------- | ------------- | ------------- | ------------- | -------- |
-| osc-fr1  | [3DS Outscale](https://outscale.com/) | [link](https://api.osc-fr1.scalingo.com) | [link](https://my.osc-fr1.scalingo.com) | [link](https://db-api.osc-fr1.scalingo.com) |
-| osc-secnum-fr1  | [3DS Outscale](https://outscale.com/) | [link](https://api.osc-secnum-fr1.scalingo.com) | [link](https://my.osc-secnum-fr1.scalingo.com) | [link](https://db-api.osc-secnum-fr1.scalingo.com) |
+| Name           | Provider                              | Provider Region     | Location      |
+| -------------- | ------------------------------------- | ------------------- | ------------- |
+| osc-fr1        | [3DS Outscale](https://outscale.com/) | eu-west-2           | Paris, France |
+| osc-secnum-fr1 | [3DS Outscale](https://outscale.com/) | cloudgouv-eu-west-1 | Paris, France |
+
 {: .table }
 
 
 It is possible to [migrate applications and data between regions]({% post_url platform/app/2000-01-01-regions-migration %}).
 
-The `osc-secnum-fr1` region is only available upon request on the support.
+{% note %}
+The `osc-secnum-fr1` region is restricted and is only available upon request
+on the support.
+
+More informations on this [page]({% post_url security/procedures/2000-01-01-secnumcloud %}).
+{% endnote %}
 
 ## Accessing a Specific Region
 
 ### Using the Web Dashboard
 
-When using the web dashboard at
-[https://my.scalingo.com](https://my.scalingo.com), you will automatically be
-redirected to the region you have access to. If your account has access to
-multiple regions, a selection screen will be presented to let you chose which
-region you want to use:
+The web dashboard is available at
+[https://dashboard.scalingo.com](https://dashboard.scalingo.com).
 
-{% assign img_url = "https://cdn.scalingo.com/documentation/internals/screenshot_dashboard_regions_selection.png" %}
-{% include mdl_img.html %}
+If your account has access to multiple regions, you will be able to see your
+applications that are present on the different regions.
 
-You can also directly head to a region's dashboard:
-
-- osc-fr1:
-  [https://my.osc-fr1.scalingo.com](https://my.osc-fr1.scalingo.com)
-- osc-secnum-fr1:
-  [https://my.osc-secnum-fr1.scalingo.com](https://my.osc-secnum-fr1.scalingo.com)
+And when you want to create an application, you will be presented with a
+selection screen to allow you to choose the region on which you want to
+create the application.
 
 ### Using the CLI
 
-If you use the CLI to manage your app, all commands now have the flag `--region`
-to specify the region you want to use.
+If you use the CLI to manage your application, all commands have the
+flag `--region` to specify the region you want to use.
 
 You can list all the regions with `scalingo regions`:
 
@@ -58,63 +58,50 @@ $ scalingo regions
 
 #### Changing the CLI default region
 
-You can set the default region in the CLI with the command `scalingo config --region $REGION_NAME`. For example to use the region `osc-fr1` you can type: `scalingo config --region osc-fr1`.
+You can set the default region in the CLI with the command
+`scalingo config --region $REGION_NAME`.
+For example to use the region `osc-fr1` you can type:
+`scalingo config --region osc-fr1`.
 
 You can also set the default region by defining the environment variable `SCALINGO_REGION`.
 
 ## Difference Between Regions
 
-Various elements change between the different regions. Here is the exhaustive
-list of the difference between the regions:
+Various elements change between the different regions.
+Here is the exhaustive list of the difference between the regions:
 
-#### App Domain Name
+### App Domain Name
 
-* osc-fr1: `my-app.osc-fr1.scalingo.io`
-* osc-secnum-fr1: `my-app.osc-secnum-fr1.scalingo.io`
+All applications have a default subdomain under `REGION_NAME.scalingo.io`
+and it will always be linked to your application.
 
-#### SSH Endpoints
+* osc-fr1: `APP_NAME.osc-fr1.scalingo.io`
+* osc-secnum-fr1: `APP_NAME.osc-secnum-fr1.scalingo.io`
 
-{% include ssh_urls.md %}
+### SSH Endpoints
 
-#### API Endpoints
+{% include ssh_endpoints.md %}
 
-* osc-fr1:
-  [https://api.osc-fr1.scalingo.com](https://api.osc-fr1.scalingo.com)
-* osc-secnum-fr1:
-  [https://api.osc-secnum-fr1.scalingo.com](https://api.osc-secnum-fr1.scalingo.com)
+### API Endpoints
 
-#### Database API Endpoints
+{% include api_endpoints.md %}
 
-* osc-fr1:
-  [https://db-api.osc-fr1.scalingo.com](https://db-api.osc-fr1.scalingo.com)
-* osc-secnum-fr1:
-  [https://db-api.osc-secnum-fr1.scalingo.com](https://db-api.osc-secnum-fr1.scalingo.com)
+### Database API Endpoints
 
-#### Outgoing IP Addresses
+{% include db_api_endpoints.md %}
+
+### Outgoing IP Addresses
 
 The IP addresses of the traffic outgoing from Scalingo hosted applications
 depend on the region. The possible values are listed [here]({% post_url
 platform/internals/2000-01-01-network %}#outgoing-ip-addresses-range).
 
-#### Internal
+### Database Web Access
 
-##### Dashboard
+#### Adminer
 
-* osc-fr1:
-  [https://my.osc-fr1.scalingo.com](https://my.osc-fr1.scalingo.com)
-* osc-secnum-fr1:
-  [https://my.osc-secnum-fr1.scalingo.com](https://my.osc-secnum-fr1.scalingo.com)
+{% include adminer_endpoints.md %}
 
-##### Adminer
+#### phpMyAdmin
 
-* osc-fr1:
-  [https://adminer.osc-fr1.scalingo.com](https://adminer.osc-fr1.scalingo.com)
-* osc-secnum-fr1:
-  [https://adminer.osc-secnum-fr1.scalingo.com](https://adminer.osc-secnum-fr1.scalingo.com)
-
-##### phpMyAdmin
-
-* osc-fr1:
-  [https://phpmyadmin.osc-fr1.scalingo.com](https://phpmyadmin.osc-fr1.scalingo.com)
-* osc-secnum-fr1:
-  [https://phpmyadmin.osc-secnum-fr1.scalingo.com](https://phpmyadmin.osc-secnum-fr1.scalingo.com)
+{% include phpmyadmin_endpoints.md %}


### PR DESCRIPTION
A "little" PR of refactoring to have endpoints documented in multiple files but at one place.
Also updated a couple of URLs and make some improvements