### PR TITLE
Shorten sec bulletins urls

### DIFF
--- a/src/_posts/security/bulletins/2023-01-01-SSB-2023-001.md
+++ b/src/_posts/security/bulletins/2023-01-01-SSB-2023-001.md
@@ -58,8 +58,8 @@ Note: we already assessed in our analysis that no HDS applications were impacted
 
 Use GitHub and Gitlab documentation to review PRs coming from untrusted users
 
-- GitHub: [https://docs.github.com/en/issues/tracking-your-work-with-issues/filtering-and-searching-issues-and-pull-requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/filtering-and-searching-issues-and-pull-requests)
-- Gitlab: [https://docs.gitlab.com/ee/user/project/merge_requests/#view-merge-requests](https://docs.gitlab.com/ee/user/project/merge_requests/#view-merge-requests)
+- [GitHub](https://docs.github.com/en/issues/tracking-your-work-with-issues/filtering-and-searching-issues-and-pull-requests)
+- [Gitlab](https://docs.gitlab.com/ee/user/project/merge_requests/#view-merge-requests)
 
 ### What will do in the future
 


### PR DESCRIPTION
Make the document responsible on chrome