### PR TITLE
docs(languages/php): updated instructions about Composer constraints

### DIFF
--- a/src/_posts/languages/php/2000-01-01-start.md
+++ b/src/_posts/languages/php/2000-01-01-start.md
@@ -1,7 +1,7 @@
 ---
 title: PHP on Scalingo
 nav: Introduction
-modified_at: 2021-12-23 17:00:00
+modified_at: 2022-07-13 12:00:00
 tags: php
 index: 1
 ---
@@ -48,7 +48,7 @@ Example to install the latest PHP version from the `8.0` branch:
 ```json
 {
   "require": {
-    "php": "8.0"
+    "php": "^8.0"
   }
 }
 ```
@@ -57,8 +57,11 @@ It installs the version 8.0.2 at the time of writing.
 
 {% note %}
 You should not specify a precise version such as `7.4.3` or you would miss
-important updates. You should specify `7.4` to install a version `7.4.x` or
-specify `7` to install a version `7.x`.
+important updates. Instead, you should specify `~7.4.3` to install a version 
+`>=7.4.3 and <7.5.0` or specify `~7.4` to install a version `>=7.4 and <8.0.0`.
+
+Further details about version constraints can be found in the 
+[Composer documentation](https://getcomposer.org/doc/articles/versions.md#writing-version-constraints)
 {% endnote %}
 
 ## Composer


### PR DESCRIPTION
The existing instructions explaining how Composer version contraints
work were wrong or misleading. This commit modifies the instructions and
adds a link to the Composer documentation.

Fixes #1684