### PR TITLE
docs: improve docs on login

### DIFF
--- a/src/_posts/platform/cli/2000-01-01-introduction.md
+++ b/src/_posts/platform/cli/2000-01-01-introduction.md
@@ -12,8 +12,12 @@ the CLI requires you to take one of these actions:
 
 * Add a password to your account on the [profile](https://my.scalingo.com/profile) page.
 * Add a SSH key to your account on the [dedicated](https://my.scalingo.com/keys) page.
-* Add a token to your account on the [profile](https://my.scalingo.com/profile) page. Then use it to
-  login with `scalingo login --api-token <token>`
+
+And then use `scalingo login`.
+
+You can also add a token to your account on the [profile](https://my.scalingo.com/profile) page. 
+Then use it to login with `scalingo login --api-token <token>`
+
 
 ### List of Ports Needed To Be Opened
 


### PR DESCRIPTION
For new user, it's not clear that one needs to run `scalingo login` to login 
The actual doc presents `scalingo login` command like it is only for a use with token.