### PR TITLE
Bump cli version to 1.27.1

### DIFF
--- a/src/changelog/cli/_posts/2023-01-06-1-27-1.md
+++ b/src/changelog/cli/_posts/2023-01-06-1-27-1.md
@@ -1,0 +1,13 @@
+---
+modified_at: 2023-01-06 16:00:00
+title: 'CLI - New version: 1.27.1'
+github: 'https://github.com/Scalingo/cli/releases'
+---
+
+### Installation
+
+[https://cli.scalingo.com](https://cli.scalingo.com)
+
+### Changelog
+
+* fix(cli-build) Compile the CLI statically to prevent GLIBC incompatibility [#863](https://github.com/Scalingo/cli/pull/863)


### PR DESCRIPTION
Related to https://github.com/Scalingo/cli/pull/864