### PR TITLE
fix(sqlAlchemy): use the correct name of the variable

### DIFF
--- a/src/_posts/languages/python/2020-11-23-SQLAlchemy.md
+++ b/src/_posts/languages/python/2020-11-23-SQLAlchemy.md
@@ -6,4 +6,4 @@ modified_at: 2021-11-23 00:00:00
 
 To connect to PostgreSQL most frameworks accept a connection URI that begins with `postgres://`, this is not the case with SQLAlchemy that requires the connection URI to begin with `postgresql://`.
 
-To handle this situation we added this feature in our buildpack: if we detect that you're using SQLAlchemy (to do so we check the presence of `sqlalchemy` in the files `requirements.txt` or `Pipfile`), we're adding a new environment variables `SCALINGO_POSTGRESQL_URL_ALCHEMY` with the right format.
+To handle this situation we added this feature in our buildpack: if we detect that you're using SQLAlchemy (to do so we check the presence of `sqlalchemy` in the files `requirements.txt` or `Pipfile`), we're adding a new environment variables `SCALINGO_POSTGRESQL_ALCHEMY_URL` with the right format.


### PR DESCRIPTION
Fix #1686 
Related to https://github.com/Scalingo/python-buildpack/pull/46

To be sure I tested by using [Python buildpack's script](https://github.com/Scalingo/python-buildpack/blob/master/vendor/python.sqlalchemy.sh):

```bash
python-buildpack git:(master !) ➜ export SCALINGO_POSTGRESQL_URL=postgres://test:test@test.com:1234
python-buildpack git:(master !) ➜ set +x ./vendor/python.sqlalchemy.sh
++ env
++ awk -F = '{print $1}'
++ grep SCALINGO_POSTGRESQL_URL
+ for database_url_variable in $(env | awk -F "=" '{print $1}' | grep "SCALINGO_POSTGRESQL_URL")
++ eval echo '$SCALINGO_POSTGRESQL_URL'
+++ echo postgres://test:test@test.com:1234
+ set_sql_alchemy_url postgres://test:test@test.com:1234 SCALINGO_POSTGRESQL_ALCHEMY
+ local database_url=postgres://test:test@test.com:1234
+ local environment_variables_prefix=SCALINGO_POSTGRESQL_ALCHEMY
+ local pattern=sqlalchemy
++ cat requirements.txt
++ grep -ic sqlalchemy
+ concerned1=1
++ cat Pipfile
++ grep -ic sqlalchemy
cat: Pipfile: Aucun fichier ou dossier de ce type
+ concerned2=0
+ '[' 1 -eq 0 ']'
+ [[ postgres://test:test@test.com:1234 =~ postgres:// ]]
+ local full_database_url
+ full_database_url=postgresql://test:test@test.com:1234
+ eval 'export SCALINGO_POSTGRESQL_ALCHEMY_URL=postgresql://test:test@test.com:1234'
++ export SCALINGO_POSTGRESQL_ALCHEMY_URL=postgresql://test:test@test.com:1234
++ SCALINGO_POSTGRESQL_ALCHEMY_URL=postgresql://test:test@test.com:1234
```