### PR TITLE
docs(changelog): CLI v1.26.0

### DIFF
--- a/src/changelog/cli/_posts/2022-10-07-1-26-0.md
+++ b/src/changelog/cli/_posts/2022-10-07-1-26-0.md
@@ -1,0 +1,16 @@
+---
+modified_at: 2022-10-07 16:00:00
+title: 'CLI - New version: 1.26.0'
+github: 'https://github.com/Scalingo/cli/releases'
+---
+
+### Installation
+
+[https://cli.scalingo.com](https://cli.scalingo.com)
+
+### Changelog
+
+* feat(db-commands) Add `database-enable-feature` and `database-disable-feature` for database addons [#807](https://github.com/Scalingo/cli/pull/807)
+* deps(go-scalingo) Bump from 5.2.2 to 6.0.0 [#804](https://github.com/Scalingo/pull/804)
+* regression(cmd-alias) 'scale' command can again be invoked by 's' [#802](https://github.com/Scalingo/cli/pull/802)
+* regression(cmd-alias) 'run' command can again be invoked by 'r' [#802](https://github.com/Scalingo/cli/pull/802)


### PR DESCRIPTION
Tweet:

> [Changelog] CLI - Release of version 1.26.0 https://cli.scalingo.com - More news at https://changelog.scalingo.com #cli #paas #changelog #bugfix