### PR TITLE
Use app directory to extract tar

### DIFF
--- a/src/_posts/platform/app/2000-01-01-tasks.md
+++ b/src/_posts/platform/app/2000-01-01-tasks.md
@@ -200,7 +200,7 @@ dump.tar
 * Extract the archive to `/tmp`
 
 ```bash
-[10:51][osc-fr1] Scalingo ~ $ tar -C /tmp -xvf /tmp/uploads/dump.tar
+[10:51][osc-fr1] Scalingo ~ $ tar -C /app -xvf /tmp/uploads/dump.tar
 /tmp/dump
 /tmp/dump/collection1.bson
 /tmp/dump/collection1.metadata.json


### PR DESCRIPTION
When I try to use the `/tmp` directory I'm getting `Operation not permitted` errors.