### PR TITLE
docs(changelog): upgrade imagick 3.7.0

### DIFF
--- a/src/changelog/buildpacks/_posts/2022-04-28-php-imagick-ext-3.7.0.md
+++ b/src/changelog/buildpacks/_posts/2022-04-28-php-imagick-ext-3.7.0.md
@@ -1,0 +1,9 @@
+---
+modified_at: 2022-04-28 14:00:00
+title: 'PHP - Support of extension `imagick` version 3.7.0'
+github: 'https://github.com/Scalingo/php-buildpack'
+---
+
+Changelog:
+
+* [imagick 3.7.0](https://pecl.php.net/package-changelog.php?package=imagick&release=3.7.0)


### PR DESCRIPTION
Tweet:

> [Changelog] Buildpacks - PHP - Support of extension imagick version 3.7.0 https://changelog.scalingo.com #php #imagick #PaaS #update #changelog

Related to https://github.com/Scalingo/php-buildpack/issues/247