### PR TITLE
fix(php-buildpack): upgrade PHP to 8.0.28, 8.1.16 and 8.2.3

### DIFF
--- a/src/_posts/languages/php/2000-01-01-start.md
+++ b/src/_posts/languages/php/2000-01-01-start.md
@@ -1,7 +1,7 @@
 ---
 title: PHP on Scalingo
 nav: Introduction
-modified_at: 2023-02-21 12:00:00
+modified_at: 2023-02-24 16:00:00
 tags: php
 index: 1
 ---
@@ -35,9 +35,9 @@ The following PHP versions are compatible with the platform:
 * **7.2** (up to 7.2.34, only for scalingo-18)
 * **7.3** (up to 7.3.33, only for scalingo-18)
 * **7.4** (up to 7.4.32, only for scalingo-18 and scalingo-20)
-* **8.0** (up to 8.0.27, only for scalingo-18 and scalingo-20)
-* **8.1** (up to 8.1.15)
-* **8.2** (up to 8.2.2)
+* **8.0** (up to 8.0.28, only for scalingo-18 and scalingo-20)
+* **8.1** (up to 8.1.16)
+* **8.2** (up to 8.2.3)
 
 ### Select a Version
 

--- a/src/changelog/buildpacks/_posts/2023-02-24-php-8.0.28-8.1.16-8.2.3.md
+++ b/src/changelog/buildpacks/_posts/2023-02-24-php-8.0.28-8.1.16-8.2.3.md
@@ -1,0 +1,11 @@
+---
+modified_at: 2023-02-24 16:00:00
+title: 'PHP - Support of versions 8.0.28, 8.1.16 and 8.2.3'
+github: 'https://github.com/Scalingo/php-buildpack'
+---
+
+Changelogs:
+
+* [PHP 8.0.28 Changelog](https://www.php.net/ChangeLog-8.php#8.0.28)
+* [PHP 8.1.16 Changelog](https://www.php.net/ChangeLog-8.php#8.1.16)
+* [PHP 8.2.3 Changelog](https://www.php.net/ChangeLog-8.php#8.2.3)


### PR DESCRIPTION
Done for the following stacks:
- `scalingo-18`
  * https://semver.scalingo.com/php-scalingo-18/resolve/~8.0
  * https://semver.scalingo.com/php-scalingo-18/resolve/~8.1
  * https://semver.scalingo.com/php-scalingo-18/resolve/~8.2 
- `scalingo-20`
  * https://semver.scalingo.com/php-scalingo-20/resolve/~8.0
  * https://semver.scalingo.com/php-scalingo-20/resolve/~8.1
  * https://semver.scalingo.com/php-scalingo-20/resolve/~8.2
- `scalingo-22`
  * https://semver.scalingo.com/php-scalingo-20/resolve/~8.1
  * https://semver.scalingo.com/php-scalingo-20/resolve/~8.2

Files have been uploaded to ObjectStorage.

Fixes https://github.com/Scalingo/php-buildpack/issues/305