### PR TITLE
fix: rewrite the Application Crash doc

### DIFF
--- a/src/_posts/platform/app/2000-01-01-crash.md
+++ b/src/_posts/platform/app/2000-01-01-crash.md
@@ -36,7 +36,7 @@ There are 3 kinds of Boot Errors:
 
 The **Start Error** is the default kind of Boot Error. It is thrown as soon as
 an unmanaged error is detected and caught by the platform. It can occur at any
-moment, as long as your deployment isn't *running* yet.
+moment, as long as your app isn't *running* yet.
 
 A Start Error makes the deployment fail instantly.
 

--- a/src/_posts/platform/app/2000-01-01-crash.md
+++ b/src/_posts/platform/app/2000-01-01-crash.md
@@ -215,6 +215,7 @@ By default, the platform only notifies the application's collaborator(s) when
 a recurrent crash occurs (i.e. when an early Runtime Error keeps occuring, or
 when a Timeout Error occurs).
 
-You can modify this behavior by tweaking your [Notifier's configuration]({% post_url platform/app/2000-01-01_notification %}).
+You can modify this behavior by tweaking your
+[Notifier's configuration]({% post_url platform/app/2000-01-01-notification %}).
 The *app_crashed*, *app_crashed_repeated* and the *app_deploy* events can be
 particularily worth considering.

--- a/src/_posts/platform/app/2000-01-01-crash.md
+++ b/src/_posts/platform/app/2000-01-01-crash.md
@@ -86,7 +86,7 @@ You may need to edit your
 requirements.
 
 If your application doesn't need a `web` or `tcp` process type, make sure to
-scale the unnecessary process type to zero.
+[scale the unnecessary process type to zero]({% post_url platform/app/2000-01-01-web-less-app %}#deploy-a-web-less-application).
 
 ### Understanding Hook Errors
 

--- a/src/_posts/platform/app/2000-01-01-crash.md
+++ b/src/_posts/platform/app/2000-01-01-crash.md
@@ -165,9 +165,9 @@ migrating to production.
 ### Recovering from a Runtime Error
 
 When a Runtime Error occurs and leads to an application crash, the platform
-automatically takes some actions to try to recover from it. The very first
-action consists in logging the crash event in your dashboard. Once done, the
-platform uses its restart policy, described hereafter:
+automatically takes some remedial measures to try to recover from it. The very
+first action consists in logging the crash event in your dashboard. Once done,
+the platform uses its restart policy, described hereafter:
 
 The platform maintains a crash counter for each running container. This crash
 counter is set to zero by default.
@@ -177,7 +177,7 @@ zero), the platform sets the crash counter to one and then tries to restart the
 container. This is done as soon as the failure is detected.
 
 After a successful restart, the container enters a *warmup* period which always
-lasts 5 minutes. From here, we distinguish two main cases:
+lasts 10 minutes. From here, we distinguish two main cases:
 
 1. The container successfully passes the *warmup* period. In this case, the
    platform considers that the restart operation fixed the issue and thus
@@ -208,3 +208,13 @@ Besides the measures taken by the platform, we strongly advise you to carefully
 investigate the logs of your crashing application as soon as possible. Once
 your fix is ready, push your updated code to Scalingo to trigger a new
 deployment.
+
+## Getting Notified When a Crash Occurs
+
+By default, the platform only notifies the application's collaborator(s) when
+a recurrent crash occurs (i.e. when an early Runtime Error keeps occuring, or
+when a Timeout Error occurs).
+
+You can modify this behavior by tweaking your [Notifier's configuration]({% post_url platform/app/2000-01-01_notification %}).
+The *app_crashed*, *app_crashed_repeated* and the *app_deploy* events can be
+particularily worth considering.

--- a/src/_posts/platform/app/2000-01-01-crash.md
+++ b/src/_posts/platform/app/2000-01-01-crash.md
@@ -1,6 +1,6 @@
 ---
 title: Application Crash
-modified_at: 2023-03-31 00:00:00
+modified_at: 2023-05-17 00:00:00
 tags: app crash recovery
 index: 12
 ---
@@ -8,35 +8,39 @@ index: 12
 When the platform starts your container(s) (be it after a successful build,
 after a scale operation or after a restart operation), your application enters
 the *run* phase of its [lifespan]({% post_url platform/internals/2000-01-01-container-management %}).
-Unfortunately, bad things may happen during this phase. Depending on the
-circumstances, these *things* can lead your application to crash, or even to be
-totally unavailable.
+Unfortunately, bad things may still happen during this phase, which can lead
+your application to crash.
 
 Various reasons can explain why your application's lifespan ends up shortened.
 At Scalingo, we distinguish two main kinds of crash:
-- **[Boot Errors](#understanding-boot-errors)** and
-- **[Runtime Errors](#understanding-runtime-errors)**.
+**[Boot Errors](#understanding-boot-errors)** and
+**[Runtime Errors](#understanding-runtime-errors)**.
 
 
 ## Understanding Boot Errors
 
 **Boot Errors** can only occur when your container is still in its *starting*
-state, **before** entering its *running* state. At this moment, your deployment
-is still ongoing and the platform doesn't consider your application as
-*running* yet.
+state, **before** entering its *running* state. At this moment, your build is
+successful, but your deployment is still ongoing and the platform doesn't
+consider your application as *running* yet.
 
 These errors are thrown by the platform when it detects that your application
 doesn't behave as expected.
 
+There are 3 kinds of Boot Errors:
+[Start Errors](#understanding-start-errors),
+[Timeout Errors](#understanding-timeout-errors) and
+[Hook Errors](#understanding-hook-errors).
+
 ### Understanding Start Errors
 
-The **Start Error** is the default kind of Boot Errors. It is thrown as soon as
+The **Start Error** is the default kind of Boot Error. It is thrown as soon as
 an unmanaged error is detected and caught by the platform. It can occur at any
 moment, as long as your deployment isn't *running* yet.
 
 A Start Error makes the deployment fail instantly.
 
-In most cases, Start Error are caused by a misconfiguration of your
+In most cases, a Start Error is caused by a misconfiguration of your
 application, or by some unmanaged error/exception in your application's code.
 
 #### Fixing Start Errors
@@ -46,24 +50,23 @@ deployment logs should help you identify the issue.
 
 ### Understanding Timeout Errors
 
-If your application has a [`web` or a `tcp` process type]({% post_url platform/app/2000-01-01-procfile %}#special-process-types),
-the process **MUST** bind to the provided network port (`PORT` environment
-variable) within a delay of 60 seconds. After this deadline, the platform
-considers the application has being unreachable and throws a **Timeout Error**,
-causing the deployment to fail.
+When your application has a [`web` or a `tcp` process type]({% post_url platform/app/2000-01-01-procfile %}#special-process-types),
+the process started in the corresponding container(s) **MUST** bind to the
+provided network port (`PORT` environment variable) within a delay of 60
+seconds. After this deadline, the platform considers the application has being
+unreachable and throws a **Timeout Error**, causing the deployment to fail.
 
 - If this situation arises after a restart or a scale operation, the platform
   automatically retries to start your container(s). After 20 unsuccessful
-  attempts (with an exponential backoff strategy), the platform gives up and
-  sends an e-mail to the application's collaborators. Note that your existing
-  containers keep running during this time and after.
+  attempts (with an exponential backoff strategy), the platform gives up.
+  Note that your existing containers keep running during this time and after.
 
 - If you are trying to deploy a new version of an already running application,
   this new deployment is considered a failure but the previous version of your
   application keeps running.
 
-- Conversely, if this is a first deployment, the platform does not make any
-  attempt to recover from the error. The deployment fails with a
+- Conversely, if this is a very first deployment, the platform does not make
+  any attempt to recover from the error. The deployment fails with a
   **timeout-error** status, letting you know that your application didn't
   bind to `PORT` soon enough.
 
@@ -179,7 +182,7 @@ container. This is done as soon as the failure is detected.
 After a successful restart, the container enters a *warmup* period which always
 lasts 10 minutes. From here, we distinguish two main cases:
 
-1. The container successfully passes the *warmup* period. In this case, the
+1. The container successfully goes past the *warmup* period. In this case, the
    platform considers that the restart operation fixed the issue and thus
    resets the container's crash counter to zero.
 
@@ -196,18 +199,12 @@ lasts 10 minutes. From here, we distinguish two main cases:
      is crashed and won't be restarted anymore, which mean your application
      may now be totally unavailable.
 
-{% note %}
-  If the container doesn't crash during the first 5 minutes of running, the
-  crash counter is reset to zero, which means an hypothetical future crash
-  would trigger an instant restart of the container.
-{% endnote %}
-
 #### Fixing Runtime Errors
 
 Besides the measures taken by the platform, we strongly advise you to carefully
 investigate the logs of your crashing application as soon as possible. Once
 your fix is ready, push your updated code to Scalingo to trigger a new
-deployment.
+deployment, hopefully resolving the issue.
 
 ## Getting Notified When a Crash Occurs
 

--- a/src/_posts/platform/app/2000-01-01-crash.md
+++ b/src/_posts/platform/app/2000-01-01-crash.md
@@ -1,6 +1,6 @@
 ---
 title: Application Crash
-modified_at: 2023-05-17 00:00:00
+modified_at: 2023-05-23 00:00:00
 tags: app crash recovery
 index: 12
 ---
@@ -20,9 +20,7 @@ At Scalingo, we distinguish two main kinds of crash:
 ## Understanding Boot Errors
 
 **Boot Errors** can only occur when your container is still in its *starting*
-state, **before** entering its *running* state. At this moment, your build is
-successful, but your deployment is still ongoing and the platform doesn't
-consider your application as *running* yet.
+state, **before** entering its *running* state.
 
 These errors are thrown by the platform when it detects that your application
 doesn't behave as expected.
@@ -96,7 +94,8 @@ If your application has a [`postdeploy` process type]({% post_url platform/app/2
 the platform can throw a **Hook Error** if the post-deployment process fails.
 
 - In such a case, the deployment fails with a **hook-error** status.
-- If your application is already running, it keeps running.
+- If your application is already running, its code isn't updated and the former
+  version keeps running.
 
 {% note %}
   Hook Errors can only occur if you have a `postdeploy` process type.

--- a/src/_posts/platform/app/2000-01-01-crash.md
+++ b/src/_posts/platform/app/2000-01-01-crash.md
@@ -213,5 +213,5 @@ when a Timeout Error occurs).
 
 You can modify this behavior by tweaking your
 [Notifier's configuration]({% post_url platform/app/2000-01-01-notification %}).
-The *app_crashed*, *app_crashed_repeated* and the *app_deploy* events can be
+The `app_crashed`, `app_crashed_repeated` and the `app_deploy` events can be
 particularily worth considering.

--- a/src/_posts/platform/app/2000-01-01-crash.md
+++ b/src/_posts/platform/app/2000-01-01-crash.md
@@ -195,7 +195,7 @@ lasts 10 minutes. From here, we distinguish two main cases:
      e-mail to the application's collaborators.
    - If the crash counter value reaches 13, which means the container keeps
      crashing after 12 delayed restarts, the platform gives up. The container
-     is crashed and won't be restarted anymore, which mean your application
+     is crashed and won't be restarted anymore, which means your application
      may now be totally unavailable.
 
 #### Fixing Runtime Errors

--- a/src/_posts/platform/app/2000-01-01-crash.md
+++ b/src/_posts/platform/app/2000-01-01-crash.md
@@ -1,6 +1,6 @@
 ---
 title: Application Crash
-modified_at: 2023-05-23 00:00:00
+modified_at: 2023-05-24 00:00:00
 tags: app crash recovery
 index: 12
 ---
@@ -36,7 +36,8 @@ The **Start Error** is the default kind of Boot Error. It is thrown as soon as
 an unmanaged error is detected and caught by the platform. It can occur at any
 moment, as long as your app isn't *running* yet.
 
-A Start Error makes the deployment fail instantly.
+A Start Error makes the deployment fail instantly. Note that the former version
+of your application (if any), keeps running.
 
 In most cases, a Start Error is caused by a misconfiguration of your
 application, or by some unmanaged error/exception in your application's code.
@@ -105,8 +106,8 @@ the platform can throw a **Hook Error** if the post-deployment process fails.
 
 Hook Errors are generally caused by an error in your codebase or by some
 misconfiguration. To recover from it, we first advise to investigate the logs
-of your failed deployment to understand the root cause. After fixing it,
-trigger a new deployment by pushing your updated code to Scalingo.
+of your application to understand the root cause. After fixing it, trigger a
+new deployment by pushing your updated code to Scalingo.
 
 
 ## Understanding Runtime Errors
@@ -138,7 +139,7 @@ error and the impact it has on your application:
   a significant impact on business operations.
 - Data loss, or Corrupt Data: losing strategic data can have serious
   consequences for your organization or for your users/customers, especially in
-  an HDS context.
+  an [HDS context]({% post_url compliance/2000-01-01-hds %}).
 - Security Risks: runtime errors can sometimes introduce security risks,
   especially if your application is too verbose. This can lead to sensitive
   data leak and further exploitation.

--- a/src/_posts/platform/app/2000-01-01-crash.md
+++ b/src/_posts/platform/app/2000-01-01-crash.md
@@ -1,69 +1,210 @@
 ---
 title: Application Crash
-modified_at: 2016-10-06 00:00:00
+modified_at: 2023-03-31 00:00:00
 tags: app crash recovery
 index: 12
 ---
 
-For various reasons your application can terminate abruptly. Two cases of crash may happen:
+When the platform starts your container(s) (be it after a successful build,
+after a scale operation or after a restart operation), your application enters
+the *run* phase of its [lifespan]({% post_url platform/internals/2000-01-01-container-management %}).
+Unfortunately, bad things may happen during this phase. Depending on the
+circumstances, these *things* can lead your application to crash, or even to be
+totally unavailable.
 
-## Boot errors
+Various reasons can explain why your application's lifespan ends up shortened.
+At Scalingo, we distinguish two main kinds of crash:
+- **[Boot Errors](#understanding-boot-errors)** and
+- **[Runtime Errors](#understanding-runtime-errors)**.
 
-They are detected directly when you deploy your application, if it crashes
-before binding the allocated network port, your deployment fails.
+
+## Understanding Boot Errors
+
+**Boot Errors** can only occur when your container is still in its *starting*
+state, **before** entering its *running* state. At this moment, your deployment
+is still ongoing and the platform doesn't consider your application as
+*running* yet.
+
+These errors are thrown by the platform when it detects that your application
+doesn't behave as expected.
+
+### Understanding Start Errors
+
+The **Start Error** is the default kind of Boot Errors. It is thrown as soon as
+an unmanaged error is detected and caught by the platform. It can occur at any
+moment, as long as your deployment isn't *running* yet.
+
+A Start Error makes the deployment fail instantly.
+
+In most cases, Start Error are caused by a misconfiguration of your
+application, or by some unmanaged error/exception in your application's code.
+
+#### Fixing Start Errors
+
+It's very likely that an action on your side is required to fix the issue. The
+deployment logs should help you identify the issue.
+
+### Understanding Timeout Errors
+
+If your application has a [`web` or a `tcp` process type]({% post_url platform/app/2000-01-01-procfile %}#special-process-types),
+the process **MUST** bind to the provided network port (`PORT` environment
+variable) within a delay of 60 seconds. After this deadline, the platform
+considers the application has being unreachable and throws a **Timeout Error**,
+causing the deployment to fail.
+
+- If this situation arises after a restart or a scale operation, the platform
+  automatically retries to start your container(s). After 20 unsuccessful
+  attempts (with an exponential backoff strategy), the platform gives up and
+  sends an e-mail to the application's collaborators. Note that your existing
+  containers keep running during this time and after.
+
+- If you are trying to deploy a new version of an already running application,
+  this new deployment is considered a failure but the previous version of your
+  application keeps running.
+
+- Conversely, if this is a first deployment, the platform does not make any
+  attempt to recover from the error. The deployment fails with a
+  **timeout-error** status, letting you know that your application didn't
+  bind to `PORT` soon enough.
 
 {% note %}
-  The former version of your application __keeps running__.
+  A Timeout Error can only occur if you have a `web` or a `tcp` process type,
+  which is very likely.
 {% endnote %}
 
-## Runtime crashes
+#### Fixing Timeout Errors
 
-Two situations are the most common causes of runtime crashes:
+To fix a Timeout Error, make sure:
+- to bind to the provided network port, by using the `PORT` environment
+  variable.
+- to listen on `0.0.0.0` and not on `127.0.0.1`.
+- that your application is starting quickly enough.
 
-* Runtime error of your application (uncaught exception, segfault of a library/runtime)
-* Temporary error of an external resource
+You may need to edit your
+[Procfile]({% post_url platform/app/2000-01-01-procfile %}) to fulfill these
+requirements.
 
-## Restart policy
+If your application doesn't need a `web` or `tcp` process type, make sure to
+scale the unnecessary process type to zero.
 
-When a runtime crash occurred we automatically restart your container. If your application
-stopped again in the 5 minutes after being restarted, we won't restart it directly, but
-5 minutes later.
+### Understanding Hook Errors
+
+If your application has a [`postdeploy` process type]({% post_url platform/app/2000-01-01-procfile %}#special-process-types),
+the platform can throw a **Hook Error** if the post-deployment process fails.
+
+- In such a case, the deployment fails with a **hook-error** status.
+- If your application is already running, it keeps running.
 
 {% note %}
-  <ul>
-    <li>5 additional minutes are added after each crash in the 5 first minutes of runtime.</li>
-    <li>A crash which occures after 5 minutes has no effect on the cool down</li>
-  </ul>
-  <p>
-    This limitation has been setup in order to avoid the situation when an
-    application try to boot and crashes immediately.
-  </p>
+  Hook Errors can only occur if you have a `postdeploy` process type.
 {% endnote %}
 
-A limit of __12__ restart operations exist. It means that after 6 hours and 30 minutes,
-your application __will not be accessible anymore__ (The last cool-off duration is 1 hour).
+#### Fixing Hook Errors
 
-## How do I know my app has crashed?
+Hook Errors are generally caused by an error in your codebase or by some
+misconfiguration. To recover from it, we first advise to investigate the logs
+of your failed deployment to understand the root cause. After fixing it,
+trigger a new deployment by pushing your updated code to Scalingo.
 
-When such an event occurred, you'll receive notifications, as well as your collaborators for the concerned application. You'll receive a notification after the 2nd, 5th and 12th crashes (following the restart policy detailed previously).
 
-It means that if your app crashed once for a temporary reason, it will be automatically restarted. If it does not crash anymore, you will not receive an email. But if it crashes in a loop, you'll get a notification in the minute.
+## Understanding Runtime Errors
 
-You'll also find the 'crash' events in your app timeline on the dashboard.
+**Runtime Errors** are errors that happen during the execution of the process.
+Per definition, they can only occur when your container has reached its
+*running* state (which means your deployment is considered successful by the
+platform).
 
-## What to do?
+Unfortunately, and even if it has reached this state, unexpected errors can
+still lead your application to crash.
 
-We strongly advise you to look at the logs of your application using the web
-dashboard or by using the [CLI tool](http://cli.scalingo.com).
+The most common causes are:
 
-According to the information gathered, you should then modify your application to
-fix the issues which lead to this instability.
+- Incompatible dependencies
+- Segfault of a library/runtime
+- Configuration issues
+- Bugs in your application code
+- Uncaught exception in your code (especially with non-compiled languages)
+- Unsufficient resources
+- Temporary error/unavailability of an external resource
+
+A Runtime Error can have several consequences, depending on the severity of the
+error and the impact it has on your application:
+
+- Reduced Performances: slow response time typically result in poor user
+  experience.
+- Downtime: the unavailability of your application, even if temporary, can have
+  a significant impact on business operations.
+- Data loss, or Corrupt Data: losing strategic data can have serious
+  consequences for your organization or for your users/customers, especially in
+  an HDS context.
+- Security Risks: runtime errors can sometimes introduce security risks,
+  especially if your application is too verbose. This can lead to sensitive
+  data leak and further exploitation.
+
+### Mitigating and Preventing Runtime Errors
+
+The very first step to take to mitigate the consequences of a Runtime Error is
+to ensure that you have regular, tested backups (for databases, this feature is
+included in all our *business* plans) and to setup some
+[redundancy]({% post_url platform/app/2000-01-01-scaling %}#redundancy).
+
+Additionally, we generally advise to have a disaster recovery plan in place.
+This plan should ideally outline the actions to be taken in the event of such a
+failure. It may include procedures and step by step guides to identify and
+resolve the encountered error.
+
+We also recommend to regularly check the application's health. This can be
+done by checking the metrics, analyzing the logs, or setting up automated
+anomaly detection. The goal is to identify and fix potential issues before they
+occur.
+
+Finally, we strongly encourage developers to test their code, to follow the
+best practices and to conduct Q/A testings in a dedicated environment before
+migrating to production.
+
+### Recovering from a Runtime Error
+
+When a Runtime Error occurs and leads to an application crash, the platform
+automatically takes some actions to try to recover from it. The very first
+action consists in logging the crash event in your dashboard. Once done, the
+platform uses its restart policy, described hereafter:
+
+The platform maintains a crash counter for each running container. This crash
+counter is set to zero by default.
+
+When a container crashes for the first time (when its crash counter equals
+zero), the platform sets the crash counter to one and then tries to restart the
+container. This is done as soon as the failure is detected.
+
+After a successful restart, the container enters a *warmup* period which always
+lasts 5 minutes. From here, we distinguish two main cases:
+
+1. The container successfully passes the *warmup* period. In this case, the
+   platform considers that the restart operation fixed the issue and thus
+   resets the container's crash counter to zero.
+
+2. The container crashes again during the *warmup* period. In this case, the
+   platform immediately increments the crash counter by one.
+   - If the crash counter value is less than 13, then the platform waits some
+     time before restarting the container again. The duration of the waiting
+     period is given by the following formula:
+     `duration (minutes) = (crash counter value - 2) x 5`
+   - It the crash counter value equals 2, 5 or 12, the platform sends a warning
+     e-mail to the application's collaborators.
+   - If the crash counter value reaches 13, which means the container keeps
+     crashing after 12 delayed restarts, the platform gives up. The container
+     is crashed and won't be restarted anymore, which mean your application
+     may now be totally unavailable.
 
 {% note %}
-  After a successful deployment, a manual restart, or scaling of your application, we
-  cancel any queued restart job, and the cool down time after the next crash is resetted.
+  If the container doesn't crash during the first 5 minutes of running, the
+  crash counter is reset to zero, which means an hypothetical future crash
+  would trigger an instant restart of the container.
 {% endnote %}
 
-## Need support?
+#### Fixing Runtime Errors
 
-Don't hesitate to contact us at [support@scalingo.com](mailto:support@scalingo.com).
+Besides the measures taken by the platform, we strongly advise you to carefully
+investigate the logs of your crashing application as soon as possible. Once
+your fix is ready, push your updated code to Scalingo to trigger a new
+deployment.

--- a/src/_posts/platform/app/2000-01-01-crash.md
+++ b/src/_posts/platform/app/2000-01-01-crash.md
@@ -191,7 +191,7 @@ lasts 10 minutes. From here, we distinguish two main cases:
      time before restarting the container again. The duration of the waiting
      period is given by the following formula:
      `duration (minutes) = (crash counter value - 2) x 5`
-   - It the crash counter value equals 2, 5 or 12, the platform sends a warning
+   - If the crash counter value equals 2, 5 or 12, the platform sends a warning
      e-mail to the application's collaborators.
    - If the crash counter value reaches 13, which means the container keeps
      crashing after 12 delayed restarts, the platform gives up. The container


### PR DESCRIPTION
This is a complete rewrite of the "Application Crash" documentation page: the content has been completed, reorganized, rephrased, ... I tried to keep it precise, concise and consistent.
IMHO this was required (the last update dated back to 2016!)

Despite my efforts, there are likely (unwanted) errors, vocabulary mistakes, and such. Please read it carefully and don't hesitate to correct things :)

It also leads to some questions and possible adjustments, hence the PR being in draft mode.
I put these in comments below, so we can handle them separately and provide fixes along the way.