### PR TITLE
docs(database): download backup from one-off

### DIFF
--- a/src/_posts/languages/java/2000-01-01-spring-boot.md
+++ b/src/_posts/languages/java/2000-01-01-spring-boot.md
@@ -20,18 +20,14 @@ page describes how to achieve both.
 
 ## WAR or JAR
 
-Your Spring Boot application can be packaged as a `jar` or as a `war` ([see the
-Spring documentation
-here](https://docs.spring.io/spring-boot/docs/current/reference/html/howto.html#howto.traditional-deployment)).
+Your Spring Boot application can be packaged as a `jar` or as a `war` ([see the Spring documentation here](https://docs.spring.io/spring-boot/docs/current/reference/html/howto.html#howto.traditional-deployment)).
 
 The way you choose to package your application changes the way you deploy on
 Scalingo.
 
 ### Listen on ${PORT}
 
-For both WAR and JAR deployments, you need to specify the good port to listen to in your Spring Boot application
-[configuration
-file](https://docs.spring.io/spring-boot/docs/current/reference/html/features.html#features.external-config).
+For both WAR and JAR deployments, you need to specify the good port to listen to in your Spring Boot application [configuration file](https://docs.spring.io/spring-boot/docs/current/reference/html/features.html#features.external-config).
 
 ```text
 server:

--- a/src/_posts/platform/databases/2000-01-01-restore-backup.md
+++ b/src/_posts/platform/databases/2000-01-01-restore-backup.md
@@ -1,6 +1,6 @@
 ---
 title: Restore your Database Backup
-modified_at: 2020-10-26 00:00:00
+modified_at: 2023-02-16 00:00:00
 tags: databases backups
 ---
 
@@ -9,7 +9,23 @@ your database on a daily basis. During your application lifetime, you might feel
 your database at a previous state. We will guide you through the different steps to download a
 specific backups and restore the database with its content.
 
-Instructions for every specific database is available in their dedicated page:
+Here are the instructions to download a backup in a one-off container:
+
+```sh
+$ scalingo --app my-app run bash
+[10:30][osc-fr1] Scalingo:my-app ~ $ install-scalingo-cli
+[10:30][osc-fr1] Scalingo:my-app ~ $ scalingo login
+[10:30][osc-fr1] Scalingo:my-app ~ $ scalingo --app my-app addons
++------------+-----------------------------------------+--------------------+---------+
+|   ADDON    |                   ID                    |        PLAN        | STATUS  |
++------------+-----------------------------------------+--------------------+---------+
+| PostgreSQL | ad-32ef9060-d912-4a53-b2bb-6cf1bf333865 | postgresql-sandbox | running |
++------------+-----------------------------------------+--------------------+---------+
+[10:30][osc-fr1] Scalingo:my-app ~ $ ADDON_UUID="ad-32ef9060-d912-4a53-b2bb-6cf1bf333865"
+[10:30][osc-fr1] Scalingo:my-app ~ $ scalingo --app my-app --addon $ADDON_UUID backups-download
+```
+
+This downloads the last successful backup. In order to restore the downloaded backup, instructions are available in each database type page:
 
 - [PostgreSQL]({% post_url databases/postgresql/2000-01-01-start %}#backups)
 - [MySQL]({% post_url databases/mysql/2000-01-01-start %}#backups)


### PR DESCRIPTION
It also contains some nitpicks following https://github.com/Scalingo/documentation/pull/1960

Fix #892 