### PR TITLE
docs(datadog): give an example of .buildpacks content

### DIFF
--- a/src/_posts/platform/app/2000-01-01-datadog.md
+++ b/src/_posts/platform/app/2000-01-01-datadog.md
@@ -2,7 +2,7 @@
 layout: page
 title: Configure Datadog to monitor Scalingo applications
 nav: Configure Datadog
-modified_at: 2018-06-15 10:00:00
+modified_at: 2023-08-30 10:00:00
 tags: integration datadog
 ---
 
@@ -22,8 +22,15 @@ configure your application to [use a multi buildpack]({% post_url
 platform/deployment/buildpacks/2000-01-01-multi %}).
 
 In the `.buildpacks` file at the root of your project, add the
-`https://github.com/DataDog/heroku-buildpack-datadog.git` buildpack in first
+`https://github.com/DataDog/heroku-buildpack-datadog` buildpack in first
 position. Then add your language specific buildpack.
+
+For example, the content of the file `.buildpacks` for a Node.js application should be:
+
+```text
+https://github.com/DataDog/heroku-buildpack-datadog
+https://github.com/Scalingo/nodejs-buildpack
+```
 
 The Datadog buildpack is configurable through various environment variables.
 The only mandatory one is `DD_API_KEY` available from the [Datadog API


### PR DESCRIPTION
A customer got confused and didn't noticed it's needed to also add the language buildpack. I think the page was slightly unclear about that.