### PR TITLE
docs(changelog): CLI v1.23.0

### DIFF
--- a/src/changelog/cli/_posts/2022-06-15-1-23-0.md
+++ b/src/changelog/cli/_posts/2022-06-15-1-23-0.md
@@ -1,0 +1,24 @@
+---
+modified_at: 2022-06-15 16:30:00
+title: 'CLI - New version: 1.23.0'
+github: 'https://github.com/Scalingo/cli/releases'
+---
+
+Installation:
+
+[https://cli.scalingo.com](https://cli.scalingo.com)
+
+Changelog:
+
+* Improve `update` description by @btrd in https://github.com/Scalingo/cli/pull/718
+* add an option (--force) allowing to destroy an app without interactive confirmation by @mrunichs in https://github.com/Scalingo/cli/pull/721
+* Fix/537/detect region from git remote by @mrunichs in https://github.com/Scalingo/cli/pull/724
+* chore(go): use go 1.17 by @EtienneM in https://github.com/Scalingo/cli/pull/728
+* fix(typo): reseted does not exists, it is reset by @curzolapierre in https://github.com/Scalingo/cli/pull/723
+* fix(domains): replace DomainsUpdate with Domain*Certificate by @EtienneM in https://github.com/Scalingo/cli/pull/731
+* build(deps): bump github.com/briandowns/spinner from 1.18.0 to 1.18.1 by @dependabot in https://github.com/Scalingo/cli/pull/719
+* build(deps): bump github.com/stretchr/testify from 1.7.0 to 1.7.1 by @dependabot in https://github.com/Scalingo/cli/pull/720
+* build(deps): bump github.com/urfave/cli from 1.22.5 to 1.22.8 by @dependabot in https://github.com/Scalingo/cli/pull/722
+* build(deps): bump github.com/urfave/cli from 1.22.8 to 1.22.9 by @dependabot in https://github.com/Scalingo/cli/pull/726
+* build(deps): bump github.com/Scalingo/go-utils/errors from 1.1.0 to 1.1.1 by @dependabot in https://github.com/Scalingo/cli/pull/732
+* build(deps): bump github.com/Scalingo/go-utils/retry from 1.1.0 to 1.1.1 by @dependabot in https://github.com/Scalingo/cli/pull/733


### PR DESCRIPTION
Tweet:

> [Changelog] CLI - Release of version 1.23.0 https://cli.scalingo.com - More news at https://changelog.scalingo.com #cli #paas #changelog #bugfix