### PR TITLE
docs(changelog): Go 1.20.0

### DIFF
--- a/src/_posts/languages/go/2000-01-01-start.md
+++ b/src/_posts/languages/go/2000-01-01-start.md
@@ -1,7 +1,7 @@
 ---
 title: Go
 nav: Introduction
-modified_at: 2022-12-13 00:00:00
+modified_at: 2023-03-13 00:00:00
 tags: go
 index: 1
 ---
@@ -14,8 +14,9 @@ The Go programming language is supported.
 
 #### Officially Supported
 
-* `go1.19.3`
-* `go1.18.8`
+* `go1.20.0`
+* `go1.19.5`
+* `go1.18.10`
 * `go1.17.13`
 * `go1.16.15`
 * `go1.15.15`

--- a/src/changelog/buildpacks/_posts/2023-03-13-go-1.20.0.md
+++ b/src/changelog/buildpacks/_posts/2023-03-13-go-1.20.0.md
@@ -1,0 +1,9 @@
+---
+modified_at: 2023-03-13 18:00:00
+title: 'Go - New Versions: 1.20.0, 1.19.5 and 1.18.10'
+github: 'https://github.com/Scalingo/go-buildpack'
+---
+
+* Go 1.20.0 [changelog](https://go.dev/doc/devel/release#go1.20)
+* Go 1.19.5 [changelog](https://go.dev/doc/devel/release#go1.19)
+* Go 1.18.10 [changelog](https://go.dev/doc/devel/release#go1.18)


### PR DESCRIPTION
Tweet:

> [Changelog] Buildpacks - Go - Support of Go 1.20.0, 1.19.5 and 1.18.10 [https://changelog.scalingo.com](https://changelog.scalingo.com/) #golang #changelog #PaaS