### PR TITLE
docs(changelog): Elasticsearch 6.8.23-1

### DIFF
--- a/src/changelog/databases/_posts/2022-06-14-elasticsearch-6.8.23-1.md
+++ b/src/changelog/databases/_posts/2022-06-14-elasticsearch-6.8.23-1.md
@@ -1,0 +1,14 @@
+---
+modified_at: 2022-06-14 11:00:00
+title: 'Elasticsearch - New Scalingo release: 6.8.23-1'
+---
+
+New default version: **6.8.23-1**
+
+Changelogs:
+- [Elasticsearch 6.8.22](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/release-notes-6.8.22.html)
+- [Elasticsearch 6.8.23]( https://www.elastic.co/guide/en/elasticsearch/reference/6.8/release-notes-6.8.23.html)
+
+Docker image on [Docker Hub](https://hub.docker.com/r/scalingo/elasticsearch):
+
+* `scalingo/elasticsearch:6.8.23-1`


### PR DESCRIPTION
Tweet:

> [Changelog] - Elasticsearch - New default version: 6.8.23-1 - https://changelog.scalingo.com #elasticsearch #changelog #PaaS