### PR TITLE
Update Rails redis cache timeout configuration examples

### DIFF
--- a/src/_posts/languages/ruby/rails/2000-01-01-redis-cache.md
+++ b/src/_posts/languages/ruby/rails/2000-01-01-redis-cache.md
@@ -30,7 +30,9 @@ change the client connection timeout. You can do it like this:
 ```ruby
 config.cache_store = :redis_cache_store, {
     url: "#{ ENV['REDIS_URL'] }/0:#{ ENV['SOURCE_VERSION'] || ENV['CONTAINER_VERSION'] }",
-    timeout: 30
+    connect_timeout: 1,
+    read_timeout: 1,
+    write_timeout: 1
 }
 ```
 
@@ -39,7 +41,9 @@ you should set the `reconnect_attempts` option:
 ```ruby
 config.cache_store = :redis_cache_store, {
     url: "#{ ENV['REDIS_URL'] }/0:#{ ENV['SOURCE_VERSION'] || ENV['CONTAINER_VERSION'] }",
-    timeout: 30,
+    connect_timeout: 1,
+    read_timeout: 1,
+    write_timeout: 1,
     reconnect_attempts: 1
 }
 ```


### PR DESCRIPTION
Rails sets a default `connect_timeout` of 20 : https://github.com/rails/rails/blob/89fc4bf9196f861372a8cb0daae59f415789403f/activesupport/lib/active_support/cache/redis_cache_store.rb#L55-L60

Setting `timeout` when the `connect_timeout` is set has no effect on it, easily testable by running this : 

```
Redis.new(connect_timeout: 20, timeout: 1, url: "redis://10.0.0.0:9876").get("foo")
```

So I'm proposing to update the config example so it doesn't suffer this issue, is more explicit and showcases all options

Thanks !