### PR TITLE
Fix cli.scalingo.com redirect issue 

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -26,7 +26,7 @@ use Rack::Rewrite do
   }
   r301 "/changelog/", "/changelog"
 
-  r301 %r{.*}, "https://#{ENV["CANONICAL_HOST"]}/platform/cli/start$&", if: proc { |rack_env|
+  r301 %r{.*}, "https://#{ENV["CANONICAL_HOST"]}/platform/cli/start", if: proc { |rack_env|
     ["cli.scalingo.com"].include?(rack_env["SERVER_NAME"])
   }
 


### PR DESCRIPTION
`https://cli.scalingo.com` redirects to `https://doc.scalingo.com/platform/cli/start/` (404 error) instead of `https://doc.scalingo.com/platform/cli/start`
Fix consists of removing the trailing slash in the destination URI.