### PR TITLE
Add note about Kibana Elasticsearch add-on

### DIFF
--- a/src/_posts/platform/getting-started/2000-01-01-getting-started-with-elk.md
+++ b/src/_posts/platform/getting-started/2000-01-01-getting-started-with-elk.md
@@ -178,6 +178,8 @@ scalingo --app my-awesome-logstash env | grep SCALINGO_ELASTICSEARCH_URL
 
 Then, a username and a password should be defined to configure Kibana authentication.
 
+**Note**: a new Elasticsearch database will be provisionned. You can safely delete it if you use the one from Logstash as described above.
+
 Once deployed, index patterns need to be configured. This is required to inform
 Kibana about the indices of Elasticsearch it need to look at.
 


### PR DESCRIPTION
The one-click button to deploy Kibana is provisioning a new Elasticsearch add-on. This may be confusing while the documentation indicates how to use the one that has been provisioned just before that with Logstash.