### PR TITLE
docs(changelog): Go 1.18.3

### DIFF
--- a/src/_posts/languages/go/2000-01-01-gomod.md
+++ b/src/_posts/languages/go/2000-01-01-gomod.md
@@ -1,7 +1,7 @@
 ---
 title: Manage Go dependencies with Go Modules
 nav: Manage dependencies with go.mod
-modified_at: 2021-06-18 00:00:00
+modified_at: 2022-06-10 00:00:00
 tags: go dependencies
 index: 2
 ---
@@ -18,16 +18,6 @@ constraint](https://golang.org/pkg/go/build/#hdr-Build_Constraints) style
 comments to track Scalingo build specific configuration which is encoded in the
 following way:
 
-- `// +scalingo goVersion <version>`: the major version of go you would like Scalingo
-  to use when compiling your code. If not specified defaults to the most recent
-  supported version of Go. Exact versions (ex `go1.16.1`) can also be specified
-  if needed, but is not generally recommended. Since Go doesn't release `.0`
-  versions, specifying a `.0` version will pin your code to the initial release
-  of the given major version (ex `go1.16.0` == `go1.16` without auto updating to
-  `go1.16.1` when it becomes available).
-
-  Example: `// +scalingo goVersion go1.11`
-
 - `// +scalingo install <packagespec>[, <packagespec>]`: a space separated list of
   the packages you want to install. If not specified, this defaults to `.`.
   Other common choices are: `./cmd/...` (all packages and sub packages in the
@@ -35,6 +25,16 @@ following way:
   directory). The exact choice depends on the layout of your repository though.
 
   Example: `// +scalingo install ./cmd/... ./special`
+
+- `// +scalingo goVersion <version>`: the major version of go you would like
+  Scalingo to use when compiling your code. If not specified, it uses the
+  version specified in the `go.mod` file. Exact versions (ex `go1.16.1`) can
+  also be specified if needed, but is not generally recommended. Since Go
+  doesn't release `.0` versions, specifying a `.0` version will pin your code
+  to the initial release of the given major version (ex `go1.16.0` == `go1.16`
+  without auto updating to `go1.16.1` when it becomes available).
+
+  Example: `// +scalingo goVersion go1.11`
 
 If a top level `vendor` directory exists and the `go.sum` file has a size
 greater than zero, `go install` is invoked with `-mod=vendor`, causing the build

--- a/src/_posts/languages/go/2000-01-01-start.md
+++ b/src/_posts/languages/go/2000-01-01-start.md
@@ -1,7 +1,7 @@
 ---
 title: Go
 nav: Introduction
-modified_at: 2022-06-01 00:00:00
+modified_at: 2022-06-10 00:00:00
 tags: go
 index: 1
 ---
@@ -14,7 +14,7 @@ The Go programming language is supported.
 
 #### Officially Supported
 
-* `go1.18.2`
+* `go1.18.3`
 * `go1.17.10`
 * `go1.16.15`
 * `go1.15.15`

--- a/src/changelog/buildpacks/_posts/2022-06-10-go-1.18.3.md
+++ b/src/changelog/buildpacks/_posts/2022-06-10-go-1.18.3.md
@@ -1,0 +1,9 @@
+---
+modified_at: 2022-06-10 14:00:00
+title: 'Go - New Versions: 1.18.3'
+github: 'https://github.com/Scalingo/go-buildpack'
+---
+
+This release also removed the need for the Go version to be specified in a build constraint `+scalingo`. The Go buildpack is now able to use the Go version specified in `go.mod` if no `+scalingo` comment is found.
+
+* Go 1.18.3 [changelog](https://go.dev/doc/devel/release#go1.18)


### PR DESCRIPTION
Tweet:

> [Changelog] Buildpacks - Go - Support of Go 1.18.3. https://changelog.scalingo.com #golang #changelog #PaaS

Fix https://github.com/Scalingo/go-buildpack/issues/23
Fix https://github.com/Scalingo/go-buildpack/issues/16