### PR TITLE
fix(procfile): update doc about Procfile

### DIFF
--- a/src/_posts/platform/app/2000-01-01-procfile.md
+++ b/src/_posts/platform/app/2000-01-01-procfile.md
@@ -1,6 +1,6 @@
 ---
 title: Procfile
-modified_at: 2023-03-10 00:00:00
+modified_at: 2023-03-15 00:00:00
 tags: internals process types procfile heroku
 index: 11
 ---
@@ -74,9 +74,9 @@ scalingo --app my-app scale worker:3:2XL
 
 ### Special Process Types
 
-By default, Scalingo uses three process types: `web`, `tcp` and `postdeploy`.
-**These process types have specific use cases** and the platform will only use
-them for what they are designed for.
+The `web`, `tcp` and `postdeploy` process types have a special meaning and are
+thus reserved for specific use cases described below. The platform will only
+use them for what they are designed for.
 
 #### The `web` Process Type
 
@@ -118,7 +118,8 @@ The Procfile is a plain text file that MUST be named `Procfile`. Even if it
 uses the YAML syntax, there is **no extension**: no `.txt`, no `.yaml`, no
 `.yml`. **Only `Procfile`**.
 
-The file MUST live in the application's root directory.
+The file MUST live in your application's root directory or in `$PROJECT_DIR`,
+if your [application code lies in a subdirectory of your repository]({% post_url platform/getting-started/2000-01-01-common-deployment-errors %}#project-in-a-subdirectory).
 
 ### Defining a Process Type
 
@@ -130,10 +131,9 @@ with the following format:
 ```
 
 - `<process_type>` designates the name of the process type. It can only contain
-  alphanumerics, dashes and underscores (`[A-Za-z0-9_-]+`). Except this rule,
-  you are free to name your process type how you want: `heavy_process`,
-  `synchronizer`, `scheduler`, `console`, `t-rex`... These are all examples of
-  valid process type names.
+  alphanumerics (`[A-Za-z0-9]+`). Except this rule, you are free to name your
+  process type how you want: `heavyProcess`, `synchronizer`, `scheduler`,
+  `console`, `trex`... These are all examples of valid process type names.
 - `<command>` designates the command to run when a Managed Runtime of the
   specified type is booted up. It can be any Bash command. Using environment
   variables in the command is allowed, and even encouraged.

--- a/src/_posts/platform/app/2000-01-01-procfile.md
+++ b/src/_posts/platform/app/2000-01-01-procfile.md
@@ -1,6 +1,6 @@
 ---
 title: Procfile
-modified_at: 2022-01-26 00:00:00
+modified_at: 2023-03-10 00:00:00
 tags: internals process types procfile heroku
 index: 11
 ---
@@ -9,48 +9,150 @@ Procfile support is one of our
 [compatibility layers]({% post_url platform/getting-started/2000-01-01-heroku-compatibility %})
 that makes Scalingo compatible with Heroku.
 
-## Definition
+## About the Procfile
 
-The Procfile is a way to define how the platform will try to start your containers.
-In this file, you can define all the different process you would like to run in your
-project **from the same code base**. It is commonly used to define how to start workers which will consume
-asynchronous jobs.
+The **Procfile** is a simple text file specifying how the platform should start
+the Managed Runtime(s) of your application.
 
-A Procfile is a text file using the YAML format describing how to start
-each type of container for your app. It has to be located at the root of your project.
-Environment variables will be interpolated.
+It allows to declare the commands executed in the Managed Runtime(s) on
+startup.
+
+Each of these commands is associated to a **process type**, which is basically
+a name that uniquely identifies the type of process.
+
+You can define as many process types as you need for your application, **from
+the same code base**.
+
+Some common use cases for process types:
+- define a process type called `web` to start a process handling HTTP requests.
+- define a process type called `worker` to handle some asynchronous
+  computation.
+- define a `clock` process type to schedule some recurring jobs.
+- define a `console` process type to boot up [one-offs]({% post_url platform/app/2000-01-01-tasks %})
+  and interact with a database from the CLI.
+- ...
+
+When starting an application, Scalingo reads the Procfile and starts at least
+one Managed Runtime for each process type defined (unless it is scaled to 0).
+
+The process type also serves as a reference to manage the resources consumed by
+your application:
+- it allows to scale the Managed Runtime(s) of the specified process type.
+- it allows to use different plans for the Managed Runtimes, depending on the
+  workload they have to handle.
+
+Example:
+
+Let's say your application has a web frontend that handles HTTP requests and a
+worker that does some heavy computing. They both share the same code base, but
+they don't start the same way and they don't have the same computing power
+requirements. In such a case, you'd have to instruct the platform to start two
+process types, which must be defined in your project's Procfile:
+- one called `web`, to instruct the platform how to start your web server (the
+  frontend).
+- another one, called `worker`, to instruct the platform how to start your...
+  worker.
+
+The `web` process type could be set to use an `L` plan (which means the
+platform will run the corresponding command in an `L` Managed Runtime), whereas
+the `worker` process type could be set to use a `2XL` plan.
+
+Now, let's say that your single `worker` Managed Runtime is a bit under
+pressure. Using the process type, you can instruct the platform to boot up a
+few more Managed Runtimes to handle the load (in the command below, we tell the
+platform that we want three `2XL` Managed Runtimes for the `worker` process
+type):
+
+```bash
+scalingo --app my-app scale worker:3:2XL
+```
+
+### Special Process Types
+
+By default, Scalingo uses three process types: `web`, `tcp` and `postdeploy`.
+**These process types have specific use cases** and the platform will only use
+them for what they are designed.
+
+#### The `web` Process Type
+
+The `web` process type defines how to start and run the Managed Runtime
+handling HTTP requests.
+
+It's the only process type that can receive external HTTP requests from
+Scalingo's routers. Consequently, if your application has a web server, it MUST
+have a `web` process type binded on `$PORT` to be publicly reachable.
+
+The `web` process type is often the only one required.
+
+{% note %}
+Almost all our buildpacks define a default `web` process type so you don't have
+to care about it. If you don't need it, you can scale it to 0 to avoid unwanted
+costs.
+{% endnote %}
+
+#### The `tcp` Process Type
+
+The `tcp` process type defines how to start the
+[TCP Gateway addon]({% post_url addons/tcp-gateway/2000-01-01-start %}).
+
+#### The `postdeploy` Process Type
+
+The `postdeploy` process type defines how to start the
+[postdeploy hook]({% post_url platform/app/2000-01-01-postdeploy-hook %}).
+
+
+## Working With the Procfile
+
+### Procfile Naming Convention
+
+The Procfile is a plain text file that MUST be named `Procfile`. Even if it
+uses the YAML syntax, there is **no extension**: no `.txt`, no `.yaml`, no
+`.yml`. **Only `Procfile`**.
+
+The file MUST live in the application's root directory.
+
+### Defining a Process Type
+
+Each process type of the application is defined on its own, individual line,
+with the following format:
+
+```yaml
+<process_type>: <command>
+```
+
+- `<process_type>` designates the name of the process type. It can only contain
+  alphanumerics, dashes and underscores (`[A-Za-z0-9_-]+`). Except this rule,
+  you are free to name your process type how you want: `heavy_process`,
+  `synchronizer`, `scheduler`, `console`, `t-rex`... These are all examples of
+  valid process type names.
+- `<command>` designates the command to run when a Managed Runtime of the
+  specified type is booted up. It can be any Bash command. Using environment
+  variables in the command is allowed, and even encouraged.
+
+{% note %}
+`<process_type>` are unique in the `Procfile`. You cannot have, for example,
+two `web` process types. If you have, the platform will only consider the
+second one. The first one will be ignored, as if it did not exist.
+{% endnote %}
+
+Here is an example of a valid Procfile defining two process types:
+- one called `web`, defining how to start a Rails web server.
+- another one called `worker`, defining how to start a Managed Runtime running
+  Sidekiq.
+
+Notice the use of the environment variables:
 
 ```yaml
 web: bundle exec rails server -p $PORT -e $RAILS_ENV -b 0.0.0.0
 worker: bundle exec sidekiq -e $RAILS_ENV
 ```
 
-By default, when you first try to deploy your application, we'll try to
-launch the `web` process. We try to determine it without your help, but in
-some cases it is required to define it, as in the previous example. If your
-application requires a `Procfile` and you haven't defined it, your deployment
-will fail and a log entry will attest the lack of Procfile.
+#### Defining a Complex Process Type
 
-The standard syntax is:
+When you have more complex commands to run, don't hesitate to write a short
+start script, for instance in `bin/start.sh`:
 
-```yaml
-<container type>: <command>
-```
-where:
-
-- `<container type>` should contain letters and digits only.
-- `<command>` can be any Bash command. It can include environment variables.
-
-{% note %}
-`container type` are unique in the `Procfile`. So, you cannot have, for example, two `web` `container type`.
-If you have, only the second one will be executed, as if the first did not exist.
-If you want to run a command, you may want to look at [Post deploy](https://doc.scalingo.com/platform/app/postdeploy-hook).
-{% endnote %}
-
-When you have more complex commands to run, don't hesitate to write a short start script,
-for instance in `bin/start.sh`:
-
-```
+```bash
 #!/bin/bash
 
 if [ "$SOME_ENV" = "SOME_VALUE" ] ; then
@@ -60,63 +162,52 @@ else
 fi
 ```
 
-Then in your `Procfile`, directly call this script:
+Then, in your `Procfile`, call this script directly:
 
 ```
 web: bash bin/start.sh
 ```
 
-### Postdeploy Hook
+### Removing a Process Type
 
-The Procfile is also the place to declare a post-deploy hook. More information [here]({% post_url
-platform/app/2000-01-01-postdeploy-hook %}).
+Removing a process type from an application is done in 3 steps:
+1. First scale the process type to be removed to 0. You can do this with the
+   CLI or via the dashboard.
+2. Edit your Procfile and remove the corresponding line. For example, if you
+   want to remove the `scheduler` process type, locate the line starting with
+   `scheduler` and remove it entirely.
+3. Commit your changes and trigger a new deployment.
 
-You can use a custom script if you only want to run the post-deploy hook in some situations, in the
-following case if the variable `SOME_ENV` equals `SOME_VALUE`:
-
-```
-#!/bin/bash
-
-if [ "$SOME_ENV" = "SOME_VALUE" ] ; then
-  exec postdeploy_command -p $PORT
-else
-  echo "Postdeploy hook disabled"
-  exit 0
-fi
-```
-
-Then modify the `Procfile`:
-
-```
-postdeploy: bash bin/postdeploy.sh
-```
-
-### Removing a Container Type
-
-If you have two container types declared in your Procfile `web` and a `worker`:
-
-```yaml
-web: bundle exec rails server -p $PORT -e $RAILS_ENV -b 0.0.0.0
-worker: bundle exec sidekiq -e $RAILS_ENV
-```
-
-But you eventually want to remove the `worker` container type. You first need to scale down to 0 the `worker` container. Then remove the line starting with `worker` in your Procfile and trigger a new deployment.
-
-If you forget to scale down the amount of `worker` containers, you will see the following error message in your application logs:
+If you don't start by scaling down the process type you don't want anymore, you
+will encounter the following error message in your application logs:
 
 ```
 2022-01-26 10:46:17.855295004 +0000 UTC [worker-1] Task 'worker' has not been found in your 'Procfile'
 ```
 
-## Using in development
 
-To reduce the environment gap between the development and the production, it
-is important to execute the same processes in development and in any deployed
-environment.
+## Developing With a Procfile
 
-To achieve this different tools exist. The most famous is `foreman`. A little
-ruby `gem` executing and displaying the output of all the processes defined in your
-Procfile.
+To reduce the gap between the development and the production environments, it
+is important to execute the same processes in both environments.
+
+Several tools exist to fulfill this need:
+- [`foreman`](https://github.com/ddollar/foreman)
+- [`honcho`](https://github.com/nickstenning/honcho)
+- [`goreman`](https://github.com/mattn/goreman)
+- [`Overmind`](https://github.com/DarthSim/overmind)
+
+### Example Using `foreman`
+
+`foreman` is a Ruby `gem` executing and displaying the output of all the
+processes defined in your Procfile. You can install it with the following
+command:
+
+```bash
+gem install foreman
+```
+
+And use it like this:
 
 ```bash
 └> cat Procfile
@@ -130,10 +221,7 @@ worker: bin/project -worker
 17:52:56 worker.1 | 2014/12/01 17:52:56 Starting Asynchronous worker
 ```
 
-To install it: `gem install foreman`
+As you can see, `foreman` started a Runtime for each process type defined in
+the project's Procfile (one for the `web` process type and another one for the
+`worker` process type).
 
-Alternatives to foreman:
-
-* [honcho](https://github.com/nickstenning/honcho)
-* [goreman](https://github.com/mattn/goreman)
-* [Overmind](https://github.com/DarthSim/overmind)

--- a/src/_posts/platform/app/2000-01-01-procfile.md
+++ b/src/_posts/platform/app/2000-01-01-procfile.md
@@ -14,11 +14,27 @@ that makes Scalingo compatible with Heroku.
 The **Procfile** is a simple text file specifying how the platform should start
 the Managed Runtime(s) of your application.
 
-It allows to declare the commands executed in the Managed Runtime(s) on
-startup.
+More precisely, it allows to declare the commands executed in the Managed
+Runtime(s) on startup.
 
 Each of these commands is associated to a **process type**, which is basically
 a name that uniquely identifies the type of process.
+
+When the platform starts a Managed Runtime for your application, it uses the
+process type to know what command to execute in it, and it also marks the
+freshly booted Managed Runtime as being of the specified process type, thereby
+creating a kind of *link* between the Managed Runtime and its process type.
+
+Consequently:
+- a Managed Runtime belongs to exactly one process type.
+- a process type can reference zero, one or multiple Managed Runtimes,
+  depending on the scale factor.
+
+Since process types are referencing Managed Runtimes, they are also used to
+manage the resources consumed by your application:
+- they allow to add or remove Managed Runtime(s) of the specified process type.
+- they allow to set different plans for the Managed Runtimes, depending on the
+  workload they have to handle.
 
 You can define as many process types as you need for your application, **from
 the same code base**.
@@ -29,15 +45,6 @@ Some common use cases for process types:
   computation.
 - define a `clock` process type to schedule some recurring jobs.
 - ...
-
-When starting an application, Scalingo reads the Procfile and starts at least
-one Managed Runtime for each process type defined (unless it is scaled to 0).
-
-The process type also serves as a reference to manage the resources consumed by
-your application:
-- it allows to scale the Managed Runtime(s) of the specified process type.
-- it allows to use different plans for the Managed Runtimes, depending on the
-  workload they have to handle.
 
 Example:
 
@@ -79,17 +86,17 @@ handling HTTP requests.
 It's the only process type that can receive external HTTP requests from
 [Scalingo's routers]({% post_url platform/internals/2000-01-01-routing %}).
 Consequently, if your application has a web server, it MUST have a `web`
-process type binded on `$PORT` to be publicly reachable.
+process type bound to `$PORT` to be publicly reachable.
 
 The `web` process type is often the only one required.
 
 {% note %}
-- Almost all our buildpacks define a default `web` process type so you don't
-  have to care about it.
-- The `web` process type is the only one that Scalingo scales to 1 by default.
-  If you don't need it, (for example, if your application is a [web-less
-  application]({% post_url platform/app/2000-01-01-web-less-app %})) you can
-  scale it to 0 to avoid unwanted costs.
+- Almost all our [buildpacks]({% post_url platform/deployment/buildpacks/2000-01-01-intro %})
+  define a default `web` process type so you don't have to care about it.
+- The `web` process type is the only one that Scalingo scales to 1:M by
+  default. If you don't need it, (for example, if your application is a
+  [web-less application]({% post_url platform/app/2000-01-01-web-less-app %}))
+  you can scale it to 0 to avoid unwanted costs.
 {% endnote %}
 
 #### The `tcp` Process Type
@@ -172,18 +179,18 @@ web: bash bin/start.sh
 
 ### Starting and Stopping a Process Type
 
-When starting or stopping a process type, you concretly instructs the platform
+When starting or stopping a process type, you concretly instruct the platform
 to create (and start) or stop (and destroy) all the Managed Runtime(s)
 referenced by this process type. In fact, these operations are the same and
 consist in **scaling** the process type, which can be done via the dashbord or
 via the CLI.
 
-Unlike the `web` process type, which is scaled to 1 by default, all other
-process types are scaled to 0 by default and, hence, must be scaled to a
-value greater than 0 to be started by the platform. **Don't forget to scale
-your process type to at least 1 to start it!**
+All **new** process types are considered to be scaled to 0:M by default and,
+hence, must be scaled to a value greater than 0 to be started by the platform.
+The only exception is the `web` process type, which is scaled to 1:M by
+default. **Don't forget to scale your process type to at least 1 to start it!**
 
-Conversely, to stop a specific process type, scale it to zero. All existing
+Conversely, to stop a specific process type, scale it to 0. All existing
 Managed Runtime(s) in charge of this specific type of process will be
 stopped and destroyed by the platform.
 

--- a/src/_posts/platform/app/2000-01-01-procfile.md
+++ b/src/_posts/platform/app/2000-01-01-procfile.md
@@ -28,8 +28,6 @@ Some common use cases for process types:
 - define a process type called `worker` to handle some asynchronous
   computation.
 - define a `clock` process type to schedule some recurring jobs.
-- define a `console` process type to boot up [one-offs]({% post_url platform/app/2000-01-01-tasks %})
-  and interact with a database from the CLI.
 - ...
 
 When starting an application, Scalingo reads the Procfile and starts at least
@@ -71,23 +69,27 @@ scalingo --app my-app scale worker:3:2XL
 
 By default, Scalingo uses three process types: `web`, `tcp` and `postdeploy`.
 **These process types have specific use cases** and the platform will only use
-them for what they are designed.
+them for what they are designed for.
 
 #### The `web` Process Type
 
-The `web` process type defines how to start and run the Managed Runtime
+The `web` process type defines how to start and run the Managed Runtime(s)
 handling HTTP requests.
 
 It's the only process type that can receive external HTTP requests from
-Scalingo's routers. Consequently, if your application has a web server, it MUST
-have a `web` process type binded on `$PORT` to be publicly reachable.
+[Scalingo's routers]({% post_url platform/internals/2000-01-01-routing %}).
+Consequently, if your application has a web server, it MUST have a `web`
+process type binded on `$PORT` to be publicly reachable.
 
 The `web` process type is often the only one required.
 
 {% note %}
-Almost all our buildpacks define a default `web` process type so you don't have
-to care about it. If you don't need it, you can scale it to 0 to avoid unwanted
-costs.
+- Almost all our buildpacks define a default `web` process type so you don't
+  have to care about it.
+- The `web` process type is the only one that Scalingo scales to 1 by default.
+  If you don't need it, (for example, if your application is a [web-less
+  application]({% post_url platform/app/2000-01-01-web-less-app %})) you can
+  scale it to 0 to avoid unwanted costs.
 {% endnote %}
 
 #### The `tcp` Process Type
@@ -130,9 +132,9 @@ with the following format:
   variables in the command is allowed, and even encouraged.
 
 {% note %}
-`<process_type>` are unique in the `Procfile`. You cannot have, for example,
-two `web` process types. If you have, the platform will only consider the
-second one. The first one will be ignored, as if it did not exist.
+`<process_type>` must be unique in the Procfile. You cannot have, for example,
+two `web` process types. This would result in an undefined behavior, and is
+consequently strongly discouraged.
 {% endnote %}
 
 Here is an example of a valid Procfile defining two process types:
@@ -167,6 +169,23 @@ Then, in your `Procfile`, call this script directly:
 ```
 web: bash bin/start.sh
 ```
+
+### Starting and Stopping a Process Type
+
+When starting or stopping a process type, you concretly instructs the platform
+to create (and start) or stop (and destroy) all the Managed Runtime(s)
+referenced by this process type. In fact, these operations are the same and
+consist in **scaling** the process type, which can be done via the dashbord or
+via the CLI.
+
+Unlike the `web` process type, which is scaled to 1 by default, all other
+process types are scaled to 0 by default and, hence, must be scaled to a
+value greater than 0 to be started by the platform. **Don't forget to scale
+your process type to at least 1 to start it!**
+
+Conversely, to stop a specific process type, scale it to zero. All existing
+Managed Runtime(s) in charge of this specific type of process will be
+stopped and destroyed by the platform.
 
 ### Removing a Process Type
 

--- a/src/_posts/platform/app/2000-01-01-procfile.md
+++ b/src/_posts/platform/app/2000-01-01-procfile.md
@@ -12,28 +12,28 @@ that makes Scalingo compatible with Heroku.
 ## About the Procfile
 
 The **Procfile** is a simple text file specifying how the platform should start
-the Managed Runtime(s) of your application.
+your application's container(s).
 
-More precisely, it allows to declare the commands executed in the Managed
-Runtime(s) on startup.
+More precisely, it allows to declare the commands executed in the container(s)
+on startup.
 
 Each of these commands is associated to a **process type**, which is basically
 a name that uniquely identifies the type of process.
 
-When the platform starts a Managed Runtime for your application, it uses the
-process type to know what command to execute in it, and it also marks the
-freshly booted Managed Runtime as being of the specified process type, thereby
-creating a kind of *link* between the Managed Runtime and its process type.
+When the platform starts a container for your application, it uses the process
+type to know what command to execute in it, and it also marks the freshly
+booted container as being of the specified process type, thereby creating a
+kind of *link* between the container and its process type.
 
 Consequently:
-- a Managed Runtime belongs to exactly one process type.
-- a process type can reference zero, one or multiple Managed Runtimes,
-  depending on the scale factor.
+- a container belongs to exactly one process type.
+- a process type can reference zero, one or multiple containers, depending on
+  the scale factor.
 
-Since process types are referencing Managed Runtimes, they are also used to
-manage the resources consumed by your application:
-- they allow to add or remove Managed Runtime(s) of the specified process type.
-- they allow to set different plans for the Managed Runtimes, depending on the
+Since process types are referencing containers, they are also used to manage
+the resources consumed by your application:
+- they allow to add or remove container(s) of the specified process type.
+- they allow to set different plans for the containers, depending on the
   workload they have to handle.
 
 You can define as many process types as you need for your application, **from
@@ -59,14 +59,13 @@ process types, which must be defined in your project's Procfile:
   worker.
 
 The `web` process type could be set to use an `L` plan (which means the
-platform will run the corresponding command in an `L` Managed Runtime), whereas
+platform will run the corresponding command in an `L` container), whereas
 the `worker` process type could be set to use a `2XL` plan.
 
-Now, let's say that your single `worker` Managed Runtime is a bit under
-pressure. Using the process type, you can instruct the platform to boot up a
-few more Managed Runtimes to handle the load (in the command below, we tell the
-platform that we want three `2XL` Managed Runtimes for the `worker` process
-type):
+Now, let's say that your single `worker` container is a bit under pressure.
+Using the process type, you can instruct the platform to boot up a few more
+containers to handle the load (in the command below, we tell the platform that
+we want three `2XL` containers for the `worker` process type):
 
 ```bash
 scalingo --app my-app scale worker:3:2XL
@@ -80,8 +79,8 @@ use them for what they are designed for.
 
 #### The `web` Process Type
 
-The `web` process type defines how to start and run the Managed Runtime(s)
-handling HTTP requests.
+The `web` process type defines how to start and run the container(s) handling
+HTTP requests.
 
 It's the only process type that can receive external HTTP requests from
 [Scalingo's routers]({% post_url platform/internals/2000-01-01-routing %}).
@@ -134,9 +133,9 @@ with the following format:
   alphanumerics (`[A-Za-z0-9]+`). Except this rule, you are free to name your
   process type how you want: `heavyProcess`, `synchronizer`, `scheduler`,
   `console`, `trex`... These are all examples of valid process type names.
-- `<command>` designates the command to run when a Managed Runtime of the
-  specified type is booted up. It can be any Bash command. Using environment
-  variables in the command is allowed, and even encouraged.
+- `<command>` designates the command to run when a container of the specified
+  type is booted up. It can be any Bash command. Using environment variables in
+  the command is allowed, and even encouraged.
 
 {% note %}
 `<process_type>` must be unique in the Procfile. You cannot have, for example,
@@ -146,7 +145,7 @@ consequently strongly discouraged.
 
 Here is an example of a valid Procfile defining two process types:
 - one called `web`, defining how to start a Rails web server.
-- another one called `worker`, defining how to start a Managed Runtime running
+- another one called `worker`, defining how to start a container running
   Sidekiq.
 
 Notice the use of the environment variables:
@@ -180,10 +179,10 @@ web: bash bin/start.sh
 ### Starting and Stopping a Process Type
 
 When starting or stopping a process type, you concretly instruct the platform
-to create (and start) or stop (and destroy) all the Managed Runtime(s)
-referenced by this process type. In fact, these operations are the same and
-consist in **scaling** the process type, which can be done via the dashbord or
-via the CLI.
+to create (and start) or stop (and destroy) all the container(s) referenced by
+this process type. In fact, these operations are the same and consist in
+**scaling** the process type, which can be done via the dashbord or via the
+CLI.
 
 All **new** process types are considered to be scaled to 0:M by default and,
 hence, must be scaled to a value greater than 0 to be started by the platform.
@@ -191,8 +190,8 @@ The only exception is the `web` process type, which is scaled to 1:M by
 default. **Don't forget to scale your process type to at least 1 to start it!**
 
 Conversely, to stop a specific process type, scale it to 0. All existing
-Managed Runtime(s) in charge of this specific type of process will be
-stopped and destroyed by the platform.
+container(s) in charge of this specific type of process will be stopped and
+destroyed by the platform.
 
 ### Removing a Process Type
 
@@ -247,7 +246,7 @@ worker: bin/project -worker
 17:52:56 worker.1 | 2014/12/01 17:52:56 Starting Asynchronous worker
 ```
 
-As you can see, `foreman` started a Runtime for each process type defined in
+As you can see, `foreman` started a container for each process type defined in
 the project's Procfile (one for the `web` process type and another one for the
 `worker` process type).
 


### PR DESCRIPTION
Here is a suggestion for an almost complete rewrite of the Procfile documentation page.

- the content has been reorganized.
- explanations about "process type" have been added.
- explanations about Procfile have been added.
- references to "container" have been removed in favor of "Managed Runtime".
- ...

(When I first had to work with a Procfile, a lot of questions popped in my head. I think this would have answered them.)

Tested locally.