### PR TITLE
fix(php-buildpack): update doc about PHP extensions

### DIFF
--- a/src/_posts/languages/php/2000-01-01-start.md
+++ b/src/_posts/languages/php/2000-01-01-start.md
@@ -54,12 +54,12 @@ Example to install the latest PHP version from the `8.0` branch:
 }
 ```
 
-It installs the version 8.0.25 at the time of writing.
+It installs the version 8.0.28 at the time of writing.
 
 {% note %}
-You should not specify a precise version such as `7.4.3` or you would miss
-important updates. Instead, you should specify `~7.4.3` to install a version
-`>=7.4.3 and <7.5.0` or specify `~7.4` to install a version `>=7.4 and <8.0.0`.
+You should not specify a precise version such as `8.2.3` or you would miss
+important updates. Instead, you should specify `~8.2.3` to install a version
+`>=8.2.3 and <8.3.0` or specify `~8.2` to install a version `>=8.2 and <9.0.0`.
 
 Further details about version constraints can be found in the
 [Composer documentation](https://getcomposer.org/doc/articles/versions.md#writing-version-constraints)
@@ -152,36 +152,23 @@ Scalingo supports the following versions of Composer:
 
 ## Native PHP Extensions
 
-Applications might require native PHP extensions, these extensions are usually
-written in C and need to be compiled as shared libraries (`.so` files) and be
+Applications might require native PHP extensions which are usually written in C
+Consequently, they need to be compiled as shared libraries (`.so` files) to be
 used by PHP.
 
-Some of them are bundled by default with the deployed version of PHP, the
+Some of them are pre-installed by default with the deployed version of PHP, the
 others are installed dynamically if specified in the project `composer.json`.
 
-### Native Extension Dependency
+### Pre-Installed Extensions
 
-If an application requires a native PHP extension, it should be added in the
-`require` block of its `composer.json`:
+These extensions are **available and enabled** by default with the installed
+version of PHP. You don't need to add them in your `composer.json` file.
 
-```json
-{
-  "require": {
-    "ext-mongodb": "*",
-    "ext-imagick": "*",
-    ...
-  }
-}
-```
-
-These dependency instructions are parsed by the deployment system which will
-install the require files.
-
-### List of Pre-Installed Extensions
-
-These extensions are available by default with the installed version of PHP:
-
-* Databases: [`mysql`](https://www.php.net/manual/en/book.mysql.php), [`mysqli`](https://www.php.net/manual/en/book.mysqli.php), [`pgsql`](https://www.php.net/manual/en/book.pgsql.php), [`pdo-mysql`](https://www.php.net/manual/en/ref.pdo-mysql.php), [`pdo-pgsql`](https://www.php.net/manual/en/ref.pdo-pgsql.php),
+* Databases: [`mysql`](https://www.php.net/manual/en/book.mysql.php),
+[`mysqli`](https://www.php.net/manual/en/book.mysqli.php),
+[`pgsql`](https://www.php.net/manual/en/book.pgsql.php),
+[`pdo-mysql`](https://www.php.net/manual/en/ref.pdo-mysql.php),
+[`pdo-pgsql`](https://www.php.net/manual/en/ref.pdo-pgsql.php),
 * Compression: [`bz2`](https://www.php.net/manual/en/book.bzip2.php),
 [`zlib`](https://www.php.net/manual/en/book.zlib.php),
 [`zip`](https://www.php.net/manual/en/book.zip.php)
@@ -194,29 +181,35 @@ These extensions are available by default with the installed version of PHP:
 * Images manipulation: [`gd`](https://www.php.net/manual/book.image.php)
 * Intl (Internationalization): [`intl`](https://www.php.net/manual/book.intl.php)
 
-### List of Available Extensions
+### Other Extensions
 
-These extensions will be installed dynamically if required in the `composer.json` file.
+All [PECL extensions](https://pecl.php.net/) are available. If the extension
+you need is not in the above list of pre-installed extensions, it will be
+compiled during the *build* phase of your deployment.
 
-* APC User Cache: [`apcu`](http://www.php.net/manual/en/book.apcu.php)
-* MongoDB Driver: [`mongodb`](https://www.php.net/manual/en/set.mongodb.php)
-* MongoDB Legacy Driver: [`mongo`](https://www.php.net/manual/en/book.mongo.php), obsolete, only PHP 5.6
-* Redis Driver: [`redis`](https://pecl.php.net/package/redis)
-* Image manipulation with ImageMagick: [`imagick`](https://www.php.net/manual/en/book.imagick.php)
-* Memcached driver: [`memcached`](https://www.php.net/manual/en/book.memcached.php)
-* Event : [`event`](https://www.php.net/manual/en/book.event.php)
-* GMP Multiple Precisions math functions: [`gmp`](https://www.php.net/manual/en/book.gmp.php)
-* FTP Client: [`ftp`](https://www.php.net/manual/book.ftp.php)
-* IMAP: [`imap`](https://www.php.net/manual/en/book.imap.php)
-* Tidy: [`tidy`](https://www.php.net/manual/en/book.tidy.php)
-* Calendar: [`calendar`](https://www.php.net/manual/book.calendar.php)
-* Data Structures: [`ds`](https://www.php.net/manual/book.ds.php), incompatible with PHP 8.0 and above
-* Lua: [`lua`](https://www.php.net/manual/en/book.lua.php), incompatible with PHP 8.0 and above
-* Gettext: [`gettext`](https://www.php.net/manual/en/book.gettext.php)
-* mcrypt: [`mcrypt`](https://pecl.php.net/package/mcrypt), automatically installed with all apps with PHP 7.1 and before. External dependency starting with PHP 7.2.
-* Sodium [`sodium`](https://pecl.php.net/package/libsodium), incompatible with PHP 7.1 and below
-* Always Populate Form Data [`apfd`](https://pecl.php.net/package/apfd)
-* Extension's missing: contact us, the support for it will be added quickly
+{% note %}
+  Note that some PECL extensions are very old, probably even unmaintained and
+  will only work with an old version of PHP (e.g. `mongo`, `sodium`, `ds` or
+  `lua`). We strongly advise you to pick your extension(s) carefully.
+{% endnote %}
+
+To enable a native PHP extension, add it in the `require` block of your
+`composer.json`, like so (notice the `ext-` prefix):
+
+```json
+{
+  "require": {
+    "ext-mongodb": "*",
+    "ext-imagick": "*",
+    ...
+  }
+}
+```
+
+These dependency instructions are parsed by the deployment system which will
+install the required files.
+
+If an extension doesn't work as expected, please get in touch with our support.
 
 ## Officially Supported Frameworks
 

--- a/src/_posts/languages/php/2000-01-01-start.md
+++ b/src/_posts/languages/php/2000-01-01-start.md
@@ -1,7 +1,7 @@
 ---
 title: PHP on Scalingo
 nav: Introduction
-modified_at: 2023-04-12 16:00:00
+modified_at: 2023-04-13 16:00:00
 tags: php
 index: 1
 ---
@@ -10,8 +10,8 @@ index: 1
 
 Your application will be detected as a PHP application if:
 
-* There is a `composer.lock` file at the root of your project
-* `index.php` is present in the root directory (legacy app)
+* a `composer.lock` file lives at the root of your project
+* or if an `index.php` file lives in the root directory (legacy app)
 
 ## Stack
 
@@ -19,10 +19,13 @@ A stack based on Nginx and PHP-FPM will be installed.
 
 ## Default Configuration
 
-The default configuration for your application is defined in the buildpack's
-[php.ini](https://github.com/Scalingo/php-buildpack/blob/master/conf/php/php.ini) and
-[php-fpm.ini](https://github.com/Scalingo/php-buildpack/blob/master/conf/php/php-fpm.conf). You can
-see on these files the configuration for parameters such as `upload_max_filesize` and `post_max_size`.
+The default configuration for your application is stored in two files, both
+available in the PHP buildpack:
+- [php.ini](https://github.com/Scalingo/php-buildpack/blob/master/conf/php/php.ini)
+- [php-fpm.ini](https://github.com/Scalingo/php-buildpack/blob/master/conf/php/php-fpm.conf)
+
+Reviewing them can give you useful inputs, such as the default values for
+parameters like `upload_max_filesize` or `post_max_size`.
 
 ## PHP Versions
 
@@ -41,28 +44,26 @@ The following PHP versions are compatible with the platform:
 
 ### Select a Version
 
-By default, the latest **7.4** version of PHP will be installed, if you need to install
-a precise version it should be mentioned in your `composer.json` file.
-
-Example to install the latest PHP version from the `8.0` branch:
+By default, the latest **`8.0`** version of PHP will be installed. If you need
+to install another version, specify it in your `composer.json` file. For
+example, to install the latest PHP version of the `8.1` branch:
 
 ```json
 {
   "require": {
-    "php": "^8.0"
+    "php": "^8.1"
   }
 }
 ```
 
-It installs the version 8.0.28 at the time of writing.
-
 {% note %}
-You should not specify a precise version such as `8.2.3` or you would miss
-important updates. Instead, you should specify `~8.2.3` to install a version
-`>=8.2.3 and <8.3.0` or specify `~8.2` to install a version `>=8.2 and <9.0.0`.
+  You should not specify a precise version such as `8.2.3` or you would miss
+  important updates. Instead, you should specify `~8.2.3` to install a version
+  `>=8.2.3 and <8.3.0` or specify `~8.2` to install a version `>=8.2 and
+  <9.0.0`.
 
-Further details about version constraints can be found in the
-[Composer documentation](https://getcomposer.org/doc/articles/versions.md#writing-version-constraints)
+  Further details about version constraints can be found in the
+  [Composer documentation](https://getcomposer.org/doc/articles/versions.md#writing-version-constraints)
 {% endnote %}
 
 ## Composer
@@ -71,40 +72,47 @@ Composer is the official package manager for PHP. The official website is
 [here](https://getcomposer.org). It aims at handling the dependency management
 of your application: installing dependencies and freezing their versions.
 
-If composer is used in a project, the deployment system will detect it and use
+If Composer is used in a project, the deployment system will detect it and use
 it to install the dependencies of the project.
 
 ### composer.json
 
-This file defines the different dependencies used by your application. It is also
-used to configure custom deployment settings for the project (see below).
+This file defines the different dependencies used by your application. It is
+also used to configure custom deployment settings for the project (see below).
 
 ### composer.lock
 
-Once the third-party libraries have been defined, their versions need to be
-frozen in order to ensure a precise version of the application will always
-deploy a compatible set of Composer packages. These versions will be written in
-a `compose.lock` file. This file is _required_ as it is read during the
+Once the third-party libraries have been defined, their versions must be frozen
+in order to ensure a precise version of the application will always deploy a
+compatible set of Composer packages. These versions must be written in a
+`compose.lock` file. This file is _required_ as it is read during the
 deployment on the platform.
 
-To generate `compose.lock` you need to run:
+To generate the `compose.lock` file, run the following command:
 
 ```bash
 $ composer install
 ```
 
-When you need to upgrade a library, for instance `slim`:
+To upgrade a dependency, run the following command (in the example below, we
+ask Composer to upgrade `slim`):
 
 ```bash
 $ composer update slim/slim
 ```
 
-After each command, the `composer.lock` file will be updated automatically, do
-not forget to commit the modifications of the file.
+In some circumstances, the `--ignore-platform-req=` flag can also be useful.
+
+After each command, the `composer.lock` file is automatically updated. Don't
+forget to commit the modifications!
 
 ### Private Dependency
 
-If you want to install a private dependency, you need to define the `COMPOSER_AUTH` environment variable on your application as specified in [the Composer documentation](https://getcomposer.org/doc/03-cli.md#composer-auth). For instance, for a GitHub hosted private dependency, the `COMPOSER_AUTH` environment variable should contain:
+If you want to install a private dependency, you need to define the
+`COMPOSER_AUTH` environment variable on your application as specified in
+[the Composer documentation](https://getcomposer.org/doc/03-cli.md#composer-auth).
+For instance, for a GitHub hosted private dependency, the `COMPOSER_AUTH`
+environment variable should contain:
 
 ```json
 {
@@ -118,25 +126,26 @@ If you want to install a private dependency, you need to define the `COMPOSER_AU
 
 ## Composer During the Deployment
 
-It is considered that when an application is deployed on Scalingo, it is run in
-"production" mode. As a result, `composer install` is run with the flag
-`--no-dev`.
+By default, Scalingo considers that your application runs in *production* mode.
+This means that `composer install` automatically runs with the `--no-dev` flag,
+and, as a result, won't install the development dependencies of your
+application, if any.
 
-If, in order to debug an application, development dependencies should be
-installed, please set the following environment variable:
-
-* `COMPOSER_DEV=true`
+If, for some reason, you'd like to run your application with these development
+dependencies installed (e.g. to debug your app), please set the `COMPOSER_DEV`
+environment variable to `true`.
 
 ### Select a Composer Version
 
-You can select the Composer version to install for your application deployment by specifying it in your `composer.json`:
+You can select the Composer version to install for your application deployment
+by specifying it in your `composer.json`:
 
 ```json
 {
   "extra": {
     "paas": {
       "engines": {
-        "composer": "1.x"
+        "composer": "2.x"
       }
     }
   }
@@ -152,9 +161,9 @@ Scalingo supports the following versions of Composer:
 
 ## Native PHP Extensions
 
-Applications might require native PHP extensions which are usually written in C
-Consequently, they need to be compiled as shared libraries (`.so` files) to be
-used by PHP.
+Applications might require native PHP extensions which are usually written in
+C. Consequently, they need to be compiled as shared libraries (`.so` files) to
+be used by PHP.
 
 Some of them are pre-installed by default with the deployed version of PHP, the
 others are installed dynamically if specified in the project `composer.json`.
@@ -242,16 +251,15 @@ languages/php/2000-01-01-basic-auth %}) for your application.
 
 The level of concurrency configured is defined automatically according to the
 size of the containers of your application. If you want to override this value,
-you can define the environment variable: `WEB_CONCURRENCY`. It directly modifies
-the
+you can define the environment variable: `WEB_CONCURRENCY`. It directly
+modifies the
 [`pm.max_children`](https://www.php.net/manual/fr/install.fpm.configuration.php)
 parameter of PHP-FPM, defining the upper limit of how many workers handling
 incoming requests will be running. Each of these processes will be able to run
 1 request at a time.
 
 The default values for `pm.max_children` are based on the `memory_limit`
-parameter of the [PHP
-configuration](https://github.com/Scalingo/php-buildpack/blob/master/conf/php/php.ini#L15),
+parameter of the [PHP configuration](https://github.com/Scalingo/php-buildpack/blob/master/conf/php/php.ini#L15),
 the used formula is: `floor(available_memory / php_memory_limit) + 2`
 
 {: .table }
@@ -333,7 +341,8 @@ default value.
 The directory where Nginx will define the root of your app.
 
 {% note %}
-  It is empty by default, it means that Nginx will look at the `index.php` at the root of your project.
+  It is empty by default, it means that Nginx will look at the `index.php` at
+  the root of your project.
 {% endnote %}
 
 This parameter can also be overridden with the `DOCUMENT_ROOT` environment
@@ -355,7 +364,9 @@ here.
 
 #### `.extra.paas.engines.composer`
 
-Define a specific version of Composer to use. By default your application uses the latest Composer version available. Most of the time, you don't need to change this value.
+Define a specific version of Composer to use. By default your application uses
+the latest Composer version available. Most of the time, you don't need to
+change this value.
 
 #### `.extra.paas.engines.nginx`
 
@@ -367,8 +378,8 @@ don't need to change this value.
 
 #### `.extra.paas.php-config`
 
-List of directives which will be added to your `php.ini`. The default values used for your
-application are in the buildpack's
+List of directives which will be added to your `php.ini`. The default values
+used for your application are in the buildpack's
 [php.ini](https://github.com/Scalingo/php-buildpack/blob/master/conf/php/php.ini).
 
 Example:
@@ -503,7 +514,8 @@ one or more configuration files:
 
 ## Example: Configuring Rate Limiting
 
-In the following example we will set a rate limit of `one request per second per IP`.
+In the following example we will set a rate limit of `one request per second
+per IP`.
 
 Create a `nginx-http.conf` file at the root of your project:
 
@@ -520,7 +532,8 @@ location /login {
 }
 ```
 
-Then modify your `composer.json` to add `nginx-http-includes` and `nginx-includes` config:
+Then modify your `composer.json` to add `nginx-http-includes` and
+`nginx-includes` config:
 
 ```json
 {
@@ -534,11 +547,11 @@ Then modify your `composer.json` to add `nginx-http-includes` and `nginx-include
 ```
 
 {% warning %}
-  This configuration will not work with `location /` as it can't be overrided in the PHP buildpack.
-  If you want to apply a rate limit on all endpoints of your application you need to set-up two apps
-  (one web app and one reverse proxy app) by using our
-  [Nginx buildpack]({% post_url platform/deployment/buildpacks/2000-01-01-nginx %}) and using this
-  [process]({% post_url platform/deployment/buildpacks/2000-01-01-nginx %}#setup-throttling-with-a-limit_req_zone).
+  This configuration will not work with `location /` as it can't be overrided
+  in the PHP buildpack. If you want to apply a rate limit on all endpoints of
+  your application you need to setup two apps (one web app and one reverse
+  proxy app) by using our [Nginx buildpack]({% post_url platform/deployment/buildpacks/2000-01-01-nginx %})
+  and using this [process]({% post_url platform/deployment/buildpacks/2000-01-01-nginx %}#setup-throttling-with-a-limit_req_zone).
 {% endwarning %}
 
 ## Example: URL Rewriting (e.g. WordPress)


### PR DESCRIPTION
Update the doc related to PHP extensions:
- we support all PECL extensions.
- re-phrased some sentences.