### PR TITLE
release(python-buildpack): Python 3.11 support and others version updates

### DIFF
--- a/src/_posts/languages/python/2000-01-01-start.md
+++ b/src/_posts/languages/python/2000-01-01-start.md
@@ -1,7 +1,7 @@
 ---
 title: Python
 nav: Introduction
-modified_at: 2022-10-26 00:00:00
+modified_at: 2023-03-09 00:00:00
 tags: python
 index: 1
 ---
@@ -18,10 +18,11 @@ present at the root of your project, defining the dependencies of your app.
 
 ## Supported Versions
 
-* 3.10.8
-* 3.9.15
-* 3.8.15
-* 3.7.15
+* `3.11.2` (default)
+* `3.10.10`
+* `3.9.16`
+* `3.8.16` (only for `scalingo-20` stacks)
+* `3.7.16` (only for `scalingo-20` stacks)
 
 ### Recommended: pipenv
 

--- a/src/changelog/buildpacks/_posts/2023-03-09-python-3.11.2.md
+++ b/src/changelog/buildpacks/_posts/2023-03-09-python-3.11.2.md
@@ -1,0 +1,16 @@
+---
+modified_at: 2023-03-09 10:00:00
+title: 'Python - New versions available: 3.11.2, 3.10.10, 3.9.16, 3.8.16 and 3.7.16'
+github: 'https://github.com/Scalingo/python-buildpack'
+---
+
+Changelogs:
+
+- Add support for Python 3.11
+- Drop support for Python 3.6
+- The default Python version for new apps is now 3.11.2 (previously 3.10.8)
+- Python 3.7.16, 3.8.16, 3.9.16, 3.10.10 and 3.11.2 are now available
+- Update wheel from 0.37.1 to 0.38.4 for Python 3.7+
+- Update pip from 22.2.2 to 23.0.1 for Python 3.7+
+- Update pipenv from 2020.11.15 to 2023.2.18 for Python 3.7+
+- Update pipenv from 2020.11.15 to 2022.4.8 for Python 3.6


### PR DESCRIPTION
Related to https://github.com/Scalingo/python-buildpack/issues/76