### PR TITLE
fix: PostgreSQL spelling

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -125,7 +125,7 @@ languages:
 
 databases:
   - url: "/databases/postgresql/start"
-    name: "PostgresSQL"
+    name: "PostgreSQL"
     logo: postgresql
   - url: "/databases/mysql/start"
     name: "MySQL"


### PR DESCRIPTION
Fix a minor typo seen on the documentation homepage:

![image](https://user-images.githubusercontent.com/1181770/207438959-079226f9-0048-441d-9283-357db53dc982.png)
