### PR TITLE
chore(php-buildpack): upgrade Composer to 2.5.7

### DIFF
--- a/src/_posts/languages/php/2000-01-01-start.md
+++ b/src/_posts/languages/php/2000-01-01-start.md
@@ -153,7 +153,7 @@ Scalingo supports the following versions of Composer:
 - 2.2.18
 - 2.3.10
 - 2.4.4
-- 2.5.5
+- 2.5.7
 
 ## Native PHP Extensions
 

--- a/src/_posts/languages/php/2000-01-01-start.md
+++ b/src/_posts/languages/php/2000-01-01-start.md
@@ -1,7 +1,7 @@
 ---
 title: PHP on Scalingo
 nav: Introduction
-modified_at: 2023-05-26 16:00:00
+modified_at: 2023-05-31 16:00:00
 tags: php
 index: 1
 ---

--- a/src/changelog/buildpacks/_posts/2023-05-31-php-composer-2.5.7.md
+++ b/src/changelog/buildpacks/_posts/2023-05-31-php-composer-2.5.7.md
@@ -1,0 +1,10 @@
+---
+modified_at: 2023-05-31 16:00:00
+title: 'PHP - Release Composer version 2.5.7'
+github: 'https://github.com/Scalingo/php-buildpack'
+---
+
+Changelog:
+
+* [Composer 2.5.6](https://github.com/composer/composer/releases/tag/2.5.6)
+* [Composer 2.5.7](https://github.com/composer/composer/releases/tag/2.5.7)


### PR DESCRIPTION
Done for:
- `scalingo-20`: https://semver.scalingo.com/composer-scalingo-20/resolve/2.x
- `scalingo-22`: https://semver.scalingo.com/composer-scalingo-22/resolve/2.x

Files have been uploaded to ObjectStorage.

Fixes https://github.com/Scalingo/php-buildpack/issues/328