### PR TITLE
fix(ffmpeg): update instructions for ffmpeg

### DIFF
--- a/src/_posts/platform/app/2000-01-01-ffmpeg.md
+++ b/src/_posts/platform/app/2000-01-01-ffmpeg.md
@@ -1,6 +1,6 @@
 ---
 title: FFmpeg
-modified_at: 2022-09-06 00:00:00
+modified_at: 2023-05-15 19:00:00
 tags: app build runtime ffmpeg ffprobe
 ---
 
@@ -50,7 +50,7 @@ ffmpeg
 You also need to define the environment variable `LD_LIBRARY_PATH`:
 
 ```bash
-scalingo --app my-app env-set LD_LIBRARY_PATH='$LD_LIBRARY_PATH:/app/.apt/usr/lib/x86_64-linux-gnu/pulseaudio'
+scalingo --app my-app env-set LD_LIBRARY_PATH='$LD_LIBRARY_PATH:/app/.apt/usr/lib/x86_64-linux-gnu/pulseaudio:/app/.apt/usr/lib/x86_64-linux-gnu/blas:/app/.apt/usr/lib/x86_64-linux-gnu/lapack'
 ```
 
 ### Trigger a new deployment


### PR DESCRIPTION
Make sure `blas` and `lapack` are in `LD_LIBRARY_PATH`.
This seems required for ffmpeg to work.

Fixes https://github.com/Scalingo/php-buildpack/issues/321