### PR TITLE
Fix documentation coherence, and wrong order of arguments

### DIFF
--- a/src/_posts/databases/elasticsearch/2000-01-01-start.md
+++ b/src/_posts/databases/elasticsearch/2000-01-01-start.md
@@ -30,7 +30,7 @@ You can add the Elasticsearch addon through the **Dashboard** or through the **c
 ### Through the command-line interface
 
 ```bash
-$ scalingo -a my-app addons-add scalingo-elasticsearch elasticsearch-starter-1024
+$ scalingo --app my-app addons-add scalingo-elasticsearch elasticsearch-starter-1024
 
 -----> Addon elasticsearch has been provisionned
        ID: my-app-3030
@@ -78,7 +78,7 @@ You can get environment variables from the dashboard or the command line interfa
 ### From the command line interface
 
 ```bash
-$ scalingo -a my-app env | grep ELASTIC
+$ scalingo --app my-app env | grep ELASTIC
 
 ELASTICSEARCH_URL=$SCALINGO_ELASTICSEARCH_URL
 SCALINGO_ELASTICSEARCH_URL=http://my-app-3030:MpIxXstskccB3Ab2iwKH@my-app-3030.elasticsearch.a.osc-fr1.scalingo-dbs.com:30995
@@ -184,7 +184,7 @@ If using a Business plan for your Elasticsearch addon, we are able to change the
 To upgrade or downgrade your addon the sub-command is the same: `addons-upgrade`.
 
 ```bash
-$ scalingo -a my-app addons-upgrade my-app-3030 2g
+$ scalingo --app my-app addons-upgrade my-app-3030 2g
 ```
 
 In this example, `my-app-3030` is the ID of the addon, and `2g` is the plan we want to upgrade to.
@@ -192,7 +192,7 @@ In this example, `my-app-3030` is the ID of the addon, and `2g` is the plan we w
 To find out the addon ID:
 
 ```bash
-$ scalingo -a my-app addons
+$ scalingo --app my-app addons
 
 +------------------------+-------------+------+
 |          ADDON         |      ID     | PLAN |

--- a/src/_posts/databases/influxdb/2000-01-01-start.md
+++ b/src/_posts/databases/influxdb/2000-01-01-start.md
@@ -28,7 +28,7 @@ You can add the InfluxDB addon through the **Dashboard** or through the **comman
 ### Through the command-line interface
 
 ```bash
-$ scalingo -a my-app addons-add influxdb 1g
+$ scalingo --app my-app addons-add influxdb 1g
 
 -----> Addon influxdb has been provisionned
        ID: my_app_3707

--- a/src/_posts/databases/mongodb/2000-01-01-compass.md
+++ b/src/_posts/databases/mongodb/2000-01-01-compass.md
@@ -77,7 +77,7 @@ local address which correspond to the DB Tunnel.
 
 Let's open a DB Tunnel with the Scalingo CLI:
 ```bash
-$ scalingo -a my-app db-tunnel SCALINGO_MONGO_URL
+$ scalingo --app my-app db-tunnel SCALINGO_MONGO_URL
 Building tunnel to c393a9e3-42fe-4e33-9e6c-8ee815e9af88.my-app-7093.mongo.a.osc-fr1.scalingo-dbs.com:31312
 You can access your database on:
 127.0.0.1:10000

--- a/src/_posts/databases/redis/2000-01-01-data-import.md
+++ b/src/_posts/databases/redis/2000-01-01-data-import.md
@@ -17,7 +17,7 @@ Redis Addon]({% post_url databases/redis/2000-01-01-start %}).
 The remote Redis instance should be accessible on the Internet, and you could connect with:
 
 ```console
-$ redis-cli -a <password> -h <host> -p <port>
+$ redis-cli --app <password> -h <host> -p <port>
 ```
 
 ## Create a redis-console on Scalingo
@@ -26,7 +26,7 @@ Thanks to the `redis-console` utility of the `scalingo` command, create a
 console to your Redis addon:
 
 ```console
-$ scalingo -a my-app redis-console
+$ scalingo --app my-app redis-console
 -----> Connecting to container [one-off-5541]...
 -----> Process 'redis-console' is starting...
 

--- a/src/_posts/languages/meteorjs/2000-01-01-telescope.md
+++ b/src/_posts/languages/meteorjs/2000-01-01-telescope.md
@@ -37,7 +37,7 @@ The Meteor framework uses extensively MongoDB as a database. Hence you need to
 provision a new instance of this database to your application.
 
 ```bash
-$ scalingo -a my-app addons-add mongodb mongo-sandbox
+$ scalingo --app my-app addons-add mongodb mongo-sandbox
 -----> Addon mongodb has been provisionned
        ID: my-app-1234
        Modified variables: [MONGO_URL SCALINGO_MONGO_URL]

--- a/src/_posts/languages/python/django/2000-01-01-start.md
+++ b/src/_posts/languages/python/django/2000-01-01-start.md
@@ -230,7 +230,7 @@ ALLOWED_HOSTS = ["localhost"] + env_allowed_hosts
 Then change the environment variable of your application with a coma-separated list of domains which will be used to access the app.
 
 ```bash
-scalingo -a app-name env-set ALLOWED_HOSTS=app-name.osc-fr1.scalingo.io,example.com
+scalingo --app app-name env-set ALLOWED_HOSTS=app-name.osc-fr1.scalingo.io,example.com
 ```
 
 ## Save Your App With Git

--- a/src/_posts/platform/app/2000-01-01-environment.md
+++ b/src/_posts/platform/app/2000-01-01-environment.md
@@ -79,13 +79,13 @@ The current web dashboard does not handle well the configuration of an environme
 A first solution is to define this environment variable using our [CLI]({% post_url platform/cli/2000-01-01-start %}). For instance, if the content of the environment variable is the content of a file:
 
 ```bash
-scalingo -a my-app env-set "MY_VAR=$(cat fichier.key)"
+scalingo --app my-app env-set "MY_VAR=$(cat fichier.key)"
 ```
 
 The con of this solution is that the web dashboard becomes unusable to edit environment variables because of this multi-lines variable. If you want to still be able to use the web dashboard to manage your environment variable, the solution is to encode your multi-lines environment variable in Base64, then decode it in your application. First, set the environment variable in Base64:
 
 ```bash
-scalingo -a my-app env-set "MY_VAR=$(cat fichier | base64 -w 0)"
+scalingo --app my-app env-set "MY_VAR=$(cat fichier | base64 -w 0)"
 ```
 
 You can now read the content of this environment variable in your application by decoding the content of the variable. For instance, in PHP:

--- a/src/_posts/platform/app/2000-01-01-scaling.md
+++ b/src/_posts/platform/app/2000-01-01-scaling.md
@@ -48,7 +48,7 @@ data with our [CLI]({% post_url platform/cli/2000-01-01-start %}) with the
 following command:
 
 ```bash
-$ scalingo --app <appname> stats
+$ scalingo --app my-app stats
 +----------+-----+------------------+-----------------+
 |   NAME   | CPU |      MEMORY      |      SWAP       |
 +----------+-----+------------------+-----------------+

--- a/src/_posts/platform/app/2000-01-01-scaling.md
+++ b/src/_posts/platform/app/2000-01-01-scaling.md
@@ -48,7 +48,7 @@ data with our [CLI]({% post_url platform/cli/2000-01-01-start %}) with the
 following command:
 
 ```bash
-$ scalingo -a <appname> stats
+$ scalingo --app <appname> stats
 +----------+-----+------------------+-----------------+
 |   NAME   | CPU |      MEMORY      |      SWAP       |
 +----------+-----+------------------+-----------------+

--- a/src/_posts/platform/cli/2000-01-01-features.md
+++ b/src/_posts/platform/cli/2000-01-01-features.md
@@ -33,9 +33,9 @@ scalingo keys-remove "Laptop SSH key"
 `scalingo env|env-set|env-unset`
 
 ```bash
-scalingo -a my-app env
-scalingo -a my-app env-set NODE_ENV=production
-scalingo -a my-app env-unset NODE_ENV
+scalingo --app my-app env
+scalingo --app my-app env-set NODE_ENV=production
+scalingo --app my-app env-unset NODE_ENV
 ```
 
 ## Configure custom domain names
@@ -43,10 +43,10 @@ scalingo -a my-app env-unset NODE_ENV
 `scalingo domains|domains-add|domains-ssl|domains-remove`
 
 ```bash
-scalingo -a my-app domains
-scalingo -a my-app domains-add example.com
-scalingo -a my-app domains-ssl example.com --cert file.crt --key file.key
-scalingo -a my-app domains-remove example.com
+scalingo --app my-app domains
+scalingo --app my-app domains-add example.com
+scalingo --app my-app domains-ssl example.com --cert file.crt --key file.key
+scalingo --app my-app domains-remove example.com
 ```
 
 ## Configure canonical domain name
@@ -54,8 +54,8 @@ scalingo -a my-app domains-remove example.com
 `scalingo set-canonical-domain|unset-canonical-domain`
 
 ```bash
-scalingo -a my-app set-canonical-domain example.com
-scalingo -a my-app unset-canonical-domain
+scalingo --app my-app set-canonical-domain example.com
+scalingo --app my-app unset-canonical-domain
 ```
 
 ## Configure router
@@ -63,10 +63,10 @@ scalingo -a my-app unset-canonical-domain
 `scalingo sticky-session|force-https`
 
 ```bash
-scalingo -a my-app sticky-session --enable
-scalingo -a my-app sticky-session --disable
-scalingo -a my-app force-https --enable
-scalingo -a my-app force-https --disable
+scalingo --app my-app sticky-session --enable
+scalingo --app my-app sticky-session --disable
+scalingo --app my-app force-https --enable
+scalingo --app my-app force-https --disable
 ```
 
 ## Manage collaborators of the application
@@ -74,9 +74,9 @@ scalingo -a my-app force-https --disable
 `scalingo collaborators|collaborators-add|collaborators-remove`
 
 ```bash
-scalingo -a my-app collaborators
-scalingo -a my-app collaborators-add user@example.com
-scalingo -a my-app collaborators-remove user@example.com
+scalingo --app my-app collaborators
+scalingo --app my-app collaborators-add user@example.com
+scalingo --app my-app collaborators-remove user@example.com
 ```
 
 ## List existing addons and plans
@@ -93,13 +93,13 @@ scalingo addons-plans mongodb
 `scalingo addons|addons-add|addons-remove|addons-upgrade`
 
 ```bash
-scalingo -a my-app addons
-scalingo -a my-app addons-add mongodb 1g
-scalingo -a my-app addons-remove my-app_12345
-scalingo -a my-app addons-upgrade my-app_12345 2g
+scalingo --app my-app addons
+scalingo --app my-app addons-add mongodb 1g
+scalingo --app my-app addons-remove my-app_12345
+scalingo --app my-app addons-upgrade my-app_12345 2g
 
 # Display logs for addon
-scalingo -a my-app --addon addon-uuid logs
+scalingo --app my-app --addon addon-uuid logs
 ```
 
 ## Download backups of your applications addons
@@ -129,18 +129,18 @@ scalingo --addon addon-uuid backups-download --silent
 
 ```bash
 # Display the last 1000 lines of log
-scalingo -a my-app logs -n 1000
+scalingo --app my-app logs -n 1000
 
 # Display logs for addon
-scalingo -a my-app --addon addon-uuid logs
+scalingo --app my-app --addon addon-uuid logs
 
 # Follow the logs of your application in real-time
-scalingo -a my-app logs -f
+scalingo --app my-app logs -f
 
 # Filter your logs by container type
-scalingo -a my-app logs -F "web"
-scalingo -a my-app logs --filter "worker"
-scalingo -a my-app logs -F "web|worker"
+scalingo --app my-app logs -F "web"
+scalingo --app my-app logs --filter "worker"
+scalingo --app my-app logs -F "web|worker"
 ```
 
 ## List the logs archives
@@ -149,10 +149,10 @@ scalingo -a my-app logs -F "web|worker"
 
 ```bash
 # Display the last 10 logs archives
-scalingo -a my-app logs-archives
+scalingo --app my-app logs-archives
 
 # Follow the 2nd page of logs archives (from 11 to 20)
-scalingo -a my-app logs-archives --page 2
+scalingo --app my-app logs-archives --page 2
 ```
 
 ## Run custom job
@@ -160,16 +160,16 @@ scalingo -a my-app logs-archives --page 2
 `scalingo run`
 
 ```bash
-scalingo -a my-app run bundle exec rails console
+scalingo --app my-app run bundle exec rails console
 
 # Define custom environment variables into the one-off container
-scalingo -a my-app run --env CUSTOM_ENV=value --env ENV_EXAMPLE=custom <command>
+scalingo --app my-app run --env CUSTOM_ENV=value --env ENV_EXAMPLE=custom <command>
 
 # Upload a file to the one-off container (target is /tmp/uploads)
-scalingo -a my-app run --file ./dump.sql <command>
+scalingo --app my-app run --file ./dump.sql <command>
 
 # Start the one-off container with a specific size of container
-scalingo -a my-app run --size 2XL <command>
+scalingo --app my-app run --size 2XL <command>
 ```
 
 ## Get metrics of your application
@@ -178,10 +178,10 @@ scalingo -a my-app run --size 2XL <command>
 
 ```bash
 # Get the current stats of the containers of your app
-scalingo -a my-app stats
+scalingo --app my-app stats
 
 # Display and update every 10 seconds the stats of the containers of your app
-scalingo -a my-app stats --stream
+scalingo --app my-app stats --stream
 ```
 
 ## Access your database
@@ -189,13 +189,13 @@ scalingo -a my-app stats --stream
 `scalingo mongo-console|redis-console|mysql-console|pgsql-console|db-tunnel`
 
 ```bash
-scalingo -a my-app mongo-console
-scalingo -a my-app redis-console
-scalingo -a my-app mysql-console
-scalingo -a my-app pgsql-console
+scalingo --app my-app mongo-console
+scalingo --app my-app redis-console
+scalingo --app my-app mysql-console
+scalingo --app my-app pgsql-console
 
 # Build an encrypted tunnel to access your database
-scalingo -a my-app db-tunnel MONGO_URL
+scalingo --app my-app db-tunnel MONGO_URL
 ```
 
 ## Manage containers, scale, send signal
@@ -203,14 +203,14 @@ scalingo -a my-app db-tunnel MONGO_URL
 `scalingo ps|restart|scale|one-off-stop`
 
 ```bash
-scalingo -a my-app ps
-scalingo -a my-app restart web-1
-scalingo -a my-app scale web:2
-scalingo -a my-app scale worker:2:L
-scalingo -a my-app scale clock:0
-scalingo -a my-app one-off-stop one-off-1234
-scalingo -a my-app send-signal --signal SIGUSR1 web
-scalingo -a my-app send-signal --signal SIGUSR2 web-1 web-2
+scalingo --app my-app ps
+scalingo --app my-app restart web-1
+scalingo --app my-app scale web:2
+scalingo --app my-app scale worker:2:L
+scalingo --app my-app scale clock:0
+scalingo --app my-app one-off-stop one-off-1234
+scalingo --app my-app send-signal --signal SIGUSR1 web
+scalingo --app my-app send-signal --signal SIGUSR2 web-1 web-2
 ```
 
 ## Check the logged in user

--- a/src/_posts/platform/cli/2000-01-01-features.md
+++ b/src/_posts/platform/cli/2000-01-01-features.md
@@ -13,9 +13,9 @@ index: 3
 scalingo create my-app
 
 # Create a new app with a custom Git remote
-scalingo create my-app --remote staging
-scalingo create my-app --remote production
-scalingo create my-app --remote custom
+scalingo --remote staging create my-app 
+scalingo --remote production create my-app 
+scalingo --remote custom create my-app 
 ```
 
 ## Setup your account SSH keys

--- a/src/_posts/platform/deployment/2000-01-01-one-click-deploy.md
+++ b/src/_posts/platform/deployment/2000-01-01-one-click-deploy.md
@@ -79,5 +79,5 @@ https://github.com/<Your account>/<Your project>/archive/refs/heads/master.tar.g
 To deploy it, you simply have to run this command
 
 ```
-scalingo -a  my-app deploy https://github.com/<Your account>/<Your project>/archive/refs/heads/master.tar.gz
+scalingo --app my-app deploy https://github.com/<Your account>/<Your project>/archive/refs/heads/master.tar.gz
 ```

--- a/src/_posts/platform/deployment/continuous-integration/2000-01-01-deploy-scalingo-from-circle-ci.md
+++ b/src/_posts/platform/deployment/continuous-integration/2000-01-01-deploy-scalingo-from-circle-ci.md
@@ -78,6 +78,6 @@ command: |
   git push git@ssh.[region].scalingo.com:my-app.git $CIRCLE_SHA1:master
   curl -LO https://github.com/Scalingo/cli/releases/download/1.6.0/scalingo_1.6.0_linux_amd64.tar.gz
   tar xvf scalingo_1.6.0_linux_amd64.tar.gz
-  scalingo_1.6.0_linux_amd64/scalingo -a my-app login --ssh
-  scalingo_1.6.0_linux_amd64/scalingo -a my-app run rake db:migrate
+  scalingo_1.6.0_linux_amd64/scalingo --app my-app login --ssh
+  scalingo_1.6.0_linux_amd64/scalingo --app my-app run rake db:migrate
 ```

--- a/src/_posts/platform/getting-started/2000-01-01-getting-started-with-metabase.md
+++ b/src/_posts/platform/getting-started/2000-01-01-getting-started-with-metabase.md
@@ -49,5 +49,5 @@ To update your Metabase application to the latest version, you need to redeploy 
 Via this command for example:
 
 ```
-scalingo --app  my-app deploy https://github.com/Scalingo/metabase-scalingo/archive/refs/heads/master.tar.gz
+scalingo --app my-app deploy https://github.com/Scalingo/metabase-scalingo/archive/refs/heads/master.tar.gz
 ```

--- a/src/_posts/platform/getting-started/2000-01-01-getting-started-with-metabase.md
+++ b/src/_posts/platform/getting-started/2000-01-01-getting-started-with-metabase.md
@@ -49,5 +49,5 @@ To update your Metabase application to the latest version, you need to redeploy 
 Via this command for example:
 
 ```
-scalingo -a  my-app deploy https://github.com/Scalingo/metabase-scalingo/archive/refs/heads/master.tar.gz
+scalingo --app  my-app deploy https://github.com/Scalingo/metabase-scalingo/archive/refs/heads/master.tar.gz
 ```


### PR DESCRIPTION
As a convention, the app options should be written as its long form.
And since CLI version upgrade, the order of the arguments has changed.