### PR TITLE
docs(log-drains): update appsignal and syslog tcp+tls examples and parameters

### DIFF
--- a/src/_posts/platform/app/2000-01-01-log-drain.md
+++ b/src/_posts/platform/app/2000-01-01-log-drain.md
@@ -69,7 +69,7 @@ scalingo --app my-app log-drains-add --type appsignal \
   --token 123456789abcdef
 ```
 Parameters:
-* `token`: API key of your application
+* `token`: Appsignal's API key
 
 These variable are available on 
 [AppSignal documentation](https://docs.appsignal.com/logging/configuration.html).

--- a/src/_posts/platform/app/2000-01-01-log-drain.md
+++ b/src/_posts/platform/app/2000-01-01-log-drain.md
@@ -25,6 +25,7 @@ Our system is able to send logs to the following SaaS logs processing providers:
 
 * [Scalingo hosted ELK stack](#scalingo-hosted-elk-stack)
 ([how to setup]({% post_url platform/getting-started/2000-01-01-getting-started-with-elk %}))
+* [AppSignal](#appsignal)
 * [Datadog](#datadog)
 * [Logentries](#logentries)
 * [Graylog](#ovh-hosted-graylog)
@@ -61,6 +62,17 @@ Parameters:
 * `url`: authentication url to access to the ELK server.
 More information on [ELK Stack on
 Scalingo]({% post_url platform/getting-started/2000-01-01-getting-started-with-elk %})
+
+#### AppSignal
+```bash
+scalingo --app my-app log-drains-add --type appsignal \
+  --token 123456789abcdef
+```
+Parameters:
+* `token`: API key of your application
+
+These variable are available on 
+[AppSignal documentation](https://docs.appsignal.com/logging/configuration.html).
 
 #### Datadog
 ```bash
@@ -109,12 +121,13 @@ destination](https://papertrailapp.com/account/destinations).
 #### Syslog TCP+TLS
 ```bash
 scalingo --app my-app log-drains-add --type syslog \
-  --host custom.logstash.com --port 12345
+  --host custom.logstash.com --port 12345 --token 132456789abcdef
 ```
 
 Parameters:
 * `host`: host of the syslog server
 * `port`: port number of the syslog server
+* `token`: token provided for the syslog server
 
 ### Add a Drain to an Addon
 

--- a/src/_posts/platform/app/2000-01-01-log-drain.md
+++ b/src/_posts/platform/app/2000-01-01-log-drain.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Log Drains
-modified_at: 2021-09-28 00:00:00
+modified_at: 2022-10-25 00:00:00
 tags: Papertrail Logentries Logmatic Graylog logs integration
 index: 19
 ---


### PR DESCRIPTION
This PR updates documentation about the new AppSignal compatibility and the token parameter for syslog (tcp+tls)
FIX #1779 