### PR TITLE
Revert "docs(compass): update instructions to match new fields name"

### DIFF
--- a/src/_posts/databases/mongodb/2000-01-01-compass.md
+++ b/src/_posts/databases/mongodb/2000-01-01-compass.md
@@ -44,19 +44,28 @@ Open MongoDB Compass, then click on "New Connection".
 After that click on "Advanced Connection Options" and fill the fields
 accordingly:
 
-* Hostname:
-    * Hostname: c393a9e3-42fe-4e33-9e6c-8ee815e9af88.my-app-7093.mongo.a.osc-fr1.scalingo-dbs.com
-    * Port 31312
-    * Authentication: Username / Password
-    * Username: my-app-7093
-    * Password: EsEjseivpacatVoogfijbiapgadTyg
-    * Authentication Database: my-app-7093
-* More Options:
-    * Read Preference: Primary
-    * SSL: Unvalidate (insecure)
-    * SSH Tunnel: Use Identity File
-    * SSH Hostname/Tunnel Port/Username: Depends on the region where your database is hosted. You can find all information at the end of [this page](#ssh-endpoints) and use it here.
-    * SSH Identity File: Your private SSH key linked to the public SSH key you uploaded on the [SSH Keys page](https://dashboard.scalingo.com/account/keys) of the Scalingo dashboard.
+* General
+    * Connection String Scheme: mongodb
+    * Host: c393a9e3-42fe-4e33-9e6c-8ee815e9af88.my-app-7093.mongo.a.osc-fr1.
+    scalingo-dbs.com:31312 (Hostname + Port)
+* Authentication
+    * Authentication Method: Username / Password
+    * Authentication Mechanism: Default
+* TLS/SSL
+    * SSL/TLS Connection: On
+    * Certificate Authority (.pem): Depends on the region where your database
+    is hosted. You can find URLs of our CA certificates at the end of
+    [this page](#ca-certificates) and use it here.
+* Proxy/SSH Tunnel
+    * SSH Tunnel/Proxy Method: SSH with Identity File
+    * SSH Hostname/SSH Port/SSH Username: Depends on the region where your
+    database is hosted. You can find all information at the end of
+    [this page](#ssh-endpoints) and use it here.
+    * SSH Identity File: Your private SSH key linked to the public SSH key you
+    uploaded on the [SSH Keys page](https://dashboard.scalingo.com/account/keys)
+    of the Scalingo dashboard.
+* Advanced
+    * Read Preference: Default
 
 {% include mongo_db_tunnel.md %}
 
@@ -78,17 +87,19 @@ Open MongoDB Compass, then click on "New Connection".
 After that click on "Advanced Connection Options" and fill the fields
 accordingly:
 
-* Hostname:
-    * Hostname: 127.0.0.1
-    * Port 10000
-    * Authentication: Username / Password
-    * Username: my-app-7093
-    * Password: EsEjseivpacatVoogfijbiapgadTyg
-    * Authentication Database: my-app-7093
-* More Options:
-    * Read Preference: Primary
-    * SSL: Unvalidate (insecure)
-    * SSH Tunnel: None
+* General
+    * Connection String Scheme: mongodb
+    * Host: 127.0.0.1:10000 (Hostname + Port)
+    * Direct Connection: Yes
+* Authentication
+    * Authentication Method: Username / Password
+    * Authentication Mechanism: Default
+* TLS/SSL
+    * SSL/TLS Connection: Default
+* Proxy/SSH Tunnel
+    * SSH Tunnel/Proxy Method: None
+* Advanced
+    * Read Preference: Default
 
 {% include mongo_db_tunnel.md %}
 
@@ -103,17 +114,21 @@ Open MongoDB Compass, then click on "New Connection".
 After that click on "Advanced Connection Options" and fill the fields
 accordingly:
 
-* Hostname:
-    * Hostname: c393a9e3-42fe-4e33-9e6c-8ee815e9af88.my-app-7093.mongo.a.osc-fr1.scalingo-dbs.com
-    * Port 31312
-    * Authentication: Username / Password
-    * Username: my-app-7093
-    * Password: EsEjseivpacatVoogfijbiapgadTyg
-    * Authentication Database: my-app-7093
-* More Options:
-    * Read Preference: Primary
-    * SSL: Unvalidate (insecure)
-    * SSH Tunnel: None
+* General
+    * Connection String Scheme: mongodb
+    * Host: c393a9e3-42fe-4e33-9e6c-8ee815e9af88.my-app-7093.mongo.a.osc-fr1.scalingo-dbs.com:31312 (Hostname + Port)
+* Authentication
+    * Authentication Method: Username / Password
+    * Authentication Mechanism: Default
+* TLS/SSL
+    * SSL/TLS Connection: On
+    * Certificate Authority (.pem): Depends on the region where your database
+    is hosted. You can find URLs of our CA certificates at the end of
+    [this page](#ca-certificates) and use it here.
+* Proxy/SSH Tunnel
+    * SSH Tunnel/Proxy Method: None
+* Advanced
+    * Read Preference: Default
 
 ### Common issues
 


### PR DESCRIPTION
This reverts commit 97e7e1f88159821f29e3d5b65e17182f5a5ef17c from #1695

As highlighted by Brandon (https://github.com/Scalingo/documentation/pull/1695#issuecomment-1211927751), the fields are correct with the latest Compass version. Sorry for not checking my Compass version :/