### PR TITLE
docs(changelog): PHP extension memcached 3.2.0

### DIFF
--- a/src/changelog/buildpacks/_posts/2022-05-12-php-ext-memcached-3.2.0.md
+++ b/src/changelog/buildpacks/_posts/2022-05-12-php-ext-memcached-3.2.0.md
@@ -1,0 +1,10 @@
+---
+modified_at: 2022-05-12 10:00:00
+title: 'PHP - Support of extention: memcached'
+title: 'PHP - Support of extension memcached version 3.2.0'
+github: 'https://github.com/Scalingo/php-buildpack'
+---
+
+Changelog:
+
+* [memcached 3.2.0](https://github.com/php-memcached-dev/php-memcached/releases/tag/v3.2.0)


### PR DESCRIPTION
Tweet:

> [Changelog] Buildpacks - PHP - Support of extension memcached version 3.2.0 https://changelog.scalingo.com #php #memcached #PaaS #update #changelog

Related to https://github.com/Scalingo/php-buildpack/issues/243