### PR TITLE
docs(documentation): update Laravel documentation

### DIFF
--- a/src/_posts/languages/php/2000-01-01-laravel.md
+++ b/src/_posts/languages/php/2000-01-01-laravel.md
@@ -218,23 +218,46 @@ of your application:
 queues: php artisan queue:work --queue=high,default
 ```
 
-The arguments of the `--queue` option must be customized to suit your needs. After deploying your
-application, you must scale the newly created type of containers `queues` at least to 1.
+The arguments of the `--queue` option must be customized to suit your needs.
+After deploying your application, you must scale the newly created type of
+containers `queues` at least to 1.
 
 ## Laravel Tasks Scheduler
 
-The Laravel PHP framework includes a command scheduler for asynchronous tasks. However, Laravel's
-[documentation](https://laravel.com/docs/8.x/scheduling#introduction) states you need to add a cron
-entry which is not possible on Scalingo.
+The Laravel PHP framework includes a command scheduler for asynchronous tasks.
+However, Laravel's [documentation](https://laravel.com/docs/9.x/scheduling#running-the-scheduler)
+states you need to add a cron entry which is not possible on Scalingo.
 
-{% note %}
-The cron feature is now available upon request. Refer to [this page]({% post_url platform/app/task-scheduling/2000-01-01-scalingo-scheduler %}) for more information.
-{% endnote %}
+From this point, there are two possibilies, depending on the frequency of the
+scheduled tasks.
 
-This documentation page guides you to let your application use the Laravel command scheduler on
-Scalingo. The following command must be added to your app. It calls the Laravel scheduler every
-minutes. It requires you to start [another process]({% post_url platform/app/2000-01-01-procfile %})
-in your application.
+### The Tasks Run on a Frequency Lower Than Once Every 10 Minutes
+
+For these cases, we highly recommend to use the [Scalingo Scheduler]({% post_url platform/app/task-scheduling/2000-01-01-scalingo-scheduler %}).
+
+All you have to do is create a `cron.json` file at the root of your application
+with a content similar to this:
+
+```json
+{
+  "jobs": [
+    {
+      "command": "15 * * * * cd /app && php artisan schedule:run >> /dev/null 2>&1"
+    }
+  ]
+}
+```
+
+In the example above, the task would run at 15 past every hour, but you can
+specify your own schedule, as long as it respects the 10 minutes interval.
+
+### The Tasks Run on a Frequency Higher Than Once Every 10 Minutes
+
+These *high-frequency* cases require a bit more work.
+
+First, you need to create your own `Command` subclass because the one
+provided by Laravel won't directly suit our needs and constraints. Here is a
+good starting point:
 
 ```php
 <?php
@@ -279,73 +302,42 @@ class SchedulerDaemon extends Command
 }
 ```
 
-Don't forget to add the following line to the `Procfile` of your application:
+In the example above, you can see that the defined scheduler runs every minute.
+(If you look closely, you will also see that our scheduler makes use of the one
+provided by Laravel, `schedule:run`.)
+
+You now have to tell Scalingo how to start this new scheduler. To do this,
+create (or update) a [`Procfile`]({% post_url platform/app/2000-01-01-procfile %}), like this:
 
 ```
-scheduler: php artisan schedule:daemon
+scheduler: php artisan scheduler:daemon
 ```
+
+After deploying your application, you must scale the newly created type of
+containers `scheduler` at least to 1.
+
+### Defining the Scheduled Tasks
 
 To define the jobs the scheduler will run, check the
-[Laravel documentation](https://laravel.com/docs/8.x/scheduling#introduction),
+[Laravel documentation](https://laravel.com/docs/9.x/scheduling#introduction),
 it consists in modifying the `schedule` method in the file `app/Console/Kernel.php`.
 
-Example:
+In the following example, the method `Foo1` will be executed daily and the
+method `Foo2` will be executed hourly:
 
 ```php
     protected function schedule(Schedule $schedule)
     {
-        $schedule->call(function () {
-            // Do something
-        })->daily();
+        $schedule->call(function () { Foo1(); })->daily();
+        $schedule->call(function () { Foo2(); })->hourly();
     }
 ```
 
 Based on an article on [Neon
 Tsunami](https://www.neontsunami.com/posts/laravel-scheduler-on-heroku).
 
-## A Cron Example
-
-A recurring need of PHP application is to execute multiple tasks at regular
-interval, in a cron-like fashion. This section explains how to set this up on a
-Scalingo application.
-
-You first need to configure the [Laravel Tasks
-Scheduler](#laravel-tasks-scheduler). Once this step is achieved, you need to
-list the tasks you want to execute.
-
-This is done in the `schedule` method of the `App\Console\Kernel` class. Here is
-an example of two tasks scheduled at regular interval. The method `Foo1` will be
-executed daily and the method `Foo2` will be executed hourly.
-
-```php
-<?php
-
-namespace App\Console;
-
-use DB;
-use Illuminate\Console\Scheduling\Schedule;
-use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
-
-class Kernel extends ConsoleKernel
-{
-    [...]
-
-    /**
-     * Define the application's command schedule.
-     *
-     * @param  \Illuminate\Console\Scheduling\Schedule  $schedule
-     * @return void
-     */
-    protected function schedule(Schedule $schedule)
-    {
-        $schedule->call(function () { Foo1(); })->daily();
-        $schedule->call(function () { Foo2(); })->hourly();
-    }
-}
-```
-
 The Laravel documentation about this feature is available
-[here](https://laravel.com/docs/8.x/scheduling#defining-schedules).
+[here](https://laravel.com/docs/9.x/scheduling#defining-schedules).
 
 ## Configure Passport
 

--- a/src/_posts/languages/php/2000-01-01-laravel.md
+++ b/src/_posts/languages/php/2000-01-01-laravel.md
@@ -305,7 +305,7 @@ In the example above, you can see that the defined scheduler runs every minute.
 (If you look closely, you will also see that our scheduler makes use of the one
 provided by Laravel, `schedule:run`.)
 
-You now have to tell Scalingo how to start this new scheduler. To do this,
+You now have to instruct Scalingo how to start this new scheduler. To do this,
 create (or update) a [`Procfile`]({% post_url platform/app/2000-01-01-procfile %}), like this:
 
 ```

--- a/src/_posts/languages/php/2000-01-01-laravel.md
+++ b/src/_posts/languages/php/2000-01-01-laravel.md
@@ -235,8 +235,7 @@ scheduled tasks.
 
 For these cases, we highly recommend to use the [Scalingo Scheduler]({% post_url platform/app/task-scheduling/2000-01-01-scalingo-scheduler %}).
 
-All you have to do is create a `cron.json` file at the root of your application
-with a content similar to this:
+Create a `cron.json` file at the root of your application with a content similar to this:
 
 ```json
 {


### PR DESCRIPTION
The section of the Laravel documentation dedicated to the Laraval Task Scheduler
is outdated.

This patch fixes this by encouraging users to use the Scalingo
Scheduler. The old way to proceed is still documented for cases where
tasks need to run more frequently than once every 10 minutes.

Fixes #1680