### PR TITLE
docs: scalingo-18 deprecation

### DIFF
--- a/src/_posts/addons/scalingo-openvpn/2000-01-01-start.md
+++ b/src/_posts/addons/scalingo-openvpn/2000-01-01-start.md
@@ -1,7 +1,7 @@
 ---
 title: Scalingo OpenVPN Addon
 nav: Introduction
-modified_at: 2023-01-11 00:00:00
+modified_at: 2023-05-26 00:00:00
 tags: vpn addon OpenVPN
 ---
 
@@ -130,7 +130,6 @@ everything you might need to configure the OpenVPN client and server.
 
 It depends on the stack:
 
-* `scalingo-18`: [2.4.x](https://packages.ubuntu.com/bionic/amd64/openvpn)
 * `scalingo-20`: [2.4.x](https://packages.ubuntu.com/focal/amd64/openvpn)
 * `scalingo-22`: [2.5.x](https://packages.ubuntu.com/jammy/amd64/openvpn)
 

--- a/src/_posts/languages/php/2000-01-01-start.md
+++ b/src/_posts/languages/php/2000-01-01-start.md
@@ -1,7 +1,7 @@
 ---
 title: PHP on Scalingo
 nav: Introduction
-modified_at: 2023-05-15 16:00:00
+modified_at: 2023-05-26 16:00:00
 tags: php
 index: 1
 ---
@@ -33,12 +33,8 @@ parameters like `upload_max_filesize` or `post_max_size`.
 
 The following PHP versions are compatible with the platform:
 
-* **7.0** (up to 7.0.33, only for scalingo-18)
-* **7.1** (up to 7.1.33, only for scalingo-18)
-* **7.2** (up to 7.2.34, only for scalingo-18)
-* **7.3** (up to 7.3.33, only for scalingo-18)
-* **7.4** (up to 7.4.32, only for scalingo-18 and scalingo-20)
-* **8.0** (up to 8.0.28, only for scalingo-18 and scalingo-20)
+* **7.4** (up to 7.4.32, only for scalingo-20)
+* **8.0** (up to 8.0.28, only for scalingo-20)
 * **8.1** (up to 8.1.19)
 * **8.2** (up to 8.2.6)
 

--- a/src/_posts/platform/internals/stacks/2000-01-01-scalingo-14-stack.md
+++ b/src/_posts/platform/internals/stacks/2000-01-01-scalingo-14-stack.md
@@ -1,12 +1,12 @@
 ---
 title: Scalingo-14 Stack
 nav: Scalingo-14
-modified_at: 2023-01-11 00:00:00
+modified_at: 2023-05-26 00:00:00
 index: 5
 ---
 
 {% warning %}
-  Scalingo-14 support ended on December 2019. If you're still using this stack, you [must upgrade]({% post_url platform/internals/stacks/2000-01-01-stacks %}#migrating-to-a-new-stack).
+scalingo-14 support ended on December 2019. If you're still using this stack, you [must upgrade]({% post_url platform/internals/stacks/2000-01-01-stacks %}#migrating-to-a-new-stack).
 {% endwarning %}
 
 This article describes the scalingo-14 stack, based on Ubuntu 14.04. [What is a stack?]({% post_url platform/internals/stacks/2000-01-01-stacks %})
@@ -17,7 +17,7 @@ Scalingo-14 is based on Ubuntu 14.04. Official support ended on December 2019.
 
 ## Testing and Upgrading Your App
 
-Learn how to test and [upgrade your app]({% post_url platform/internals/stacks/2000-01-01-stacks %}#migrating-to-a-new-stack) to scalingo-18.
+Learn how to test and [upgrade your app]({% post_url platform/internals/stacks/2000-01-01-stacks %}#migrating-to-a-new-stack) to scalingo-14.
 
 ##  Docker Image
 

--- a/src/_posts/platform/internals/stacks/2000-01-01-scalingo-18-stack.md
+++ b/src/_posts/platform/internals/stacks/2000-01-01-scalingo-18-stack.md
@@ -1,17 +1,19 @@
 ---
 title: Scalingo-18 Stack
 nav: Scalingo-18
-modified_at: 2023-01-11 00:00:00
+modified_at: 2023-05-26 00:00:00
 index: 4
 ---
+
+{% warning %}
+scalingo-18 support ended on April 2023. If you're still using this stack, you [must upgrade]({% post_url platform/internals/stacks/2000-01-01-stacks %}#migrating-to-a-new-stack).
+{% endwarning %}
 
 This article describes the scalingo-18 stack, based on Ubuntu 18.04. [What is a stack?]({% post_url platform/internals/stacks/2000-01-01-stacks %})
 
 ## Support Period
 
-scalingo-18 is based on Ubuntu 18.04. It will be supported through April 2023.
-
-It is deprecated since January 2023, you cannot set it anymore on any application.
+scalingo-18 is based on Ubuntu 18.04. Official support ended on April 2023.
 
 ## Testing and Upgrading Your App
 


### PR DESCRIPTION
scalingo-18 is deprecated, customers have been contacted multiple times about this. We forgot to update a bunch of doc page to reflect this.