### PR TITLE
fix(page layout): breadcrumb media query for small screens added

### DIFF
--- a/src/_layouts/page.html
+++ b/src/_layouts/page.html
@@ -5,7 +5,7 @@ layout: default
 <div class="flex bg-sc-gray-5 w-full rounded-lg justify-center">
   <div class="flex xl:flex-row items-start flex-col-reverse xl:flex-grow m-10 justify-center relative">
     <article class="max-w-sc-content-720 text-sc-text-1">
-      <div id="breadcrumb" class="text-sc-text-2 mb-4">{% breadcrumb %}</div>
+      <div id="breadcrumb" class="text-sc-text-2 mb-4 hidden xl:block">{% breadcrumb %}</div>
       <h1 class="text-sc-gray-1 text-sc-title-1 font-bold mb-12 hidden xl:block">{{ page.title }}</h1>
       <section class="py-0">
         {{ content | inject_anchors }}
@@ -26,12 +26,14 @@ layout: default
         </div>
       </section>
     </article>
-    <nav class="xl:sticky xl:top-[75px] xl:border-l xl:border-sc-gray-3 xl:w-[260px] xl:pl-5 xl:ml-5 xl:py-3 2xl:w-[280px] 2xl:pl-10 2xl:ml-10">
+
+    <nav class="xl:sticky xl:top-[75px] xl:border-l xl:border-sc-gray-3 xl:w-[260px] xl:pl-5 xl:ml-5 xl:py-3 2xl:w-[280px] 2xl:pl-10 2xl:ml-10 mb-12">
       <div class="font-bold text-sc-gray-1 text-sc-title-6 mb-2">In this article</div>
       <div class="toc flex flex-cols space-y-4">
         {% include organisms/content_table.html html=content h_min=2 h_max=3 %}
       </div>
     </nav>
     <h1 class="text-sc-gray-1 text-sc-title-1 font-bold mb-12 xl:hidden">{{ page.title }}</h1>
+    <div id="breadcrumb" class="text-sc-text-2 xl:hidden mb-2">{% breadcrumb %}</div>
   </div>
 </div>


### PR DESCRIPTION
Fixes https://github.com/Scalingo/documentation/issues/2204

![image](https://github.com/Scalingo/documentation/assets/94181724/d69bdf4b-25ce-48be-b1ff-791920921397)

Added margin bottom to nav in small screens, otherwise it was too close to article content.