### PR TITLE
docs(changelog): Ruby 3.2.0 is available

### DIFF
--- a/src/_posts/languages/ruby/2000-01-01-start.md
+++ b/src/_posts/languages/ruby/2000-01-01-start.md
@@ -90,9 +90,10 @@ version are also present if your require them for specific tests.
 
 ### MRI
 
-* `3.1.1`
+* `3.2.0`
+* `3.1.2`
 * `3.0.3`
-* `2.7.4`
+* `2.7.5`
 * `2.6.8`
 * `2.5.9`
 * `2.4.10`

--- a/src/changelog/buildpacks/_posts/2022-12-29-ruby-3.2.0.md
+++ b/src/changelog/buildpacks/_posts/2022-12-29-ruby-3.2.0.md
@@ -1,0 +1,11 @@
+---
+modified_at: 2022-12-29 15:00:00
+title: 'Ruby - 3.2.0 is available'
+github: 'https://github.com/Scalingo/ruby-buildpack'
+---
+
+Ruby 3.2.0 is now available.
+
+Changelogs:
+
+* [3.2.0](https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/)


### PR DESCRIPTION
Fix https://github.com/Scalingo/ruby-buildpack/issues/46

Tweet:

> [Changelog] Buildpacks - Ruby - Support of Ruby 3.2.0 https://changelog.scalingo.com #ruby #changelog #PaaS