### PR TITLE
fix(elascticsearch): need to reach the support to restore a backup

### DIFF
--- a/src/_posts/databases/elasticsearch/2000-01-01-start.md
+++ b/src/_posts/databases/elasticsearch/2000-01-01-start.md
@@ -278,16 +278,8 @@ internal working of Elasticsearch and we cannot circumvent it.
 
 ### Restoring a Backup
 
-You can restore your database with data from a previous backup. Automated
-backups are listed in the database specific dashboard:
-
-1. Go to your app on [Scalingo Dashboard](https://my.scalingo.com/apps)
-2. Click on **Addons** tab
-3. Click **Link to dashboard** which will take you to the **Elasticsearch dashboard**
-4. Click on **Backups** tab
-5. Click on the "Restore" button in front of the backup you want to restore
-
-{% assign img_url = "https://cdn.scalingo.com/documentation/screenshot_dashboard_addons_elasticsearch_restore.png" %}
-{% include mdl_img.html %}
+To be able to restore a backup, please reach the support by providing the following information:
+- application name on which the database is linked
+- the date of the backup you want to restore
 
 {% include encryption_at_rest.md %}


### PR DESCRIPTION
We don't propose the restore button anymore, it is needed to reach the support to be able to restore a backup on ElasticSearch.