### PR TITLE
chore(php): update PHP to 7.4.32, 8.0.25 and 8.1.12

### DIFF
--- a/src/_posts/languages/php/2000-01-01-start.md
+++ b/src/_posts/languages/php/2000-01-01-start.md
@@ -1,7 +1,7 @@
 ---
 title: PHP on Scalingo
 nav: Introduction
-modified_at: 2022-11-02 16:00:00
+modified_at: 2022-11-02 17:00:00
 tags: php
 index: 1
 ---
@@ -34,9 +34,9 @@ The following PHP versions are compatible with the platform:
 * **7.1** (up to 7.1.33, only for scalingo-18)
 * **7.2** (up to 7.2.34, only for scalingo-18)
 * **7.3** (up to 7.3.33, only for scalingo-18)
-* **7.4** (up to 7.4.30)
-* **8.0** (up to 8.0.20)
-* **8.1** (up to 8.1.7)
+* **7.4** (up to 7.4.32)
+* **8.0** (up to 8.0.25)
+* **8.1** (up to 8.1.12)
 
 ### Select a Version
 
@@ -53,7 +53,7 @@ Example to install the latest PHP version from the `8.0` branch:
 }
 ```
 
-It installs the version 8.0.20 at the time of writing.
+It installs the version 8.0.25 at the time of writing.
 
 {% note %}
 You should not specify a precise version such as `7.4.3` or you would miss

--- a/src/_posts/languages/php/2000-01-01-start.md
+++ b/src/_posts/languages/php/2000-01-01-start.md
@@ -1,7 +1,7 @@
 ---
 title: PHP on Scalingo
 nav: Introduction
-modified_at: 2022-07-13 12:00:00
+modified_at: 2022-11-02 16:00:00
 tags: php
 index: 1
 ---
@@ -144,9 +144,9 @@ You can select the Composer version to install for your application deployment b
 
 Scalingo supports the following versions of Composer:
 
-- 1.10.26
-- 2.2.12
-- 2.3.5
+- 2.2.18
+- 2.3.10
+- 2.4.4
 
 ## Native PHP Extensions
 

--- a/src/changelog/buildpacks/_posts/2022-11-02-php-8.1.12.md
+++ b/src/changelog/buildpacks/_posts/2022-11-02-php-8.1.12.md
@@ -1,0 +1,11 @@
+---
+modified_at: 2022-11-02 17:00:00
+title: 'PHP - Support of versions 8.1.12, 8.0.25 and 7.4.32'
+github: 'https://github.com/Scalingo/php-buildpack'
+---
+
+Changelogs:
+
+* [PHP 7.4.32 Changelog](https://www.php.net/ChangeLog-7.php#7.4.32)
+* [PHP 8.0.25 Changelog](https://www.php.net/ChangeLog-8.php#8.0.25)
+* [PHP 8.1.12 Changelog](https://www.php.net/ChangeLog-8.php#8.1.12)

--- a/src/changelog/buildpacks/_posts/2022-11-02-php-composer-2.4.4.md
+++ b/src/changelog/buildpacks/_posts/2022-11-02-php-composer-2.4.4.md
@@ -1,0 +1,9 @@
+---
+modified_at: 2022-11-02 16:00:00
+title: 'PHP - Release Composer version 2.4.4'
+github: 'https://github.com/Scalingo/php-buildpack'
+---
+
+Changelog:
+
+* [Composer 2.4.4](https://github.com/composer/composer/releases/tag/2.4.4)


### PR DESCRIPTION
PHP updates for both `scalingo-18` and `scalingo-20`:
- 8.1.12
- 8.0.25
- 7.4.32
    
https://semver.scalingo.com/php-scalingo-18/resolve/~7.4
https://semver.scalingo.com/php-scalingo-18/resolve/~8.0
https://semver.scalingo.com/php-scalingo-18/resolve/~8.1
    
https://semver.scalingo.com/php-scalingo-20/resolve/~7.4
https://semver.scalingo.com/php-scalingo-20/resolve/~8.0
https://semver.scalingo.com/php-scalingo-20/resolve/~8.1
    
Files have been uploaded to the ObjectStorage.
    
Fixes https://github.com/Scalingo/php-buildpack/issues/263