### PR TITLE
fix(scalingo scheduler): update Scalingo Scheduler's doc

### DIFF
--- a/src/_posts/platform/app/task-scheduling/2000-01-01-scalingo-scheduler.md
+++ b/src/_posts/platform/app/task-scheduling/2000-01-01-scalingo-scheduler.md
@@ -1,42 +1,132 @@
 ---
 title: Scalingo Scheduler - Run Scheduled Tasks
 nav: Scalingo Scheduler
-modified_at: 2022-10-24 10:00:00
+modified_at: 2023-01-31 17:00:00
 tags: task-scheduling
 index: 1
 ---
 
-Scalingo Scheduler is here to help you run scheduled tasks at regular intervals.
+Scalingo provides a feature called *Scalingo Scheduler* to help you run tasks
+on a regular basis.
 
-The syntax used to describe this interval is the same as in the cron software.
+## About the Scalingo Scheduler
 
-Scalingo Scheduler launches tasks as [one-off containers]({% post_url platform/app/2000-01-01-tasks %}) in detached mode. Therefore the related one-off documentation and their detached mode applies.
+As the name suggests, the Scalingo Scheduler allows to define tasks so that
+they run periodically at fixed times, dates, or intervals. It can be leveraged
+to do a variety of tasks such as sending a newsletter every morning, exporting
+data every hour, checking for new orders every 15 minutes, ...
 
-{% warning %}
-Scheduled tasks execution is expected but not guaranteed. Scalingo Scheduler is known to occasionally (but rarely) miss the execution of scheduled jobs. If scheduled tasks are a critical component of your application, it is recommended to [run a custom clock process]({% post_url platform/app/task-scheduling/2000-01-01-custom-clock-processes %}) instead for more reliability, control, and visibility.
-{% endwarning %}
+The Scalingo Scheduler launches tasks in [one-off containers]({% post_url platform/app/2000-01-01-tasks %})
+running in detached mode. Therefore, [the related one-off documentation]({% post_url platform/app/2000-01-01-tasks %})
+fully applies.
 
-## Defining Tasks
+The Scalingo Scheduler also works with [Review Apps]({% post_url platform/app/2000-01-01-review-apps %}),
+just like the parent application does.
 
-Scheduled tasks are defined by adding a `cron.json` file at the root of your application's source code.
+### Limitations
 
-The file will be read at the next deployment and the tasks will be launched automatically.
+The following limitations currently exist, be it for security, performance or
+stability reasons:
 
-It must be a **valid JSON file** in the format specified below.
+- The Scalingo Scheduler has been designed to run short-lived tasks.
+  Consequently, **scheduled tasks won't run more than 15 minutes**. They are
+  automatically killed as soon as they reach this limit.
+
+- Moreover, a one-off container started by the Scalingo Scheduler will not run
+  longer than its scheduling interval. For example, a scheduled task set up to
+  run every 10 minutes will be terminated after running for 10 minutes. A
+  scheduled task set to run every 30 minutes will be killed after running for
+  15 minutes (see above).
+
+- The smallest scheduling interval is set to 10 minutes. For example, the
+  Scalingo Scheduler won't let you set up a task to run every 5 minutes (the
+  deployment will fail).
+
+- **A maximum of 5 tasks** can be scheduled through the Scalingo Scheduler.
+  Please get in touch with the support if you need more, they will study your
+  request and advise you.
+
+- Task execution is expected but **not guaranteed**. The Scalingo Scheduler is
+  known to occasionally (but rarely) miss the execution of a scheduled job.
+
+- Execution time can be delayed by a maximum of 10% of the interval between 2
+  tasks (up to 20 minutes).
+
+  * `*/10 * * * *` (every 10 minutes): task will be executed every 10 to 11
+    minutes;
+  * `0 */1 * * *` (every hour): task will be executed between minute 0 and
+    minute 6 of each hour;
+  * `0 0 * * *`: (everyday at midnight): task will be executed between 00:00
+    and 00:20 UTC.
+
+- Two one-off containers running the same scheduled task may overlap for a
+  brief time if the task is not finished when a new one is started.
+
+{% note %}
+All these limitations can be circumvented by using a
+[custom clock process]({% post_url platform/app/task-scheduling/2000-01-01-custom-clock-processes %}).
+{% endnote %}
+
+### Costs
+
+Although the Scalingo Scheduler itself is free, the one-off containers in which
+the commands are run are billed like any other
+[one-off container]({% post_url platform/app/2000-01-01-tasks %}).
+
+Consequently, billing depends on the type of container you defined in your task
+(M is the default container size) and on the job lifespan.
+
+For example, if your job runs during 5 minutes, you will be billed 5 minutes of
+an M container.
+
+## Working with the Scalingo Scheduler
+
+### Enabling the Scalingo Scheduler
+
+The Scalingo Scheduler is enabled automatically as soon as a `cron.json` file
+is present at the root of your application.
+
+### Disabling the Scalingo Scheduler
+
+For now, it's not possible to disable scheduled tasks once a `cron.json` has
+been committed.
+
+If you wish to control the execution of tasks differently between environment
+(for example, if you want to disable scheduled tasks for your staging apps or
+for your [review apps]({% post_url platform/app/2000-01-01-review-apps %})) we
+suggest to modify the task's code to [detect the environment]({% post_url platform/app/2000-01-01-environment.md#runtime-environment-variables %})
+where they are executed.
+
+### Defining Tasks
+
+Scheduled tasks are defined in the `cron.json` file stored at the root of your
+application's source code. The platform automatically detects and reads the
+file during deployment, and sets up the tasks according to the given schedule.
+
+The `cron.json` file must be a **valid JSON file** in the format specified
+below.
 
 Each job is configured as a JSON object with two keys:
 
 - `command`: contains both the cron expression and the command to execute:
-  - The cron expression follows the [crontab standard](https://en.wikipedia.org/wiki/Cron#CRON_expression). You may
-  find the website [crontab.guru](https://crontab.guru/#*/10_*_*_*_*) useful to write your own cron expression.
+  - The cron expression follows the [crontab standard](https://en.wikipedia.org/wiki/Cron#CRON_expression).
+    You may find the website [crontab.guru](https://crontab.guru/#*/10_*_*_*_*)
+    useful to write your own cron expression.
   - The command is any command you can execute in a one-off container
-  (i.e. with the command `scalingo --app my-app run <command>`).
-- `size`: specify the [container size]({% post_url platform/internals/2000-01-01-container-sizes %}) of the one-off
-container executing the command. This key is optional, it defaults to M (512 MiB RAM).
+    (i.e. with the command `scalingo --app my-app run <command>`).
+- `size`: specify the [size]({% post_url platform/internals/2000-01-01-container-sizes %})
+  of the one-off container executing the command. This key is optional and
+  defaults to M (512 MiB RAM).
 
-**All dates are expressed in UTC**. For instance, if you are located in Paris or Berlin (CET timezone, UTC+1) and you want a cron job to be executed at 10:00 in your local time, your cron expression should mention 09:00. For Athens (EET, UTC+2) you would your cron expression should mention 08:00.
+**All dates are expressed in UTC**. For instance, if you are located in Paris
+or Berlin (CET timezone, UTC+1) and you want a scheduled task to be executed at
+10:00 in your local time, your cron expression should mention 09:00. For Athens
+(EET, UTC+2), your cron expression should mention 08:00 to achieve the same
+result.
 
-For instance here is a file example of how to schedule a task every morning at 8AM CET:
+#### Examples
+
+Schedule a task to run every morning at 8AM CET:
 
 ```json
 {
@@ -48,7 +138,8 @@ For instance here is a file example of how to schedule a task every morning at 8
 }
 ```
 
-And here is a file example of how to schedule a task every 10 minutes to execute the command `rails orders:check` on a 2XL container:
+Schedule a task to run `rails orders:check` every 10 minutes in a 2XL
+container:
 
 ```json
 {
@@ -61,84 +152,29 @@ And here is a file example of how to schedule a task every 10 minutes to execute
 }
 ```
 
-{% warning %}
-Your cron expression must be set with at least a 10 minutes interval.
-{% endwarning %}
+### Listing Scheduled Tasks
 
-
-### Costs
-
-Scalingo Scheduler in itself is free.
-
-The one-off containers launched to run the commands will be billed like other [one-off containers]({% post_url platform/app/2000-01-01-tasks %}).
-
-You will be billed for the type of container you defined in your task (M is the default container size) and for the time it was executed.
-
-For example if your task run during 5 minutes, you will be billed 5 minutes of an M container.
-
-## Long-running Tasks
-
-Scheduled tasks are meant to execute short running tasks.
-Tasks are automatically killed after 15 minutes.
-
-A one-off container started by Scalingo Scheduler will not run longer than its scheduling interval. For example, for a job that runs every 10 minutes, one-offs will be terminated after running for 10 minutes.
-
-If your tasks may last more than the in-between interval of two tasks we suggest to use [custom clock processes]({% post_url platform/app/task-scheduling/2000-01-01-custom-clock-processes %})
-
-{% warning %}
-Note that two containers running the same job may overlap for a brief time if the task is not finished when a new one is started.
-{% endwarning %}
-
-## Get The List Of Current Scheduled Tasks
-
-Get the list of tasks configured on your application using the Scalingo CLI:
+You can list your scheduled tasks by using the Scalingo CLI:
 
 ```bash
 $ scalingo --app my-app cron-tasks
-+---------------------------------+------+
-|            COMMAND              | SIZE |
-+---------------------------------+------+
-| */10 * * * * rails orders:check | 2XL  |
-+---------------------------------+------+
++---------------------------------+------+------------------------+---------------------+
+|            COMMAND              | SIZE |     LAST EXECUTION     |    NEXT EXECUTION   |
++---------------------------------+------+------------------------+---------------------+
+| */10 * * * * rails orders:check | 2XL  | No previous executions | 2023/01/31 14:10:00 |
++---------------------------------+------+------------------------+---------------------+
 ```
 
-## Modify or Delete Scheduled Tasks
+### Updating or Removing Scheduled Tasks
 
-In order to modify or delete a cron task, you must modify or delete the associated entry in the `cron.json` and push your code to trigger a new deployment.
+To modify or remove a scheduled task, you must modify or delete the associated
+entry in the `cron.json` file and push your updated file to Scalingo. This will
+trigger a new deployment, allowing the platform to handle your changes.
 
-The list of tasks will be updated when the application will be redeployed.
+If there is no more task, or if you want to remove all tasks, you can also
+remove the file.
 
-If there is no more task, or if you want to remove all tasks, you can also remove the file.
+### Reading Scheduled Tasks Logs
 
-## FAQ
-
-### How To Enable Scalingo Scheduler?
-
-Scalingo Scheduler will be enabled automatically as soon as a `cron.json` file is present.
-
-### How To Disable Scalingo Scheduler?
-
-Once you committed a `cron.json` it's not possible to disable tasks.
-
-If you wish to control the execution of tasks differently between environment (think about staging apps or [review apps]({% post_url
-platform/app/2000-01-01-review-apps %})) we suggest to modify the tasks related code to detect the environment where they are executed.
-
-### How Precise Is Scalingo Scheduler?
-
-Execution time can be delayed by a maximum of 10% of the interval between 2 tasks (up to 20 minutes).
-
-* `*/10 * * * *` (every 10 minutes): task will be executed every 10 to 11 minutes
-* `0 */1 * * *` (every hour): task will be executed between minute 0 and minute 6 of each hour
-* `0 0 * * *`: (everyday at midnight): task will be executed between 00:00 and 00:20 UTC
-
-This is to prevent load spikes on the infrastructure and to give time for our infrastructure to pull your application images.
-
-If you need more precision we suggest to [run a custom clock process]({% post_url platform/app/task-scheduling/2000-01-01-custom-clock-processes %}).
-
-### Does Scalingo Scheduler work with Review Apps?
-
-Of course, it works in the same way as the parent app.
-
-### Where can we see logs of the tasks executed?
-
-Tasks logs are included in the [application logs]({% post_url platform/app/2000-01-01-logs %}) next to other containers logs.
+Logs for scheduled tasks are included in the [application logs]({% post_url platform/app/2000-01-01-logs %}), 
+next to other containers logs.

--- a/src/_posts/platform/app/task-scheduling/2000-01-01-scalingo-scheduler.md
+++ b/src/_posts/platform/app/task-scheduling/2000-01-01-scalingo-scheduler.md
@@ -11,17 +11,19 @@ on a regular basis.
 
 ## About the Scalingo Scheduler
 
-As the name suggests, the Scalingo Scheduler allows to define tasks so that
-they run periodically at fixed times, dates, or intervals. It can be leveraged
-to do a variety of tasks such as sending a newsletter every morning, exporting
-data every hour, checking for new orders every 15 minutes, ...
+The Scalingo Scheduler allows to define tasks so that they run periodically at
+fixed times, dates, or intervals. It can be leveraged to do a variety of tasks
+such as sending a newsletter every morning, exporting data every hour, checking
+for new orders every 15 minutes, ...
 
-The Scalingo Scheduler launches tasks in [one-off containers]({% post_url platform/app/2000-01-01-tasks %})
-running in detached mode. Therefore, [the related one-off documentation]({% post_url platform/app/2000-01-01-tasks %})
+The Scalingo Scheduler launches tasks in one-off containers running in detached
+mode. Therefore, [the related one-off documentation]({% post_url platform/app/2000-01-01-tasks %})
 fully applies.
 
+
 The Scalingo Scheduler also works with [Review Apps]({% post_url platform/app/2000-01-01-review-apps %}),
-just like the parent application does.
+meaning that review apps have the same scheduled tasks as their parent
+application.
 
 ### Limitations
 
@@ -83,13 +85,13 @@ an M container.
 
 ### Enabling the Scalingo Scheduler
 
-The Scalingo Scheduler is enabled automatically as soon as a `cron.json` file
-is present at the root of your application.
+The Scalingo Scheduler is enabled automatically as soon as a valid `cron.json`
+file is present at the root of your application.
 
 ### Disabling the Scalingo Scheduler
 
-For now, it's not possible to disable scheduled tasks once a `cron.json` has
-been committed.
+For now, it's not possible to disable scheduled tasks without modifying or
+removing the `cron.json` file and triggering a new deployment thereafter.
 
 If you wish to control the execution of tasks differently between environment
 (for example, if you want to disable scheduled tasks for your staging apps or
@@ -109,9 +111,10 @@ below.
 Each job is configured as a JSON object with two keys:
 
 - `command`: contains both the cron expression and the command to execute:
-  - The cron expression follows the [crontab standard](https://en.wikipedia.org/wiki/Cron#CRON_expression).
+  - The cron expression follows the **[crontab standard](https://en.wikipedia.org/wiki/Cron#CRON_expression)**.
     You may find the website [crontab.guru](https://crontab.guru/#*/10_*_*_*_*)
-    useful to write your own cron expression.
+    useful to write your own cron expression. Note that we do not support the
+    non standard `@-ly` syntax.
   - The command is any command you can execute in a one-off container
     (i.e. with the command `scalingo --app my-app run <command>`).
 - `size`: specify the [size]({% post_url platform/internals/2000-01-01-container-sizes %})


### PR DESCRIPTION
Fully reorganized/rewrote the documentation about the Scalingo Scheduler:
- I grouped the limitations in a single section ;
- I added the missing ones ;
- I re-phrased some sentences ;
- I ditch the FAQ (information have been dispatched in their sections).

I hope this will make things a bit clearer for the users.