### PR TITLE
docs(changelog): Redis 6.2.7-1 and 5.0.14-1

### DIFF
--- a/src/changelog/databases/_posts/2022-08-05-redis.6.2.7-1.md
+++ b/src/changelog/databases/_posts/2022-08-05-redis.6.2.7-1.md
@@ -1,0 +1,19 @@
+---
+modified_at: 2022-08-05 17:00:00
+title: 'Redis - New versions: 6.2.7-1 and 5.0.14-1'
+---
+
+New default version: **6.2.7-1**.
+
+This version contains a security fix for a bug which affects all Redis versions 5.0 or newer.
+
+Changelogs:
+
+* [6.2.6](https://github.com/redis/redis/releases/tag/6.2.6)
+* [6.2.7](https://github.com/redis/redis/releases/tag/6.2.7)
+* [5.0.14](https://github.com/redis/redis/releases/tag/5.0.14)
+
+Docker image on [Docker Hub](https://hub.docker.com/r/scalingo/redis):
+
+* `scalingo/redis:6.2.7-1`
+* `scalingo/redis:5.0.14-1`


### PR DESCRIPTION
Tweet:

> [Changelog] - Redis - New versions: 6.2.7-1 and 5.0.14-1 - 6.2.7-1 is the new default - https://changelog.scalingo.com #redis #changelog #PaaS