### PR TITLE
Added GIT_FETCH_EXTRA_FLAGS variable

### DIFF
--- a/src/_posts/platform/deployment/2000-01-01-deploy-with-git.md
+++ b/src/_posts/platform/deployment/2000-01-01-deploy-with-git.md
@@ -1,6 +1,6 @@
 ---
 title: Deploy with Git
-modified_at: 2023-02-13 00:00:00
+modified_at: 2023-03-13 00:00:00
 tags: git deployment
 index: 4
 ---
@@ -157,6 +157,7 @@ the parameter `depth` from configuration file.
   ```yml
   # .gitlab-ci.yml
   variables:
+    GIT_FETCH_EXTRA_FLAGS: --unshallow
     GIT_DEPTH: 0
   ```
 


### PR DESCRIPTION
Still head the Shallow Error with the `GIT_DEPTH` variable in our case. Found this issue and it worked with `GIT_FETCH_EXTRA_FLAGS: --unshallow` https://gitlab.com/gitlab-org/gitlab/-/issues/292470

Maybe consider adding it.