### PR TITLE
fix(php,datadog): Use the new Datadog installer

### DIFF
--- a/src/_posts/languages/php/2000-01-01-start.md
+++ b/src/_posts/languages/php/2000-01-01-start.md
@@ -306,14 +306,15 @@ Your can read the logs on your dashboard or with the Scalingo CLI utility.
 The Datadog agent must be installed first ([see the documentation]({% post_url platform/app/2000-01-01-datadog %})).
 {% endnote %}
 
-To enable [Datadog](https://www.datadoghq.com/) support, set the `extra.paas.datadog` property to `true`. It makes the following Datadog product available:
+To enable [Datadog](https://www.datadoghq.com/) support, set the `extra.paas.datadog` property to `true`. It makes the following Datadog products available:
 
-- Datadog APM with the [Datadog Tracer extension](https://github.com/DataDog/dd-trace-php/).
-- Datadog Application Security with the [Datadog AppSec extension](https://github.com/DataDog/dd-appsec-php).
+- Datadog APM (Application Performance Monitoring)
+- Datadog ASM (Application Security Management)
 
-This automatically installs and enables the latest available version of the Datadog Tracer. To install a specific version, use the `DATADOG_TRACER_VERSION` environment variable (`latest` by default).
+This automatically installs the latest available version of the Datadog Tracer and enables APM. To disable the tracer, set the `DATADOG_TRACER_VERSION` environment variable to `0` (`latest` by default).
+Note that disabling the tracer will also disable APM and ASM.
 
-The Datadog AppSec extension is disabled by default. To install and enable the AppSec extension, set the `DATADOG_APPSEC_VERSION` environment variable to `latest` or any other valid version. Note that the AppSec extension requires the Tracer extension.
+The Datadog ASM (Application Security Management) extension is disabled by default. To install and enable ASM, set the `DATADOG_APPSEC_VERSION` environment variable to `latest` (`0` by default).
 
 #### `.extra.paas.new-relic`
 


### PR DESCRIPTION
This is the documentation update for the following php-buildpack pull request: https://github.com/Scalingo/php-buildpack/pull/351