### PR TITLE
chore(php-composer): upgrade PHP Composer to 2.4.4

### DIFF
--- a/src/_posts/languages/php/2000-01-01-start.md
+++ b/src/_posts/languages/php/2000-01-01-start.md
@@ -1,7 +1,7 @@
 ---
 title: PHP on Scalingo
 nav: Introduction
-modified_at: 2022-07-13 12:00:00
+modified_at: 2022-11-02 16:00:00
 tags: php
 index: 1
 ---
@@ -144,9 +144,9 @@ You can select the Composer version to install for your application deployment b
 
 Scalingo supports the following versions of Composer:
 
-- 1.10.26
-- 2.2.12
-- 2.3.5
+- 2.2.18
+- 2.3.10
+- 2.4.4
 
 ## Native PHP Extensions
 

--- a/src/changelog/buildpacks/_posts/2022-11-02-php-composer-2.4.4.md
+++ b/src/changelog/buildpacks/_posts/2022-11-02-php-composer-2.4.4.md
@@ -1,0 +1,9 @@
+---
+modified_at: 2022-11-02 16:00:00
+title: 'PHP - Release Composer version 2.4.4'
+github: 'https://github.com/Scalingo/php-buildpack'
+---
+
+Changelog:
+
+* [Composer 2.4.4](https://github.com/composer/composer/releases/tag/2.4.4)


### PR DESCRIPTION
Follow of the PHP Composer 2.4.4 upgrade:

https://semver.scalingo.com/composer-scalingo-18/resolve/2.x
https://semver.scalingo.com/composer-scalingo-20/resolve/2.x

Files have been uploaded to the ObjectStorage.

Fixes https://github.com/Scalingo/php-buildpack/issues/272