### PR TITLE
docs(php-buildpack): release of PHP 7.4.30, 8.0.20 and 8.1.7

### DIFF
--- a/src/_posts/languages/php/2000-01-01-start.md
+++ b/src/_posts/languages/php/2000-01-01-start.md
@@ -1,7 +1,7 @@
 ---
 title: PHP on Scalingo
 nav: Introduction
-modified_at: 2021-12-23 17:00:00
+modified_at: 2022-07-12 16:30:00
 tags: php
 index: 1
 ---
@@ -34,9 +34,9 @@ The following PHP versions are compatible with the platform:
 * **7.1** (up to 7.1.33, only for scalingo-18)
 * **7.2** (up to 7.2.34, only for scalingo-18)
 * **7.3** (up to 7.3.33, only for scalingo-18)
-* **7.4** (up to 7.4.29)
-* **8.0** (up to 8.0.19)
-* **8.1** (up to 8.1.6)
+* **7.4** (up to 7.4.30)
+* **8.0** (up to 8.0.20)
+* **8.1** (up to 8.1.7)
 
 ### Select a Version
 
@@ -53,7 +53,7 @@ Example to install the latest PHP version from the `8.0` branch:
 }
 ```
 
-It installs the version 8.0.2 at the time of writing.
+It installs the version 8.0.20 at the time of writing.
 
 {% note %}
 You should not specify a precise version such as `7.4.3` or you would miss

--- a/src/changelog/buildpacks/_posts/2022-07-12-php-8.1.7.md
+++ b/src/changelog/buildpacks/_posts/2022-07-12-php-8.1.7.md
@@ -6,21 +6,6 @@ github: 'https://github.com/Scalingo/php-buildpack'
 
 Changelogs:
 
-* [PHP 7.4.27 Changelog](https://www.php.net/ChangeLog-7.php#7.4.27)
-* [PHP 7.4.28 Changelog](https://www.php.net/ChangeLog-7.php#7.4.28)
-* [PHP 7.4.29 Changelog](https://www.php.net/ChangeLog-7.php#7.4.29)
 * [PHP 7.4.30 Changelog](https://www.php.net/ChangeLog-7.php#7.4.30)
-* [PHP 8.0.14 Changelog](https://www.php.net/ChangeLog-8.php#8.0.14)
-* [PHP 8.0.15 Changelog](https://www.php.net/ChangeLog-8.php#8.0.15)
-* [PHP 8.0.16 Changelog](https://www.php.net/ChangeLog-8.php#8.0.16)
-* [PHP 8.0.17 Changelog](https://www.php.net/ChangeLog-8.php#8.0.17)
-* [PHP 8.0.18 Changelog](https://www.php.net/ChangeLog-8.php#8.0.18)
-* [PHP 8.0.19 Changelog](https://www.php.net/ChangeLog-8.php#8.0.19)
 * [PHP 8.0.20 Changelog](https://www.php.net/ChangeLog-8.php#8.0.20)
-* [PHP 8.1.1 Changelog](https://www.php.net/ChangeLog-8.php#8.1.1)
-* [PHP 8.1.2 Changelog](https://www.php.net/ChangeLog-8.php#8.1.2)
-* [PHP 8.1.3 Changelog](https://www.php.net/ChangeLog-8.php#8.1.3)
-* [PHP 8.1.4 Changelog](https://www.php.net/ChangeLog-8.php#8.1.4)
-* [PHP 8.1.5 Changelog](https://www.php.net/ChangeLog-8.php#8.1.5)
-* [PHP 8.1.6 Changelog](https://www.php.net/ChangeLog-8.php#8.1.6)
 * [PHP 8.1.7 Changelog](https://www.php.net/ChangeLog-8.php#8.1.7)

--- a/src/changelog/buildpacks/_posts/2022-07-12-php-8.1.7.md
+++ b/src/changelog/buildpacks/_posts/2022-07-12-php-8.1.7.md
@@ -1,0 +1,26 @@
+---
+modified_at: 2022-07-12 16:30:00
+title: 'PHP - Support of versions 8.1.7, 8.0.20 and 7.4.30'
+github: 'https://github.com/Scalingo/php-buildpack'
+---
+
+Changelogs:
+
+* [PHP 7.4.27 Changelog](https://www.php.net/ChangeLog-7.php#7.4.27)
+* [PHP 7.4.28 Changelog](https://www.php.net/ChangeLog-7.php#7.4.28)
+* [PHP 7.4.29 Changelog](https://www.php.net/ChangeLog-7.php#7.4.29)
+* [PHP 7.4.30 Changelog](https://www.php.net/ChangeLog-7.php#7.4.30)
+* [PHP 8.0.14 Changelog](https://www.php.net/ChangeLog-8.php#8.0.14)
+* [PHP 8.0.15 Changelog](https://www.php.net/ChangeLog-8.php#8.0.15)
+* [PHP 8.0.16 Changelog](https://www.php.net/ChangeLog-8.php#8.0.16)
+* [PHP 8.0.17 Changelog](https://www.php.net/ChangeLog-8.php#8.0.17)
+* [PHP 8.0.18 Changelog](https://www.php.net/ChangeLog-8.php#8.0.18)
+* [PHP 8.0.19 Changelog](https://www.php.net/ChangeLog-8.php#8.0.19)
+* [PHP 8.0.20 Changelog](https://www.php.net/ChangeLog-8.php#8.0.20)
+* [PHP 8.1.1 Changelog](https://www.php.net/ChangeLog-8.php#8.1.1)
+* [PHP 8.1.2 Changelog](https://www.php.net/ChangeLog-8.php#8.1.2)
+* [PHP 8.1.3 Changelog](https://www.php.net/ChangeLog-8.php#8.1.3)
+* [PHP 8.1.4 Changelog](https://www.php.net/ChangeLog-8.php#8.1.4)
+* [PHP 8.1.5 Changelog](https://www.php.net/ChangeLog-8.php#8.1.5)
+* [PHP 8.1.6 Changelog](https://www.php.net/ChangeLog-8.php#8.1.6)
+* [PHP 8.1.7 Changelog](https://www.php.net/ChangeLog-8.php#8.1.7)


### PR DESCRIPTION
Updated documentation following the release of PHP:
- 7.4.30
- 8.0.20
- 8.1.7

Fixes https://github.com/Scalingo/php-buildpack/issues/256