### PR TITLE
docs(changelog): CLI v1.25.1

### DIFF
--- a/src/changelog/cli/_posts/2022-09-26-1-25-1.md
+++ b/src/changelog/cli/_posts/2022-09-26-1-25-1.md
@@ -1,0 +1,16 @@
+---
+modified_at: 2022-09-26 12:00:00
+title: 'CLI - New version: 1.25.1'
+github: 'https://github.com/Scalingo/cli/releases'
+---
+
+### Installation
+
+[https://cli.scalingo.com](https://cli.scalingo.com)
+
+### Changelog
+
+This release is mandatory to keep the `logs` command working in the coming weeks.
+
+* chore(deps): upgrade github.com/Scalingo/go-scalingo/v5
+* chore(deps): bump github.com/google/go-github/v47 from 47.0.0 to 47.1.0


### PR DESCRIPTION
Tweet:

> [Changelog] CLI - Release of version 1.25.1 https://cli.scalingo.com - More news at https://changelog.scalingo.com #cli #paas #changelog #bugfix

Related to https://github.com/Scalingo/cli/releases/tag/1.25.1