### PR TITLE
docs(changelog): Go 1.18.2 and 1.17.10

### DIFF
--- a/src/_posts/languages/go/2000-01-01-start.md
+++ b/src/_posts/languages/go/2000-01-01-start.md
@@ -1,7 +1,7 @@
 ---
 title: Go
 nav: Introduction
-modified_at: 2022-03-16 00:00:00
+modified_at: 2022-06-01 00:00:00
 tags: go
 index: 1
 ---
@@ -14,8 +14,8 @@ The Go programming language is supported.
 
 #### Officially Supported
 
-* `go1.18`
-* `go1.17.8`
+* `go1.18.2`
+* `go1.17.10`
 * `go1.16.15`
 * `go1.15.15`
 * `go1.14.15`

--- a/src/changelog/buildpacks/_posts/2022-06-01-go-1.18.2.md
+++ b/src/changelog/buildpacks/_posts/2022-06-01-go-1.18.2.md
@@ -1,0 +1,8 @@
+---
+modified_at: 2022-06-01 14:00:00
+title: 'Go - New Versions: 1.18.2 and 1.17.10'
+github: 'https://github.com/Scalingo/go-buildpack'
+---
+
+* Go 1.18.2 [changelog](https://go.dev/doc/devel/release#go1.18)
+* Go 1.17.10 [changelog](https://go.dev/doc/devel/release#go1.17)


### PR DESCRIPTION
Tweet:

> [Changelog] Buildpacks - Go - Support of Go 1.18.2 and 1.17.10. https://changelog.scalingo.com #golang #changelog #PaaS

Fix https://github.com/Scalingo/go-buildpack/issues/21