### PR TITLE
docs: VPN addons are only for runtime

### DIFF
--- a/src/_posts/addons/scalingo-openvpn/2000-01-01-start.md
+++ b/src/_posts/addons/scalingo-openvpn/2000-01-01-start.md
@@ -1,7 +1,7 @@
 ---
 title: Scalingo OpenVPN Addon
 nav: Introduction
-modified_at: 2023-05-26 00:00:00
+modified_at: 2023-08-28 00:00:00
 tags: vpn addon OpenVPN
 ---
 
@@ -16,6 +16,7 @@ With this addon, only the traffic targeting your VPN network will go through the
 
 This addon provides a way to create VPN connections from your application
 containers using the **OpenVPN** technology.
+This connection is done during the runtime of the application. You don't have access to your VPN network during the build of your application.
 
 ## Setup of the Addon
 

--- a/src/_posts/addons/scalingo-openvpn/2000-01-01-start.md
+++ b/src/_posts/addons/scalingo-openvpn/2000-01-01-start.md
@@ -1,7 +1,7 @@
 ---
 title: Scalingo OpenVPN Addon
 nav: Introduction
-modified_at: 2023-08-28 00:00:00
+modified_at: 2023-08-30 00:00:00
 tags: vpn addon OpenVPN
 ---
 
@@ -16,7 +16,10 @@ With this addon, only the traffic targeting your VPN network will go through the
 
 This addon provides a way to create VPN connections from your application
 containers using the **OpenVPN** technology.
+
+{% note %}
 This connection is done during the runtime of the application. You don't have access to your VPN network during the build of your application.
+{% endnote %}
 
 ## Setup of the Addon
 

--- a/src/_posts/addons/scalingo-vpn-ipsec/2000-01-01-start.md
+++ b/src/_posts/addons/scalingo-vpn-ipsec/2000-01-01-start.md
@@ -14,7 +14,10 @@ join the private network of this infrastructure.
 
 This addon provides a way to create VPN connections from your application
 containers using the **IPSec** technology.
+
+{% note %}
 This connection is done during the runtime of the application. You don't have access to your VPN network during the build of your application.
+{% endnote %}
 
 ## What kind of VPN can it connect to?
 

--- a/src/_posts/addons/scalingo-vpn-ipsec/2000-01-01-start.md
+++ b/src/_posts/addons/scalingo-vpn-ipsec/2000-01-01-start.md
@@ -1,7 +1,7 @@
 ---
 title: Scalingo VPNC IPSec Addon
 nav: Introduction
-modified_at: 2017-12-05 00:00:00
+modified_at: 2023-08-28 00:00:00
 tags: vpn addon custom feature
 ---
 
@@ -13,7 +13,8 @@ or databases in this infrastructure are to create a VPN connection and
 join the private network of this infrastructure.
 
 This addon provides a way to create VPN connections from your application
-containers.
+containers using the **IPSec** technology.
+This connection is done during the runtime of the application. You don't have access to your VPN network during the build of your application.
 
 ## What kind of VPN can it connect to?
 


### PR DESCRIPTION
Here is how the block looks:

![2023-08-30_11-08](https://github.com/Scalingo/documentation/assets/1567651/0f397e26-4e2f-4a29-bba3-df364888061b)


Fix #1662