### PR TITLE
chore(php-buildpack): upgrade Composer to 2.5.8

### DIFF
--- a/src/_posts/languages/php/2000-01-01-dependencies.md
+++ b/src/_posts/languages/php/2000-01-01-dependencies.md
@@ -1,7 +1,7 @@
 ---
 title: Managing Dependencies
 nav: Managing Dependencies
-modified_at: 2023-06-05 16:00:00
+modified_at: 2023-06-13 16:00:00
 tags: php
 index: 3
 ---
@@ -98,7 +98,7 @@ Scalingo currently supports the following versions of Composer:
 - `2.2.18`
 - `2.3.10`
 - `2.4.4`
-- `2.5.7`
+- `2.5.8`
 
 ## Working with Composer Environments
 

--- a/src/changelog/buildpacks/_posts/2023-06-13-php-composer-2.5.8.md
+++ b/src/changelog/buildpacks/_posts/2023-06-13-php-composer-2.5.8.md
@@ -1,0 +1,9 @@
+---
+modified_at: 2023-06-13 16:00:00
+title: 'PHP - Release Composer version 2.5.8'
+github: 'https://github.com/Scalingo/php-buildpack'
+---
+
+Changelog:
+
+* [Composer 2.5.7](https://github.com/composer/composer/releases/tag/2.5.8)

--- a/src/changelog/buildpacks/_posts/2023-06-13-php-composer-2.5.8.md
+++ b/src/changelog/buildpacks/_posts/2023-06-13-php-composer-2.5.8.md
@@ -6,4 +6,4 @@ github: 'https://github.com/Scalingo/php-buildpack'
 
 Changelog:
 
-* [Composer 2.5.7](https://github.com/composer/composer/releases/tag/2.5.8)
+* [Composer 2.5.8](https://github.com/composer/composer/releases/tag/2.5.8)


### PR DESCRIPTION
Done for:
- `scalingo-20`: https://semver.scalingo.com/composer-scalingo-20/resolve/2.x
- `scalingo-22`: https://semver.scalingo.com/composer-scalingo-22/resolve/2.x

Files have been uploaded to ObjectStorage.

Fixes https://github.com/Scalingo/php-buildpack/issues/333