### PR TITLE
fix/php buildpack/330/set default php version to 8.1

### DIFF
--- a/src/_posts/languages/php/2000-01-01-start.md
+++ b/src/_posts/languages/php/2000-01-01-start.md
@@ -1,7 +1,7 @@
 ---
 title: PHP on Scalingo
 nav: Introduction
-modified_at: 2023-06-07 16:00:00
+modified_at: 2023-06-08 16:00:00
 tags: php
 index: 1
 ---
@@ -42,14 +42,15 @@ The following PHP versions are available:
 
 ### Select a Version
 
-By default, the latest **`8.0`** version of PHP will be installed. If you need
-to install another version, specify it in your `composer.json` file. For
-example, to install the latest PHP version of the `8.1` branch:
+The default PHP version on both `scalingo-20` and `scalingo-22` is the latest
+**`8.1`** version. If you need to install another version, specify it in your
+`composer.json` file. For example, to install the latest PHP version of the
+`8.2` branch:
 
 ```json
 {
   "require": {
-    "php": "^8.1"
+    "php": "^8.2"
   }
 }
 ```

--- a/src/changelog/buildpacks/_posts/2023-06-08-php-default-version-8.1.md
+++ b/src/changelog/buildpacks/_posts/2023-06-08-php-default-version-8.1.md
@@ -1,8 +1,8 @@
 ---
 modified_at: 2023-06-08 16:00:00
-title: 'PHP - Default version updated to 8.1.x on scalingo-20 and scalingo-22'
+title: 'PHP - Default PHP version updated to 8.1.x on scalingo-20 and scalingo-22'
 github: 'https://github.com/Scalingo/php-buildpack'
 ---
 
 For a complete view of all available PHP versions, depending on the stack,
-please see https://doc.scalingo.com/languages/php/start#php-versions
+please see [the dedicated page in our documentation](https://doc.scalingo.com/languages/php/start#php-versions).

--- a/src/changelog/buildpacks/_posts/2023-06-08-php-default-version-8.1.md
+++ b/src/changelog/buildpacks/_posts/2023-06-08-php-default-version-8.1.md
@@ -1,0 +1,8 @@
+---
+modified_at: 2023-06-08 16:00:00
+title: 'PHP - Default version updated to 8.1.x on scalingo-20 and scalingo-22'
+github: 'https://github.com/Scalingo/php-buildpack'
+---
+
+For a complete view of all available PHP versions, depending on the stack,
+please see https://doc.scalingo.com/languages/php/start#php-versions

--- a/src/changelog/buildpacks/_posts/2023-06-08-php-default-version-8.1.md
+++ b/src/changelog/buildpacks/_posts/2023-06-08-php-default-version-8.1.md
@@ -5,4 +5,4 @@ github: 'https://github.com/Scalingo/php-buildpack'
 ---
 
 For a complete view of all available PHP versions, depending on the stack,
-please see [the dedicated page in our documentation](https://doc.scalingo.com/languages/php/start#php-versions).
+please see [the dedicated page in our documentation]({% post_url languages/php/2000-01-01-start %}#php-versions).


### PR DESCRIPTION
Following https://github.com/Scalingo/semver.io/pull/64
Fixes https://github.com/Scalingo/php-buildpack/issues/330