### PR TITLE
fix(django): update instructions to get started

### DIFF
--- a/src/_posts/languages/python/django/2000-01-01-start.md
+++ b/src/_posts/languages/python/django/2000-01-01-start.md
@@ -1,7 +1,7 @@
 ---
 title: Get Started with Django on Scalingo
 nav: Get Started
-modified_at: 2023-02-22 00:00:00
+modified_at: 2023-08-25 16:00:00
 tags: python django tutorial getting-started-tutorial
 index: 1
 ---
@@ -19,8 +19,8 @@ cd my-project
 virtualenv venv
 source venv/bin/activate
 
-# Install Django toolbelt
-pip install django-toolbelt
+# Install Django and other useful packages:
+pip install django django-environ psycopg gunicorn dj-database-url whitenoise
 
 # Initialize Django project, this command will
 # create a manage.py file and a myapp directory
@@ -29,7 +29,9 @@ django-admin.py startproject myapp .
 
 ## Define How To Start Your Application
 
-By default, the platform is looking for the web process type to start. You need to specify how to start the applicative server, and define it to display logs on `stdout` to fit the [12-factor](http://12factor.net/) principles.
+By default, the platform is looking for the web process type to start. You need
+to specify how to start the applicative server, and define it to display logs
+on `stdout` to fit the [12-factor](http://12factor.net/) principles.
 
 ### Using a WSGI Server
 
@@ -41,7 +43,8 @@ web: gunicorn myapp.wsgi --log-file -
 
 ### Using a ASGI Server
 
-In order to make use of a ASGI server such as Uvicorn, create a file named `Procfile` at the root of the project containing:
+In order to make use of a ASGI server such as Uvicorn, create a file named
+`Procfile` at the root of the project containing:
 
 ```yaml
 web: gunicorn myapp.asgi --worker-class=uvicorn.workers.UvicornWorker --log-file -
@@ -67,7 +70,8 @@ Then in your `Procfile`, directly call this script:
 web: bash bin/start.sh
 ```
 
-For more details, check the documentation about [Procfile]({% post_url platform/app/2000-01-01-procfile %}).
+For more details, check the documentation about
+[Procfile]({% post_url platform/app/2000-01-01-procfile %}).
 
 
 ## Python App Recognition and Dependencies Definition
@@ -104,7 +108,7 @@ By default, only the PostgreSQL driver is installed, you need to replace
 it by the MySQL driver.
 
 ```bash
-pip uninstall psycopg2
+pip uninstall psycopg
 pip install mysqlclient
 pip freeze > requirements.txt
 ```
@@ -193,9 +197,10 @@ application = Cling(get_wsgi_application())
 
 `Cling` is part of the `dj_static` module and is designed to serve static files.
 
-If you don't need to serve static files, you can setup the following environment variable:
+If you don't need to serve static files, you can setup the following
+environment variable:
 
-```text
+```bash
 DISABLE_COLLECTSTATIC=1
 ```
 
@@ -203,13 +208,16 @@ It will be taken into account during the next deployment of your application.
 
 ### Configuration of Allowed Hosts
 
-By default, Django filter the allowed domain names used to access the application. Without specifying them, you'll get the following error:
+By default, Django will only serve requests coming for specific domain names to
+prevent HTTP Host header attacks. Without specifying these allowed domains, you
+will get the following error:
 
 ```
 > Invalid HTTP_HOST header: '<domain>'. You may need to add '<domain>' to ALLOWED_HOSTS.
 ```
 
-So you need to modify the `settings.py`. Replace this static array:
+Consequently, you need to modify the `settings.py` file. Replace this static
+array:
 
 ```python
 ALLOWED_HOSTS = ["localhost"]
@@ -219,6 +227,7 @@ By this dynamic block reading the environment:
 
 ```python
 env_allowed_hosts = []
+
 try:
   env_allowed_hosts = os.environ["ALLOWED_HOSTS"].split(",")
 except KeyError:
@@ -227,7 +236,8 @@ except KeyError:
 ALLOWED_HOSTS = ["localhost"] + env_allowed_hosts
 ```
 
-Then change the environment variable of your application with a coma-separated list of domains which will be used to access the app.
+Then change the environment variable of your application with a coma-separated
+list of domains which will be used to access the app.
 
 ```bash
 scalingo --app app-name env-set ALLOWED_HOSTS=app-name.osc-fr1.scalingo.io,example.com
@@ -235,25 +245,30 @@ scalingo --app app-name env-set ALLOWED_HOSTS=app-name.osc-fr1.scalingo.io,examp
 
 ### Automatic Database Migrations
 
-You can configure a [postdeploy hook]({% post_url platform/app/2000-01-01-postdeploy-hook %}) to migrate your database schema automatically after a deployment.
+You can configure a [postdeploy hook]({% post_url platform/app/2000-01-01-postdeploy-hook %})
+to migrate your database schema automatically after a deployment.
 
 Database migrations in Django are separated in two steps:
 
-- `python manage.py makemigrations`, which creates migrations files from model change
-- `python manage.py migrate`, which applies the migration file to the related database
+- `python manage.py makemigrations`, which creates migrations files from model
+  change
+- `python manage.py migrate`, which applies the migration file to the related
+  database
 
-Because `makemigrations` modifies the source code, this command must be done on your computer, and the created
-migration files committed to Git. This is not a command to execute in your postdeploy hook.
+Because `makemigrations` modifies the source code, this command must be done on
+your computer, and the created migration files committed to Git. This is not a
+command to execute in your postdeploy hook.
 
-The `migrate` command is the one to execute to apply to migrations to your database. You can add it to your `Procfile`
-like this:
+The `migrate` command is the one to execute to apply to migrations to your
+database. You can add it to your `Procfile` like this:
 
 ```
 web: gunicorn mydjango.wsgi --log-file -
 postdeploy: python manage.py migrate
 ```
 
-Once your application is deployed, your migrations will be applied automatically.
+Once your application is deployed, your migrations will be applied
+automatically.
 
 ## Save Your App With Git
 


### PR DESCRIPTION
Previous version had deprecated dependencies, as pointed out by @stephane in #2069.
Fixes #2069