### PR TITLE
fix: text won't break and enlarges box on mobile screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ object(s)`. Then, insert it with:
 To install dependencies locally:
 
 ```
-docker-compose run web --rm bundle install
-docker-compose run web --rm yarn install --ignore-engines
+docker-compose run --rm web bundle install
+docker-compose run --rm web yarn install --ignore-engines
 ```
 
 To build the static site and spin-up a file server:

--- a/src/app/styles/index.postcss.css
+++ b/src/app/styles/index.postcss.css
@@ -194,6 +194,10 @@ article code.language-plaintext {
   @apply bg-sc-gray-3 text-sc-gray-2 font-mono px-2 py-1 rounded;
 }
 
+body {
+  @apply break-all sm:break-normal;
+}
+
 .highlight .hll { background-color: #060C20; }
 .highlight .c { color: #75715e } /* Comment */
 .highlight .err { color: #960050; background-color: #1e0010 } /* Error */

--- a/src/app/styles/index.postcss.css
+++ b/src/app/styles/index.postcss.css
@@ -194,7 +194,7 @@ article code.language-plaintext {
   @apply bg-sc-gray-3 text-sc-gray-2 font-mono px-2 py-1 rounded;
 }
 
-body {
+article {
   @apply break-all sm:break-normal;
 }
 


### PR DESCRIPTION
[DOC-88]
Allows text to break on small screens.
Long wordings without space as DATABASE_URL=$SCALINGO_MONGO_URL in src/_posts/platform/app were enlarging their own box and text went outside of parents box.

[DOC-88]: https://scalingo.atlassian.net/browse/DOC-88?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ