### PR TITLE
docs(docker): fix token creation link and login to registry

### DIFF
--- a/src/_posts/addons/scalingo-docker-image/2000-01-01-start.md
+++ b/src/_posts/addons/scalingo-docker-image/2000-01-01-start.md
@@ -1,7 +1,7 @@
 ---
 title: Scalingo Docker Image Addon
 nav: Introduction
-modified_at: 2021-07-13 00:00:00
+modified_at: 2022-07-19 00:00:00
 tags: docker images download feature
 index: 1
 ---
@@ -49,17 +49,14 @@ The application registry URL depends on the region your application is running o
 $ docker login $DOCKER_REGISTRY_URL
 Username: <Scalingo username>
 Password: <Scalingo API token>
-Email:    <Scalingo email>
 ```
 
-The API token must be created on [your
-profile](https://my.scalingo.com/profile), copy it from there.
-
+The API token must be created on [your profile](https://dashboard.scalingo.com/account/tokens), copy it from there.
 
 ### Download Your Image
 
 {% note %}
-  Be sure to always have the prefix `app-` before the application name in the full URL.
+Be sure to always have the prefix `app-` before the application name in the full URL.
 {% endnote %}
 
 ```bash


### PR DESCRIPTION
I noticed this following a support conversation