### PR TITLE
Vite note about vite compiling on the fly

### DIFF
--- a/src/_posts/languages/nodejs/2000-01-01-start.md
+++ b/src/_posts/languages/nodejs/2000-01-01-start.md
@@ -358,6 +358,8 @@ In the `vite.config` (or `vite.config.ts`) file you need to add the following
   },
 ```
 
+As a note, `vite --port $PORT` may compile components, depending of your configuraiton. If it does, it will leads to a very long first http request that may even crash your container. In this case, in the `package.json`, replace the `start` rule content to use `node server.js` (see section `Framework Requiring to Serve Static Files`) or `vite preview --port $PORT`.
+
 ## AngularJS
 
 Please refer to the AngularJS [dedicated page]({% post_url languages/nodejs/2000-01-01-angularjs %}) for instructions on how to deploy such an application on Scalingo.

--- a/src/_posts/languages/nodejs/2000-01-01-start.md
+++ b/src/_posts/languages/nodejs/2000-01-01-start.md
@@ -358,7 +358,7 @@ In the `vite.config` (or `vite.config.ts`) file you need to add the following
   },
 ```
 
-As a note, `vite --port $PORT` may compile components, depending of your configuraiton. If it does, it will leads to a very long first http request that may even crash your container. In this case, in the `package.json`, replace the `start` rule content to use `node server.js` (see section `Framework Requiring to Serve Static Files`) or `vite preview --port $PORT`.
+As a note, `vite --port $PORT` may compile components, depending on your configuration. If it does, it leads to a very long first HTTP request that may even crash your container. In this case, in the `package.json`, replace the `start` rule content to use `node server.js` (see section `Framework Requiring to Serve Static Files`) or `vite preview --port $PORT`.
 
 ## AngularJS
 


### PR DESCRIPTION
Using with in `start` may crash the container currently