### PR TITLE
chore(php): update Composer to 2.5.3

### DIFF
--- a/src/_posts/languages/php/2000-01-01-start.md
+++ b/src/_posts/languages/php/2000-01-01-start.md
@@ -1,7 +1,7 @@
 ---
 title: PHP on Scalingo
 nav: Introduction
-modified_at: 2023-02-07 12:00:00
+modified_at: 2023-02-13 12:00:00
 tags: php
 index: 1
 ---
@@ -148,7 +148,7 @@ Scalingo supports the following versions of Composer:
 - 2.2.18
 - 2.3.10
 - 2.4.4
-- 2.5.2
+- 2.5.3
 
 ## Native PHP Extensions
 

--- a/src/changelog/buildpacks/_posts/2023-02-13-php-composer-2.5.3.md
+++ b/src/changelog/buildpacks/_posts/2023-02-13-php-composer-2.5.3.md
@@ -1,0 +1,9 @@
+---
+modified_at: 2023-02-13 12:00:00
+title: 'PHP - Release Composer version 2.5.3'
+github: 'https://github.com/Scalingo/php-buildpack'
+---
+
+Changelog:
+
+* [Composer 2.5.3](https://github.com/composer/composer/releases/tag/2.5.3)


### PR DESCRIPTION
Done for `scalingo-18`, `scalingo-20` and `scalingo-22`.

Files have been uploaded to ObjectStorage.

Fixes https://github.com/Scalingo/php-buildpack/issues/304