### PR TITLE
docs(database upgrade): add a note explaining upgrade to minor version before accessing major

### DIFF
--- a/src/_posts/databases/elasticsearch/2000-01-01-start.md
+++ b/src/_posts/databases/elasticsearch/2000-01-01-start.md
@@ -224,6 +224,11 @@ This operation is similar to changing your database plan. Your database will be 
 restarted with the new database version. When this operation finishes, your application will be
 restarted.
 
+{% note %}
+Your database needs to be upgraded to the latest minor version before having access to the next major version.
+Per example, your version is 2.3.X and you want to upgrade to 3.1.X. If there is a 2.5.X version, you need to upgrade it to the 2.5.X first.
+{% endnote %}
+
 If using a Business plan for your Elasticsearch addon, we are able to upgrade your instance to a
 newer version without downtime. In order to do so, we follow [Elasticsearch
 guidelines](https://www.elastic.co/guide/en/elasticsearch/reference/current/rolling-upgrades.html).

--- a/src/_posts/databases/elasticsearch/2000-01-01-start.md
+++ b/src/_posts/databases/elasticsearch/2000-01-01-start.md
@@ -226,7 +226,7 @@ restarted.
 
 {% note %}
 Your database needs to be upgraded to the latest minor version before having access to the next major version.
-Per example, your version is 2.3.X and you want to upgrade to 3.1.X. If there is a 2.5.X version, you need to upgrade it to the 2.5.X first.
+For instance, your version is 2.3.X and you want to upgrade to 3.1.X. If there is a 2.5.X version, you need to upgrade it to the 2.5.X first.
 {% endnote %}
 
 If using a Business plan for your Elasticsearch addon, we are able to upgrade your instance to a

--- a/src/_posts/databases/influxdb/2000-01-01-start.md
+++ b/src/_posts/databases/influxdb/2000-01-01-start.md
@@ -168,6 +168,11 @@ This operation is similar to changing your database plan; your database will be 
 restarted with the new database version. When this operation finishes, your application will be
 restarted.
 
+{% note %}
+Your database needs to be upgraded to the latest minor version before having access to the next major version.
+Per example, your version is 2.3.X and you want to upgrade to 3.1.X. If there is a 2.5.X version, you need to upgrade it to the 2.5.X first.
+{% endnote %}
+
 {% warning %}
 Beware that no downgrade is possible once your database has been upgraded.
 {% endwarning %}

--- a/src/_posts/databases/influxdb/2000-01-01-start.md
+++ b/src/_posts/databases/influxdb/2000-01-01-start.md
@@ -170,7 +170,7 @@ restarted.
 
 {% note %}
 Your database needs to be upgraded to the latest minor version before having access to the next major version.
-Per example, your version is 2.3.X and you want to upgrade to 3.1.X. If there is a 2.5.X version, you need to upgrade it to the 2.5.X first.
+For instance, your version is 2.3.X and you want to upgrade to 3.1.X. If there is a 2.5.X version, you need to upgrade it to the 2.5.X first.
 {% endnote %}
 
 {% warning %}

--- a/src/_posts/databases/mongodb/2000-01-01-start.md
+++ b/src/_posts/databases/mongodb/2000-01-01-start.md
@@ -188,6 +188,11 @@ This operation is similar to changing your database plan; your database will be 
 restarted with the new database version. When this operation finishes, your application will be
 restarted.
 
+{% note %}
+Your database needs to be upgraded to the latest minor version before having access to the next major version.
+Per example, your version is 2.3.X and you want to upgrade to 3.1.X. If there is a 2.5.X version, you need to upgrade it to the 2.5.X first.
+{% endnote %}
+
 If using a Business plan for your MongoDB addon, we are able to upgrade your instance to a newer
 version *without downtime*. In order to do so, we follow [MongoDB
 guidelines](https://docs.mongodb.com/manual/release-notes/3.4-upgrade-replica-set/#upgrade-process).

--- a/src/_posts/databases/mongodb/2000-01-01-start.md
+++ b/src/_posts/databases/mongodb/2000-01-01-start.md
@@ -190,7 +190,7 @@ restarted.
 
 {% note %}
 Your database needs to be upgraded to the latest minor version before having access to the next major version.
-Per example, your version is 2.3.X and you want to upgrade to 3.1.X. If there is a 2.5.X version, you need to upgrade it to the 2.5.X first.
+For instance, your version is 2.3.X and you want to upgrade to 3.1.X. If there is a 2.5.X version, you need to upgrade it to the 2.5.X first.
 {% endnote %}
 
 If using a Business plan for your MongoDB addon, we are able to upgrade your instance to a newer

--- a/src/_posts/databases/mysql/2000-01-01-start.md
+++ b/src/_posts/databases/mysql/2000-01-01-start.md
@@ -207,7 +207,7 @@ database with one click through your database dashboard.
 
 {% note %}
 Your database needs to be upgraded to the latest minor version before having access to the next major version.
-Per example, your version is 2.3.X and you want to upgrade to 3.1.X. If there is a 2.5.X version, you need to upgrade it to the 2.5.X first.
+For instance, your version is 2.3.X and you want to upgrade to 3.1.X. If there is a 2.5.X version, you need to upgrade it to the 2.5.X first.
 {% endnote %}
 
 If your database uses a business plan, we are able to achieve zero-downtime

--- a/src/_posts/databases/mysql/2000-01-01-start.md
+++ b/src/_posts/databases/mysql/2000-01-01-start.md
@@ -205,6 +205,11 @@ When the database vendor releases a new version of your database engine, we will
 provide it as soon as possible. You will have the choice to upgrade your
 database with one click through your database dashboard.
 
+{% note %}
+Your database needs to be upgraded to the latest minor version before having access to the next major version.
+Per example, your version is 2.3.X and you want to upgrade to 3.1.X. If there is a 2.5.X version, you need to upgrade it to the 2.5.X first.
+{% endnote %}
+
 If your database uses a business plan, we are able to achieve zero-downtime
 upgrade.
 

--- a/src/_posts/databases/postgresql/2000-01-01-start.md
+++ b/src/_posts/databases/postgresql/2000-01-01-start.md
@@ -197,7 +197,7 @@ database with one click through your database dashboard.
 
 {% note %}
 Your database needs to be upgraded to the latest minor version before having access to the next major version.
-Per example, your version is 2.3.X and you want to upgrade to 3.1.X. If there is a 2.5.X version, you need to upgrade it to the 2.5.X first.
+For instance, your version is 2.3.X and you want to upgrade to 3.1.X. If there is a 2.5.X version, you need to upgrade it to the 2.5.X first.
 {% endnote %}
 
 If your database uses a business plan, we are able to achieve zero-downtime

--- a/src/_posts/databases/postgresql/2000-01-01-start.md
+++ b/src/_posts/databases/postgresql/2000-01-01-start.md
@@ -195,6 +195,11 @@ When the database vendor releases a new version of your database engine, we will
 try to provide it as soon as possible. You will have the choice to upgrade your
 database with one click through your database dashboard.
 
+{% note %}
+Your database needs to be upgraded to the latest minor version before having access to the next major version.
+Per example, your version is 2.3.X and you want to upgrade to 3.1.X. If there is a 2.5.X version, you need to upgrade it to the 2.5.X first.
+{% endnote %}
+
 If your database uses a business plan, we are able to achieve zero-downtime
 upgrade of minor version. In the case of major version upgrade, we need to
 completely stop the nodes, hence we can't achieve zero-downtime. On single node

--- a/src/_posts/databases/redis/2000-01-01-start.md
+++ b/src/_posts/databases/redis/2000-01-01-start.md
@@ -227,6 +227,11 @@ stopped and restarted with then new database version. Thanks to Docker
 containers this happens seamlessly and quickly without manual action. When this
 operation finishes, your application will be restarted.
 
+{% note %}
+Your database needs to be upgraded to the latest minor version before having access to the next major version.
+Per example, your version is 2.3.X and you want to upgrade to 3.1.X. If there is a 2.5.X version, you need to upgrade it to the 2.5.X first.
+{% endnote %}
+
 {% warning %}
 Beware that no downgrade is possible once your database has been upgraded.
 {% endwarning %}

--- a/src/_posts/databases/redis/2000-01-01-start.md
+++ b/src/_posts/databases/redis/2000-01-01-start.md
@@ -229,7 +229,7 @@ operation finishes, your application will be restarted.
 
 {% note %}
 Your database needs to be upgraded to the latest minor version before having access to the next major version.
-Per example, your version is 2.3.X and you want to upgrade to 3.1.X. If there is a 2.5.X version, you need to upgrade it to the 2.5.X first.
+For instance, your version is 2.3.X and you want to upgrade to 3.1.X. If there is a 2.5.X version, you need to upgrade it to the 2.5.X first.
 {% endnote %}
 
 {% warning %}


### PR DESCRIPTION
Added a note about this information because it can confuse some clients :
https://app.intercom.com/a/inbox/w4oogu7s/inbox/admin/5676128/conversation/12375700136909?view=List