### PR TITLE
docs(changelog): PHP 8.1.6, 8.0.19 and 7.4.29

### DIFF
--- a/src/_posts/languages/php/2000-01-01-start.md
+++ b/src/_posts/languages/php/2000-01-01-start.md
@@ -34,9 +34,9 @@ The following PHP versions are compatible with the platform:
 * **7.1** (up to 7.1.33, only for scalingo-18)
 * **7.2** (up to 7.2.34, only for scalingo-18)
 * **7.3** (up to 7.3.33, only for scalingo-18)
-* **7.4** (up to 7.4.26)
-* **8.0** (up to 8.0.13)
-* **8.1** (up to 8.1.0)
+* **7.4** (up to 7.4.29)
+* **8.0** (up to 8.0.19)
+* **8.1** (up to 8.1.6)
 
 ### Select a Version
 

--- a/src/changelog/buildpacks/_posts/2022-05-18-php-8.1.6.md
+++ b/src/changelog/buildpacks/_posts/2022-05-18-php-8.1.6.md
@@ -1,0 +1,23 @@
+---
+modified_at: 2022-05-18 12:00:00
+title: 'PHP - Support of versions 8.1.6, 8.0.19 and 7.4.29'
+github: 'https://github.com/Scalingo/php-buildpack'
+---
+
+Changelogs:
+
+* [PHP 7.4.27 Changelog](https://www.php.net/ChangeLog-7.php#7.4.27)
+* [PHP 7.4.28 Changelog](https://www.php.net/ChangeLog-7.php#7.4.28)
+* [PHP 7.4.29 Changelog](https://www.php.net/ChangeLog-7.php#7.4.29)
+* [PHP 8.0.14 Changelog](https://www.php.net/ChangeLog-8.php#8.0.14)
+* [PHP 8.0.15 Changelog](https://www.php.net/ChangeLog-8.php#8.0.15)
+* [PHP 8.0.16 Changelog](https://www.php.net/ChangeLog-8.php#8.0.16)
+* [PHP 8.0.17 Changelog](https://www.php.net/ChangeLog-8.php#8.0.17)
+* [PHP 8.0.18 Changelog](https://www.php.net/ChangeLog-8.php#8.0.18)
+* [PHP 8.0.19 Changelog](https://www.php.net/ChangeLog-8.php#8.0.19)
+* [PHP 8.1.1 Changelog](https://www.php.net/ChangeLog-8.php#8.1.1)
+* [PHP 8.1.2 Changelog](https://www.php.net/ChangeLog-8.php#8.1.2)
+* [PHP 8.1.3 Changelog](https://www.php.net/ChangeLog-8.php#8.1.3)
+* [PHP 8.1.4 Changelog](https://www.php.net/ChangeLog-8.php#8.1.4)
+* [PHP 8.1.5 Changelog](https://www.php.net/ChangeLog-8.php#8.1.5)
+* [PHP 8.1.6 Changelog](https://www.php.net/ChangeLog-8.php#8.1.6)


### PR DESCRIPTION
Tweet 

> [Changelog] Buildpacks - PHP - Support of PHP 8.1.6, 8.0.19 and 7.4.29 https://changelog.scalingo.com #php #changelog #PaaS

Fix https://github.com/Scalingo/php-buildpack/issues/229