### PR TITLE
fix(custom clock process): update Custom Clock Processes' doc

### DIFF
--- a/src/_posts/platform/app/task-scheduling/2000-01-01-custom-clock-processes.md
+++ b/src/_posts/platform/app/task-scheduling/2000-01-01-custom-clock-processes.md
@@ -7,7 +7,7 @@ index: 2
 ---
 
 Scalingo provides a feature called *Custom Clock Processes* to help you run
-tasks on a regular basis. Unlike jobs setup through the [Scalingo Scheduler]({% post_url platform/app/task-scheduling/2000-01-01-scalingo-scheduler.md %}),
+tasks on a regular basis. Unlike jobs setup through the [Scalingo Scheduler]({% post_url platform/app/task-scheduling/2000-01-01-scalingo-scheduler %}),
 custom clock processes do not suffer from many limitations.
 
 ## About Custom Clock Processes
@@ -26,14 +26,14 @@ It's usually written in the language of your choice. This means that your
 custom clock process can either share the same code base as your application's
 or a dedicated one.
 
-Custom clock processes also work with [Review Apps]({% post_url platform/app/2000-01-01-review-apps.md %}),
+Custom clock processes also work with [Review Apps]({% post_url platform/app/2000-01-01-review-apps %}),
 just like the parent application does.
 
 ### Limitations
 
 Custom clock processes have very few limitations:
-- For deployments: [deployment limits]({% post_url platform/deployment/2000-01-01-limits.md %})
-- For containers: [containers limits]({% post_url platform/internals/2001-01-01-container-sized.md#container-limits %})
+- For deployments: [deployment limits]({% post_url platform/deployment/2000-01-01-limits %})
+- For containers: [containers limits]({% post_url platform/internals/2001-01-01-container-sizes#container-limits %})
 
 They **do not** have the limitations imposed by the Scalingo Scheduler.
 Consequently, they allow to:
@@ -69,7 +69,7 @@ billed 3 days of a 2XL container.
 ### Defining Custom Clock Processes
 
 Defining a custom clock process is done by adding a new **process type** in
-the [`Procfile`]({% post_url platform/app/2000-01-01-procfile.md %}) of your
+the [`Procfile`]({% post_url platform/app/2000-01-01-procfile %}) of your
 application.
 
 In the following examples, the name `clock` is used to designate our custom
@@ -279,7 +279,7 @@ scalingo --app my-app scale web:0
 ```
 
 For more details about web-less applications, please refer to [our
-documentation]({% post_url platform/app/2000-01-01-web-less-app.md %}).
+documentation]({% post_url platform/app/2000-01-01-web-less-app %}).
 
 ### Disabling Custom Clock Processes
 

--- a/src/_posts/platform/app/task-scheduling/2000-01-01-custom-clock-processes.md
+++ b/src/_posts/platform/app/task-scheduling/2000-01-01-custom-clock-processes.md
@@ -50,11 +50,15 @@ Consequently, they allow to:
 
 ### Costs
 
-The feature itself it completely free, but the containers in which the jobs are
-run are billed like any other containers.
+The feature itself it completely free, but the container in which the
+scheduler and the jobs are run is billed like any other container.
 
 Consequently, billing of a custom clock process mainly depends on both the
-container size chosen to run your tasks and on the container(s) lifespan.
+container size chosen to run your tasks and on the container lifespan.
+
+Your custom clock process is most probably to run 24/7, as opposed to the
+Scalingo Scheduler's one-off containers that are short-lived. A custom clock
+process can therefore be a bit more costly.
 
 For example, if you setup your custom clock process to run in a 2XL container,
 and you let it run for 3 days before scaling it down to zero, you will be
@@ -219,7 +223,7 @@ This example leverages the `node-cron` package to:
 - run `job1` every 2 minutes
 - run `job2` every minute
 
-Both jobs just log a message.
+Both jobs log a message.
 
 `Procfile`:
 
@@ -273,6 +277,9 @@ before or after your deployment:
 ```bash
 scalingo --app my-app scale web:0
 ```
+
+For more details about web-less applications, please refer to [our
+documentation]({% post_url platform/app/2000-01-01-web-less-app.md %}).
 
 ### Disabling Custom Clock Processes
 

--- a/src/_posts/platform/app/task-scheduling/2000-01-01-custom-clock-processes.md
+++ b/src/_posts/platform/app/task-scheduling/2000-01-01-custom-clock-processes.md
@@ -6,13 +6,13 @@ tags: task-scheduling
 index: 2
 ---
 
-Scalingo provides a feature called *Custom Clock Processes* to help you run
-tasks on a regular basis. Unlike jobs setup through the [Scalingo Scheduler]({% post_url platform/app/task-scheduling/2000-01-01-scalingo-scheduler %}),
-custom clock processes do not suffer from many limitations.
+Scalingo allows to define *Custom Clock Processes* to help you run tasks on a
+regular basis. Unlike jobs setup through the [Scalingo Scheduler]({% post_url platform/app/task-scheduling/2000-01-01-scalingo-scheduler %}),
+custom clock processes do not suffer from the same limitations.
 
 ## About Custom Clock Processes
 
-Custom clock processes allow to define tasks so that they run periodically.
+Custom clock processes allow to setup tasks so that they run periodically.
 They give you full control over the schedule, periodicity and conditions on
 which the jobs are launched, making them a powerful alternative to the Scalingo
 Scheduler.
@@ -26,14 +26,11 @@ It's usually written in the language of your choice. This means that your
 custom clock process can either share the same code base as your application's
 or a dedicated one.
 
-Custom clock processes also work with [Review Apps]({% post_url platform/app/2000-01-01-review-apps %}),
-just like the parent application does.
-
 ### Limitations
 
 Custom clock processes have very few limitations:
 - For deployments: [deployment limits]({% post_url platform/deployment/2000-01-01-limits %})
-- For containers: [containers limits]({% post_url platform/internals/2001-01-01-container-sizes %}#container-limits)
+- For containers: [containers limits]({% post_url platform/internals/2000-01-01-container-sizes %}#container-limits)
 
 They **do not** have the limitations imposed by the Scalingo Scheduler.
 Consequently, they allow to:
@@ -50,11 +47,10 @@ Consequently, they allow to:
 
 ### Costs
 
-The feature itself it completely free, but the container in which the
-scheduler and the jobs are run is billed like any other container.
-
-Consequently, billing of a custom clock process mainly depends on both the
-container size chosen to run your tasks and on the container lifespan.
+The container in which the scheduler and the jobs are run is billed like any
+other container. Consequently, billing of a custom clock process mainly depends
+on both the container size chosen to run your tasks and on the container
+lifespan.
 
 Your custom clock process is most probably to run 24/7, as opposed to the
 Scalingo Scheduler's one-off containers that are short-lived. A custom clock

--- a/src/_posts/platform/app/task-scheduling/2000-01-01-custom-clock-processes.md
+++ b/src/_posts/platform/app/task-scheduling/2000-01-01-custom-clock-processes.md
@@ -73,10 +73,10 @@ the [`Procfile`]({% post_url platform/app/2000-01-01-procfile.md %}) of your
 application.
 
 In the following examples, the name `clock` is used to designate our custom
-clock process type. But, except from `web` and `tcp`, which are reserved by the
-platform, you can chose whatever you want. `scheduler`, `cron`, `planner`,
-`timer`, `butler`, ... These are all valid names for your custom clock process
-type.
+clock process type. But, except from `web`, `tcp` and `postdeploy`, which are
+reserved by the platform, you can chose whatever you want. `scheduler`, `cron`,
+`planner`, `timer`, `butler`, ... These are all valid names for your custom
+clock process type.
 
 The syntax is pretty straightforward:
 

--- a/src/_posts/platform/app/task-scheduling/2000-01-01-custom-clock-processes.md
+++ b/src/_posts/platform/app/task-scheduling/2000-01-01-custom-clock-processes.md
@@ -33,7 +33,7 @@ just like the parent application does.
 
 Custom clock processes have very few limitations:
 - For deployments: [deployment limits]({% post_url platform/deployment/2000-01-01-limits %})
-- For containers: [containers limits]({% post_url platform/internals/2001-01-01-container-sizes#container-limits %})
+- For containers: [containers limits]({% post_url platform/internals/2001-01-01-container-sizes %}#container-limits)
 
 They **do not** have the limitations imposed by the Scalingo Scheduler.
 Consequently, they allow to:


### PR DESCRIPTION
Fully reorganized/rewrote the documentation about Custom Clock Processes:
- I calked the page organization on my suggestions for the Scalingo Scheduler (see PR https://github.com/Scalingo/documentation/pull/1915)
- I specifically listed the differences with the Scalingo Scheduler
- I added some precisions about how they work
- I added a 'Costs' section
- I rephrased some explanations
- ...

I hope this will make things a bit clearer for the users.