### PR TITLE
fix(changelog): update nodejs buildpack that add support of nodejs 16.20.1

### DIFF
--- a/src/changelog/buildpacks/_posts/2023-06-28-nodejs-1.20.1.md
+++ b/src/changelog/buildpacks/_posts/2023-06-28-nodejs-1.20.1.md
@@ -1,0 +1,9 @@
+---
+modified_at: 2023-06-28 09:00:00
+title: 'Node.js: Support of extension Node.js 16.20.1'
+github: 'https://github.com/Scalingo/nodejs-buildpack'
+---
+
+We have updated our Node.js buildpack. Noticeable changes:
+
+- Support of the version of Node v16.20.1

--- a/src/changelog/buildpacks/_posts/2023-06-28-nodejs-1.20.1.md
+++ b/src/changelog/buildpacks/_posts/2023-06-28-nodejs-1.20.1.md
@@ -1,9 +1,9 @@
 ---
 modified_at: 2023-06-28 09:00:00
-title: 'Node.js: Support of extension Node.js 16.20.1'
+title: 'Node.js: Support of new versions 20.3.1, 18.16.1 and 16.20.1'
 github: 'https://github.com/Scalingo/nodejs-buildpack'
 ---
 
 We have updated our Node.js buildpack. Noticeable changes:
 
-- Support of the version of Node v16.20.1
+- Support of the versions of Node.js 20.3.1, 18.16.1 and 16.20.1


### PR DESCRIPTION
Related to https://github.com/Scalingo/nodejs-buildpack/issues/76
