### PR TITLE
docs(changelog): MySQL 5.7.38-1

### DIFF
--- a/src/changelog/databases/_posts/2022-05-11-mysql-5.7.38-1.md
+++ b/src/changelog/databases/_posts/2022-05-11-mysql-5.7.38-1.md
@@ -1,0 +1,17 @@
+---
+modified_at: 2022-05-11 16:00:00
+title: 'MySQL - New version: 5.7.38-1'
+---
+
+New default version: **5.7.38-1**
+
+Changelog:
+* [MySQL 5.7.34](https://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-5-7-34.html)
+* [MySQL 5.7.35](https://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-5-7-35.html)
+* [MySQL 5.7.36](https://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-5-7-36.html)
+* [MySQL 5.7.37](https://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-5-7-37.html)
+* [MySQL 5.7.38](https://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-5-7-38.html)
+
+Docker image on [Docker Hub](https://hub.docker.com/r/scalingo/mysql):
+
+* `scalingo/mysql:5.7.38-1`


### PR DESCRIPTION
Tweet

> [Changelog] - MySQL - New default version: 5.7.38-1 - https://changelog.scalingo.com #mysql #changelog #PaaS