### PR TITLE
feat(samples): remove deprecated Go Martini

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -153,9 +153,6 @@ samples:
   - url: go-gin
     name: Go/Gin
     logo: go
-  - url: go-martini
-    name: Go/Martini
-    logo: go
   - url: meteor
     name: MeteorJS
     logo: meteorjs


### PR DESCRIPTION
- [x] The repository has been archived (https://github.com/Scalingo/sample-go-martini/)
- [ ] The domain name redirects to https://go-gin.is-easy-on-scalingo.com/