### PR TITLE
docs(changelog): InfluxDB 1.8.10-1

### DIFF
--- a/src/changelog/databases/_posts/2022-05-19-influxdb-1.8.10.md
+++ b/src/changelog/databases/_posts/2022-05-19-influxdb-1.8.10.md
@@ -1,0 +1,15 @@
+---
+modified_at: 2022-05-19 18:30:00
+title: 'InfluxDB - New versions: 1.8.10'
+---
+
+New default version: **1.8.10**
+
+Changelogs
+
+* [InfluxDB 1.7](https://docs.influxdata.com/influxdb/v1.7/about_the_project/releasenotes-changelog/)
+* [InfluxDB 1.8](https://docs.influxdata.com/influxdb/v1.8/about_the_project/releasenotes-changelog/)
+
+Docker image on [Docker Hub](https://hub.docker.com/r/scalingo/influxdb):
+
+* `scalingo/influxdb:1.8.10-1`


### PR DESCRIPTION
Tweet:

> [Changelog] - InfluxDB - New default version: 1.8.10-1 - https://changelog.scalingo.com #influxdb #changelog #PaaS