### PR TITLE
Add trademarks relating to databases

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -125,22 +125,22 @@ languages:
 
 databases:
   - url: "/databases/postgresql/start"
-    name: "PostgreSQL"
+    name: "Scalingo for PostgreSQL®"
     logo: postgresql
   - url: "/databases/mysql/start"
-    name: "MySQL"
+    name: "Scalingo for MySQL®"
     logo: mysql
   - url: "/databases/mongodb/start"
-    name: "MongoDB"
+    name: "Scalingo for MongoDB®"
     logo: mongodb
   - url: "/databases/redis/start"
-    name: "Redis"
+    name: "Scalingo for Redis®"
     logo: redis
   - url: "/databases/influxdb/start"
-    name: "InfluxDB"
+    name: "Scalingo for InfluxDB®"
     logo: influxdb
   - url: "/databases/elasticsearch/start"
-    name: "Elasticsearch"
+    name: "Scalingo for Elasticsearch®"
     logo: elasticsearch
 
 samples:

--- a/src/_posts/databases/2000-01-01-elasticsearch.md
+++ b/src/_posts/databases/2000-01-01-elasticsearch.md
@@ -1,4 +1,4 @@
 ---
-title: Elasticsearch
+title: Scalingo for Elasticsearch®
 index: 5
 ---

--- a/src/_posts/databases/2000-01-01-influxdb.md
+++ b/src/_posts/databases/2000-01-01-influxdb.md
@@ -1,4 +1,4 @@
 ---
-title: InfluxDB
+title: Scalingo for InfluxDB®
 index: 6
 ---

--- a/src/_posts/databases/2000-01-01-mongodb.md
+++ b/src/_posts/databases/2000-01-01-mongodb.md
@@ -1,4 +1,4 @@
 ---
-title: MongoDB
+title: Scalingo for MongoDB®
 index: 3
 ---

--- a/src/_posts/databases/2000-01-01-mysql.md
+++ b/src/_posts/databases/2000-01-01-mysql.md
@@ -1,4 +1,4 @@
 ---
-title: MySQL
+title: Scalingo for MySQL®
 index: 2
 ---

--- a/src/_posts/databases/2000-01-01-postgresql.md
+++ b/src/_posts/databases/2000-01-01-postgresql.md
@@ -1,4 +1,4 @@
 ---
-title: PostgreSQL
+title: Scalingo for PostgreSQL®
 index: 1
 ---

--- a/src/_posts/databases/2000-01-01-redis.md
+++ b/src/_posts/databases/2000-01-01-redis.md
@@ -1,4 +1,4 @@
 ---
-title: Redis
+title: Scalingo for Redis®
 index: 4
 ---

--- a/src/_posts/databases/elasticsearch/2000-01-01-start.md
+++ b/src/_posts/databases/elasticsearch/2000-01-01-start.md
@@ -1,5 +1,5 @@
 ---
-title: Elasticsearch
+title: Scalingo for Elasticsearch®
 nav: Introduction
 modified_at: 2023-06-22 00:00:00
 tags: databases elasticsearch addon
@@ -7,14 +7,14 @@ tags: databases elasticsearch addon
 
 {% include info_command_line_tool.md %}
 
-Elasticsearch is the official addon provided by Scalingo.
+Scalingo for Elasticsearch® is the official Elasticsearch® addon provided by Scalingo.
 Details on the available plans can be found
 [here](https://scalingo.com/databases/elasticsearch). This addon gives
-your app instant access to an Elasticsearch database.
+your app instant access to an Elasticsearch® database.
 
-## Adding Elasticsearch to your app
+## Adding Scalingo for Elasticsearch® to your app
 
-You can add the Elasticsearch addon through the **Dashboard** or through the **command-line interface**. The capacity of your database is elastic, you will be able to upgrade it later.
+You can add the Scalingo for Elasticsearch® addon through the **Dashboard** or through the **command-line interface**. The capacity of your database is elastic, you will be able to upgrade it later.
 
 ### Through the Dashboard
 
@@ -38,7 +38,7 @@ $ scalingo --app my-app addons-add scalingo-elasticsearch elasticsearch-starter-
        Message from addon provider: Database successfully created
 ```
 
-This command will provision the application `my-app` with a `1g` Elasticsearch database plan.
+This command will provision the application `my-app` with a `1g` Scalingo for Elasticsearch® database plan.
 
 To find out what other plans are available:
 
@@ -46,17 +46,17 @@ To find out what other plans are available:
 $ scalingo addons-plans elasticsearch
 ```
 
-## Elasticsearch Cluster Setup
+## Scalingo gor Elasticsearch® Cluster Setup
 
-If using a Business plan for your Elasticsearch addon, we setup an Elasticsearch
+If using a Business plan for your Scalingo for Elasticsearch® addon, we setup an Elasticsearch®
 cluster. This cluster has the following configuration:
 
-- multiple Elasticsearch nodes in a private network: the amount of memory per
+- multiple Elasticsearch® nodes in a private network: the amount of memory per
   node depends on the plan,
-- a couple of HAProxy as entrypoint to the Elasticsearch private network: one is
+- a couple of HAProxy as entrypoint to the Elasticsearch® private network: one is
   the master and the other is just here as a backup in case of failing master.
 
-The communication between the Elasticsearch nodes is encrypted.
+The communication between the Elasticsearch® nodes is encrypted.
 
 ## Getting your connection URI
 
@@ -88,7 +88,7 @@ SCALINGO_ELASTICSEARCH_URL=http://my-app-3030:MpIxXstskccB3Ab2iwKH@my-app-3030.e
 
 {% include info_command_line_tool.md %}
 
-The difference between this data storage engine and the others is that Elasticsearch
+The difference between this data storage engine and the others is that Elasticsearch®
 communicates over HTTP, so you can use any tool built for that. You don't have to use
 an official client. The most common command line tool is `curl`. The following example
 uses it.
@@ -124,11 +124,11 @@ $ scalingo --app my-app run curl $SCALINGO_ELASTICSEARCH_URL
 
 ### Force TLS Connections
 
-Our Elasticsearch image support TLS to encrypt all of its network traffic
+Our Elasticsearch® image support TLS to encrypt all of its network traffic
 between the client and the server.
 
-Elasticsearch cannot listen to connections with and without TLS. If you want to
-encrypt communications with your Elasticsearch databases, you need to force all
+Scalingo for Elasticsearch® cannot listen to connections with and without TLS. If you want to
+encrypt communications with your Elasticsearch® databases, you need to force all
 connections to use TLS. Forcing TLS connections is as simple as heading to the
 database dashboard and clicking on the toggle button:
 
@@ -148,7 +148,7 @@ The `--insecure` option is mandatory as the generated certificates for your
 databases are
 [self-signed](https://en.wikipedia.org/wiki/Self-signed_certificate). If you
 want the certificate to be trust-able, you need to download our certification
-authority certificate and specify it to the Elasticsearch CLI tool.
+authority certificate and specify it to the Elasticsearch® CLI tool.
 
 Some existing databases may not have yet TLS support. To activate TLS, you need
 to restart the database. Any action leading to the restart will activate TLS
@@ -169,7 +169,7 @@ curl --cacert=/path/to/ca.pem -X GET "<URL>"
 
 You can upgrade or downgrade your database plan whenever you need it. This operation happens instantly thanks to Docker containers and no manual input is required. When you change the plan, your database will be stopped then restarted on a new host with new parameters of the chosen plan. During the operation the connection is dropped between your app and the database. Finally, after the operation is successful, the related app will be restarted.
 
-If using a Business plan for your Elasticsearch addon, we are able to change the plan of your database without downtime.
+If using a Business plan for your Scalingo for Elasticsearch® addon, we are able to change the plan of your database without downtime.
 
 ### From the Dashboard
 
@@ -203,7 +203,7 @@ $ scalingo --app my-app addons
 
 ## Database dashboard
 
-The Elasticsearch dashboard is the central place for administrative tasks such as:
+The Scalingo for Elasticsearch® dashboard is the central place for administrative tasks such as:
 
 - Monitor database and system stats
 - Upgrade the database engine version
@@ -229,8 +229,8 @@ Your database needs to be upgraded to the latest minor version before having acc
 For instance, your version is 2.3.X and you want to upgrade to 3.1.X. If there is a 2.5.X version, you need to upgrade it to the 2.5.X first.
 {% endnote %}
 
-If using a Business plan for your Elasticsearch addon, we are able to upgrade your instance to a
-newer version without downtime. In order to do so, we follow [Elasticsearch
+If using a Business plan for your Scalingo for Elasticsearch® addon, we are able to upgrade your instance to a
+newer version without downtime. In order to do so, we follow [Elasticsearch®
 guidelines](https://www.elastic.co/guide/en/elasticsearch/reference/current/rolling-upgrades.html).
 
 We first disable the shard allocation in the cluster. Then we shut down and upgrade the first node.
@@ -280,7 +280,7 @@ Beware that no downgrade is possible once your database has been upgraded.
 
 By default, Scalingo creates a read and write user on your database. This user has all rights on the database.
 
-It is not possible to create another user on an Elasticsearch database.
+It is not possible to create another user on an Scalingo for Elasticsearch® database.
 
 ## Backups
 
@@ -288,8 +288,8 @@ It is not possible to create another user on an Elasticsearch database.
 
 ### Download Backups
 
-Elasticsearch backups cannot be downloaded. This restriction is imposed by the
-internal working of Elasticsearch and we cannot circumvent it.
+Scalingo for Elasticsearch® backups cannot be downloaded. This restriction is imposed by the
+internal working of Elasticsearch® and we cannot circumvent it.
 
 ### Restoring a Backup
 
@@ -298,7 +298,7 @@ backups are listed in the database specific dashboard:
 
 1. Go to your app on [Scalingo Dashboard](https://my.scalingo.com/apps)
 2. Click on **Addons** tab
-3. Click **Link to dashboard** which will take you to the **Elasticsearch dashboard**
+3. Click **Link to dashboard** which will take you to the **Scalingo for Elasticsearch® dashboard**
 4. Click on **Backups** tab
 5. Click on the "Restore" button in front of the backup you want to restore
 

--- a/src/_posts/databases/influxdb/2000-01-01-dump-restore.md
+++ b/src/_posts/databases/influxdb/2000-01-01-dump-restore.md
@@ -1,5 +1,5 @@
 ---
-title: How to dump and restore my InfluxDB database on Scalingo
+title: How to dump and restore my Scalingo for InfluxDB® database on Scalingo
 nav: Dump and Restore
 modified_at: 2017-02-06 18:04:00
 index: 2
@@ -11,7 +11,7 @@ Scalingo handles daily backup for any paying plan. Unfortunately it is not
 possible for you to dump your data remotely from your local workstation. Refer
 to the
 <a href="#why-you-cannot-manage-the-backups-for-influxdb-on-scalingo">Why you
-cannot manage the backups for InfluxDB on Scalingo</a> section for more details
+cannot manage the backups on Scalingo for InfluxDB®</a> section for more details
 about the technical reasons.
 
 ## Restore on your local workstation
@@ -20,7 +20,7 @@ Daily backups done by Scalingo are listed in the database specific dashboard:
 
 1. Go to your app on [Scalingo Dashboard](https://my.scalingo.com/apps)
 2. Click on **Addons** tab
-3. Click **Link to dashboard** which will take you to the **InfluxDB dashboard**
+3. Click **Link to dashboard** which will take you to the **Scalingo for InfluxDB® dashboard**
 4. Click on **Backups** tab
 5. Download the backup you want
 
@@ -31,9 +31,9 @@ Daily backups done by Scalingo are listed in the database specific dashboard:
 
 You can restore your data on your local environment if needed. Download a backup on your database
 dashboard. It is a **.tar.gz** containing a dump of your database which has been
-done following the instructions from the [InfluxDB
+done following the instructions from the [InfluxDB®
 documentation](https://docs.influxdata.com/influxdb/v1.2/administration/backup_and_restore/).
-Before starting the restore process, you need to stop the InfluxDB daemon. Then type
+Before starting the restore process, you need to stop the InfluxDB® daemon. Then type
 the following commands:
 
 ```bash
@@ -48,12 +48,12 @@ depending on your configuration.
 If you need to restore a backup on your Scalingo server, please contact our
 support at [support@scalingo.com](mailto:support@scalingo.com).
 
-## Why you cannot manage the backups for InfluxDB on Scalingo
+## Why you cannot manage the backups on Scalingo for InfluxDB®
 
-Unfortunately, backing up and restoring your data from InfluxDB on Scalingo is not possible
+Unfortunately, backing up and restoring your data on Scalingo for InfluxDB® is not possible
 remotely. The problem is that the port used to make backup is different than the port used for the
-InfluxDB console. The remote backup port is not authenticated with a username and a password. Hence
+InfluxDB® console. The remote backup port is not authenticated with a username and a password. Hence
 we do not want it to be exposed over the Internet.
 
-Moreover, to restore your data on InfluxDB, the InfluxDB daemon must be stopped. This action is not
+Moreover, to restore your data on Scalingo for InfluxDB®, the InfluxDB® daemon must be stopped. This action is not
 possible on Scalingo.

--- a/src/_posts/databases/influxdb/2000-01-01-start.md
+++ b/src/_posts/databases/influxdb/2000-01-01-start.md
@@ -1,5 +1,5 @@
 ---
-title: InfluxDB
+title: Scalingo for InfluxDB®
 nav: Introduction
 modified_at: 2022-04-28 00:00:00
 tags: databases influxdb addon
@@ -8,11 +8,11 @@ index: 1
 
 {% include info_command_line_tool.md %}
 
-InfluxDB is the official addon provided by Scalingo, details on the available plans can be found [here](https://scalingo.com/databases/influxdb). This addon gives your app instant access to an InfluxDB database.
+Scalingo for InfluxDB® is the official InfluxDB® addon provided by Scalingo, details on the available plans can be found [here](https://scalingo.com/databases/influxdb). This addon gives your app instant access to an InfluxDB® database.
 
-## Adding InfluxDB to your app
+## Adding Scalingo for InfluxDB® to your app
 
-You can add the InfluxDB addon through the **Dashboard** or through the **command line interface**. The capacity of your database is elastic, you will be able to upgrade it later.
+You can add the Scalingo for InfluxDB® addon through the **Dashboard** or through the **command line interface**. The capacity of your database is elastic, you will be able to upgrade it later.
 
 ### Through the Dashboard
 
@@ -36,7 +36,7 @@ $ scalingo --app my-app addons-add influxdb 1g
        Message from addon provider: Database successfully created
 ```
 
-This command will provision the application `my-app` with a `1g` InfluxDB database plan.
+This command will provision the application `my-app` with a `1g` Scalingo for InfluxDB® database plan.
 
 To find out what other plans are available:
 
@@ -79,12 +79,12 @@ platform/databases/2000-01-01-access %}) guide.
 
 ### Force TLS Connections
 
-InfluxDB [support
+InfluxDB® [support
 TLS](https://docs.influxdata.com/influxdb/v1.2/administration/https_setup) to
 encrypt all of its network traffic between the client and the server.
 
-InfluxDB cannot listen to connections with and without TLS. If you want to
-encrypt communications with your InfluxDB databases, you need to force all
+InfluxDB® cannot listen to connections with and without TLS. If you want to
+encrypt communications with your Scalingo for InfluxDB® databases, you need to force all
 connections to use TLS. Forcing TLS connections is as simple as heading to the
 database dashboard and clicking on the toggle button:
 
@@ -149,7 +149,7 @@ $ scalingo --app my-app addons
 
 ## Database dashboard
 
-The InfluxDB dashboard is the central place for administrative tasks such as:
+The Scalingo InfluxDB® dashboard is the central place for administrative tasks such as:
 
 - Monitor database and system stats
 - Upgrade the database engine version
@@ -206,7 +206,7 @@ Beware that no downgrade is possible once your database has been upgraded.
     <tbody>
       <tr>
         <td class="mdl-data-table__cell--non-numeric">Data size</td>
-        <td class="mdl-data-table__cell--non-numeric">Size of your data provided by InfluxDB</td>
+        <td class="mdl-data-table__cell--non-numeric">Size of your data provided by InfluxDB®</td>
       </tr>
       <tr>
         <td class="mdl-data-table__cell--non-numeric">Database on disk size</td>
@@ -227,7 +227,7 @@ Periodic backups are listed in the database specific dashboard.
 
 1. Go to your app on [Scalingo Dashboard](https://my.scalingo.com/apps)
 2. Click on **Addons** tab
-3. Click **Link to dashboard** which will take you to the **InfluxDB dashboard**
+3. Click **Link to dashboard** which will take you to the **Scalingo for InfluxDB® dashboard**
 4. Click on **Backups** tab
 5. Download the backup you want
 
@@ -236,13 +236,13 @@ Periodic backups are listed in the database specific dashboard.
 
 ### Restoring a Backup
 
-Follow our guide: [How to dump and restore my InfluxDB database on Scalingo]({% post_url databases/influxdb/2000-01-01-dump-restore %})
+Follow our guide: [How to dump and restore my Scalingo for InfluxDB® database on Scalingo]({% post_url databases/influxdb/2000-01-01-dump-restore %})
 
 {% include encryption_at_rest.md %}
 
 ## Add Retention Policies
 
-InfluxDB provides a way to automatically delete records older than a certain date called retention
+InfluxDB® provides a way to automatically delete records older than a certain date called retention
 policy:
 
 ```
@@ -257,7 +257,7 @@ you can log into your database dashboard, and go to the "Advanced" tab.
 
 ## Removing a Measurement
 
-Your user is not admin on the InfluxDB database. Hence, removing a measurement
+Your user is not admin on the Scalingo for InfluxDB® database. Hence, removing a measurement
 with `DROP MEASUREMENT` leads to an error:
 
 ```
@@ -273,9 +273,9 @@ DROP SERIES FROM mymeasurement
 
 ## Control Memory Usage
 
-To reduce the memory usage of your InfluxDB database, you can leverage a combination of both continuous queries and retention policies:
+To reduce the memory usage of your InfluxDB® database, you can leverage a combination of both continuous queries and retention policies:
 
-- Use a continuous query to aggregate data to a larger time step. It can be created from the InfluxDB CLI.
+- Use a continuous query to aggregate data to a larger time step. It can be created from the InfluxDB® CLI.
 - Use a retention policy to remove old unaggregated data. It can be created from your database dashboard.
 
-If you are looking at reducing the memory usage, big tag cardinality also induces some memory issues. InfluxDB has the [`SHOW CARDINALITY`](https://docs.influxdata.com/influxdb/v1.6/query_language/spec/#show-cardinality) command to help you debug that.
+If you are looking at reducing the memory usage, big tag cardinality also induces some memory issues. InfluxDB® has the [`SHOW CARDINALITY`](https://docs.influxdata.com/influxdb/v1.6/query_language/spec/#show-cardinality) command to help you debug that.

--- a/src/_posts/databases/mongodb/2000-01-01-compass.md
+++ b/src/_posts/databases/mongodb/2000-01-01-compass.md
@@ -1,19 +1,19 @@
 ---
-title: Access Your MongoDB Database With Compass
+title: Access Your MongoDB® Database With Compass
 nav: Compass
 modified_at: 2022-07-25 00:00:00
 tags: databases mongodb compass tunnel
 index: 4
 ---
 
-MongoDB Compass is the official GUI to manage MongoDB database.
+MongoDB® Compass is the official GUI to manage MongoDB® database.
 It supports CRUD operations and offers nice visualization of your data.
 It is freely available on the
-[MongoDB website](https://www.mongodb.com/products/compass).
+[MongoDB® website](https://www.mongodb.com/products/compass).
 
 Databases hosted on Scalingo are not by default directly available on Internet.
-There are a couple of ways to get access to a Scalingo MongoDB hosted database
-with MongoDB Compass:
+There are a couple of ways to get access to a Scalingo for MongoDB® database
+with MongoDB® Compass:
 * Connection via an Encrypted Tunnel
 * Connection via the DB Tunnel of our CLI
 * Connection with TLS
@@ -40,7 +40,7 @@ In this case:
 
 ### Connection via an Encrypted Tunnel
 
-Open MongoDB Compass, then click on "New Connection".
+Open MongoDB® Compass, then click on "New Connection".
 After that click on "Advanced Connection Options" and fill the fields
 accordingly:
 
@@ -72,7 +72,7 @@ accordingly:
 ### Connection via the DB Tunnel of our CLI
 
 You can also use another method, that consist to create an Encrypted Tunnel
-with our CLI. Then in MongoDB Compass to connect into the database with a
+with our CLI. Then in MongoDB® Compass to connect into the database with a
 local address which correspond to the DB Tunnel.
 
 {% note %}
@@ -87,7 +87,7 @@ You can access your database on:
 127.0.0.1:10000
 ```
 
-Open MongoDB Compass, then click on "New Connection".
+Open MongoDB® Compass, then click on "New Connection".
 After that click on "Advanced Connection Options" and fill the fields
 accordingly:
 
@@ -114,7 +114,7 @@ you can make it available on the internet from your database dashboard.
 You must activate the
 [Internet Accessibility]({% post_url platform/databases/2000-01-01-access %}#internet-accessibility).
 
-Open MongoDB Compass, then click on "New Connection".
+Open MongoDB® Compass, then click on "New Connection".
 After that click on "Advanced Connection Options" and fill the fields
 accordingly:
 
@@ -139,7 +139,7 @@ accordingly:
 #### topology type: unknown is not writable
 
 If your plan has a single node replica, you might see the error
-`topology type: unknown is not writable` in MongoDB Compass.
+`topology type: unknown is not writable` in MongoDB® Compass.
 In such case, you should leave the field "Replica Set Name" from "Advanced"
 section empty.
 

--- a/src/_posts/databases/mongodb/2000-01-01-dump-restore.md
+++ b/src/_posts/databases/mongodb/2000-01-01-dump-restore.md
@@ -1,5 +1,5 @@
 ---
-title: How to dump and restore my MongoDB database on Scalingo
+title: How to dump and restore my Scalingo for MongoDB®
 nav: Dump and Restore
 modified_at: 2023-07-26 00:00:00
 tags: databases mongodb mongo tunnel dump restore
@@ -62,7 +62,7 @@ It is not possible to access a replica set using the DB tunnel.
 You should enable [Internet Accessibility]({% post_url platform/databases/2000-01-01-access %}#direct-access)
 to your database. The reason is that the DB tunnel is designed to connect to
 only one node.
-On the other hand, MongoDB clients require to reach all the instances
+On the other hand, MongoDB® clients require to reach all the instances
 of the replica set to work.
 {% endwarning %}
 
@@ -151,7 +151,7 @@ The advantage of this method is the network.
 From your workstation you don't always have a good bandwidth.
 From our infrastructure, data transfers will be way faster.
 
-You need to install the MongoDB CLI tools in the one-off before executing
+You need to install the MongoDB® CLI tools in the one-off before executing
 `mongodump` or `mongorestore`:
 
 ```bash

--- a/src/_posts/databases/mongodb/2000-01-01-robo3t.md
+++ b/src/_posts/databases/mongodb/2000-01-01-robo3t.md
@@ -1,5 +1,5 @@
 ---
-title: Access Your MongoDB Database With Robo 3T
+title: Access Your MongoDB® Database With Robo 3T
 nav: Robo 3T
 modified_at: 2022-04-28 00:00:00
 tags: databases mongodb robomongo robo3t tunnel
@@ -19,7 +19,7 @@ platform/databases/2000-01-01-access %}).
 ### Connection via an Encrypted Tunnel
 
 Robo 3T (formerly Robomongo) lets you configure this tunnel. We will guide
-through the steps to configure the connection to a Scalingo hosted MongoDB
+through the steps to configure the connection to a Scalingo for MongoDB® instance
 through an encrypted tunnel.
 
 The connection data can be found from the `MONGO_URL` environment variable of your

--- a/src/_posts/databases/mongodb/2000-01-01-start.md
+++ b/src/_posts/databases/mongodb/2000-01-01-start.md
@@ -1,5 +1,5 @@
 ---
-title: MongoDB
+title: Scalingo for MongoDB®
 nav: Introduction
 modified_at: 2023-05-23 00:00:00
 tags: databases mongodb addon
@@ -8,12 +8,12 @@ index: 1
 
 {% include info_command_line_tool.md %}
 
-MongoDB is the official addon provided by Scalingo, details on the available plans can be found [here](https://scalingo.com/databases/mongodb). This addon gives your app instant access to a MongoDB database running in its own Docker container.
+Scalingo for MongoDB® is the official MongoDB® addon provided by Scalingo, details on the available plans can be found [here](https://scalingo.com/databases/mongodb). This addon gives your app instant access to a MongoDB® database running in its own Docker container.
 
 
-## Adding MongoDB To Your App
+## Adding Scalingo for MongoDB® To Your App
 
-You can add the MongoDB addon through the **Dashboard** or through the **command line interface**. The capacity of your database is elastic, you will be able to upgrade it later.
+You can add the Scalingo for MongoDB® addon through the **Dashboard** or through the **command line interface**. The capacity of your database is elastic, you will be able to upgrade it later.
 
 ### Through the Dashboard
 
@@ -37,7 +37,7 @@ $ scalingo --app my-app addons-add mongodb 1g
        Message from addon provider: Database successfully created
 ```
 
-This command will provision the application `my-app` with a `1g` MongoDB database plan.
+This command will provision the application `my-app` with a `1g` Scalingo for MongoDB® database plan.
 
 To find out what other plans are available:
 
@@ -45,15 +45,15 @@ To find out what other plans are available:
 $ scalingo addons-plans mongodb
 ```
 
-## MongoDB Replica Set Setup
+## Scalingo for MongoDB® Replica Set Setup
 
-If using a Business plan for your MongoDB addon, we setup a MongoDB replica set. It has the following configuration:
+If using a Business plan for your Scalingo for MongoDB® addon, we setup a MongoDB® replica set. It has the following configuration:
 
 - 2 data nodes: one is the leader and the other is the follower. The leader receives all query to the database.
 - 1 shadow data node: this node is used for backups.
 - 1 arbiter: it does not contain any data. It's purpose is to take part to the vote in case of failing leader.
 
-The communication between the MongoDB nodes is encrypted.
+The communication between the MongoDB® nodes is encrypted.
 
 ## Getting Your Connection URI
 
@@ -89,12 +89,12 @@ platform/databases/2000-01-01-access %}) guide.
 
 ### Force TLS Connections
 
-MongoDB [support
+MongoDB® [support
 TLS](https://docs.mongodb.com/manual/core/security-transport-encryption/) to
 encrypt all of its network traffic: either between the client and the
 server or between the different replicas of your database.
 
-By default, all new MongoDB databases have TLS activated. If you want to
+By default, all new Scalingo for MongoDB® databases have TLS activated. If you want to
 connect to it, use the `--ssl` option:
 
 ```shell
@@ -111,7 +111,7 @@ The `--sslAllowInvalidCertificates` option is mandatory as the generated
 certificates for your databases are
 [self-signed](https://en.wikipedia.org/wiki/Self-signed_certificate). If you
 want the certificate to be trust-able, you need to download our certification
-authority certificate and specify it to the MongoDB CLI tool.
+authority certificate and specify it to the MongoDB® CLI tool.
 
 If you want to force connections to your database to use TLS, head to the
 database dashboard and click on the toggle button:
@@ -171,11 +171,11 @@ $ scalingo --app my-app addons
 
 ## Database Dashboard
 
-The MongoDB dashboard is the central place for administrative tasks such as:
+The Scalingo for MongoDB® dashboard is the central place for administrative tasks such as:
 
 - Monitor database and system stats
 - Upgrade the database engine version
-- Activate database specific features (e.g. Oplog for MongoDB)
+- Activate database specific features (e.g. Oplog for MongoDB®)
 - Manage database users
 - Manage backups
 
@@ -195,12 +195,12 @@ Your database needs to be upgraded to the latest minor version before having acc
 For instance, your version is 2.3.X and you want to upgrade to 3.1.X. If there is a 2.5.X version, you need to upgrade it to the 2.5.X first.
 {% endnote %}
 
-If using a Business plan for your MongoDB addon, we are able to upgrade your instance to a newer
-version *without downtime*. In order to do so, we follow [MongoDB
+If using a Business plan for your Scalingo for MongoDB® addon, we are able to upgrade your instance to a newer
+version *without downtime*. In order to do so, we follow [MongoDB®
 guidelines](https://www.mongodb.com/docs/manual/release-notes/4.0-upgrade-replica-set/).
 
 We first upgrade the secondary members of the replica set. Then, the primary member steps down (by
-issuing a MongoDB command) to force the election of a new primary amongst the current secondary
+issuing a MongoDB® command) to force the election of a new primary amongst the current secondary
 members. During the election, the replica set cannot receive write commands. This election process
 usually takes a dozen seconds. Once a new primary is elected, we can safely upgrade the remaining
 member and set the feature compatibility version to the latest one.
@@ -236,8 +236,8 @@ Beware that no downgrade is possible once your database has been upgraded.
   <table class="mdl-data-table ">
     <tbody>
       <tr>
-        <td class="mdl-data-table__cell--non-numeric">MongoDB index size</td>
-        <td class="mdl-data-table__cell--non-numeric">Index size reported by MongoDB, for the best performance this value should fit in the memory size.</td>
+        <td class="mdl-data-table__cell--non-numeric">MongoDB® index size</td>
+        <td class="mdl-data-table__cell--non-numeric">Index size reported by MongoDB®, for the best performance this value should fit in the memory size.</td>
       </tr>
       <tr>
         <td class="mdl-data-table__cell--non-numeric">Data size</td>
@@ -262,7 +262,7 @@ Automated backups are listed in the database specific dashboard.
 
 1. Go to your app on [Scalingo Dashboard](https://my.scalingo.com/apps)
 2. Click on **Addons** tab
-3. Click **Dashboard** which will take you to the **MongoDB dashboard**
+3. Click **Dashboard** which will take you to the **Scalingo for MongoDB® dashboard**
 4. Click on **Backups** tab
 5. Download the backup you want
 
@@ -271,13 +271,13 @@ Automated backups are listed in the database specific dashboard.
 
 ### Manual Database Backup
 
-If you wish to manually backup your database, please follow [How to dump and restore my MongoDB database on Scalingo]({% post_url databases/mongodb/2000-01-01-dump-restore %}) guide.
+If you wish to manually backup your database, please follow [How to dump and restore my Scalingo for MongoDB®]({% post_url databases/mongodb/2000-01-01-dump-restore %}) guide.
 
 {% include encryption_at_rest.md %}
 
-## MongoDB Oplog
+## MongoDB® Oplog
 
-Oplog is a MongoDB feature which logs all the operations achieved on a MongoDB cluster. This feature is tightly related to MongoDB replication, but is also used by Meteor to increase app performance. If you wish to use Oplog in your application please refer to the official [MongoDB documentation](https://docs.mongodb.org/manual/core/replica-set-oplog/). Oplog can be enabled from the database dashboard, when activated it will automatically add the `MONGO_OPLOG_URL` variable in your application.
+Oplog is a MongoDB® feature which logs all the operations achieved on a MongoDB® cluster. This feature is tightly related to MongoDB® replication, but is also used by Meteor to increase app performance. If you wish to use Oplog in your application please refer to the official [MongoDB® documentation](https://docs.mongodb.org/manual/core/replica-set-oplog/). Oplog can be enabled from the database dashboard, when activated it will automatically add the `MONGO_OPLOG_URL` variable in your application.
 
 ### Activating Oplog
 

--- a/src/_posts/databases/mysql/2000-01-01-dump-restore.md
+++ b/src/_posts/databases/mysql/2000-01-01-dump-restore.md
@@ -1,5 +1,5 @@
 ---
-title: How to dump and restore my MySQL database on Scalingo
+title: How to dump and restore my Scalingo for MySQL® database
 nav: Dump and Restore
 modified_at: 2023-07-26 00:00:00
 tags: databases mysql tunnel
@@ -77,7 +77,7 @@ The advantage of this method is the network.
 From your workstation you don't always have a good bandwidth. From our infrastructure,
 data transfers will be way faster.
 
-You need to install the MySQL CLI tools in the one-off before executing `mysqldump` or `mysql`:
+You need to install the MySQL® CLI tools in the one-off before executing `mysqldump` or `mysql`:
 
 ```bash
 $ scalingo --app my-app run bash

--- a/src/_posts/databases/mysql/2000-01-01-mysql-8-prerequisites.md
+++ b/src/_posts/databases/mysql/2000-01-01-mysql-8-prerequisites.md
@@ -1,13 +1,13 @@
 ---
-title: Prerequisites Before Upgrading to MySQL 8
+title: Prerequisites Before Upgrading to MySQL® 8
 nav: Upgrading to MySQL 8
 modified_at: 2020-09-04 00:00:00
 tags: databases mysql addon
 index: 4
 ---
 
-Starting with MySQL 8, Scalingo enables group replication on all MySQL
-databases. This MySQL feature has a couple of strong prerequisites ([MySQL
+Starting with MySQL® 8, Scalingo enables group replication on all MySQL®
+databases. This MySQL® feature has a couple of strong prerequisites ([MySQL®
 documentation](https://dev.mysql.com/doc/refman/8.0/en/group-replication-requirements.html)).
 Please make sure your database is compatible before proceeding with the upgrade:
 

--- a/src/_posts/databases/mysql/2000-01-01-start.md
+++ b/src/_posts/databases/mysql/2000-01-01-start.md
@@ -1,5 +1,5 @@
 ---
-title: MySQL
+title: Scalingo for MySQL®
 nav: Introduction
 modified_at: 2023-06-22 00:00:00
 tags: databases mysql addon
@@ -8,12 +8,12 @@ index: 1
 
 {% include info_command_line_tool.md %}
 
-MySQL is the official addon provided by Scalingo, details on the available plans can be found [here](https://scalingo.com/databases/mysql). This addon gives your app instant access to a MySQL database running in its own Docker container.
+Scalingo for MySQL® is the official MySQL® addon provided by Scalingo, details on the available plans can be found [here](https://scalingo.com/databases/mysql). This addon gives your app instant access to a MySQL® database running in its own Docker container.
 
 
-## Adding MySQL to Your App
+## Adding Scalingo for MySQL® to Your App
 
-You can add the MySQL addon through the dashboard or through the command line
+You can add the Scalingo for MySQL® addon through the dashboard or through the command line
 interface. The capacity of your database is elastic, you will be able to upgrade
 it later.
 
@@ -39,7 +39,7 @@ $ scalingo --app my-app addons-add mysql mysql-starter-1024
        Message from addon provider: Database successfully created
 ```
 
-This command will provision the application `my-app` with a `mysql-starter-1024` MySQL database plan.
+This command will provision the application `my-app` with a `mysql-starter-1024` Scalingo for MySQL® database plan.
 
 To find out what other plans are available:
 
@@ -47,18 +47,18 @@ To find out what other plans are available:
 $ scalingo addons-plans mysql
 ```
 
-## MySQL Cluster Setup
+## Scalingo for MySQL® Cluster Setup
 
 {% warning %}
-MySQL business plans are only available starting with MySQL 8. Consider [upgrading to MySQL 8]({% post_url databases/mysql/2000-01-01-mysql-8-prerequisites %}) if you want to benefit from high availability with MySQL.
+Scalingo for MySQL® business plans are only available starting with MySQL® 8. Consider [upgrading to MySQL® 8]({% post_url databases/mysql/2000-01-01-mysql-8-prerequisites %}) if you want to benefit from high availability with MySQL®.
 {% endwarning %}
 
-If using a Business plan for your MySQL addon, we setup a MySQL InnoDB cluster.
+If using a Business plan for your Scalingo for MySQL® addon, we setup a MySQL® InnoDB cluster.
 This cluster has the following configuration:
 
-- three MySQL nodes in a private network: the amount of memory per node depends
+- three MySQL® nodes in a private network: the amount of memory per node depends
   on the plan,
-- a couple of MySQL Routers as entrypoint to the MySQL private network: one is
+- a couple of MySQL® Routers as entrypoint to the MySQL® private network: one is
   the leader and the other is just here as a backup in case of failing leader.
 
 The communications in the private network are encrypted.
@@ -113,12 +113,12 @@ platform/databases/2000-01-01-access %}) guide.
 
 ### Force TLS Connections
 
-MySQL [support
+MySQL® [support
 TLS](https://dev.mysql.com/doc/refman/5.7/en/encrypted-connections.html) to
 encrypt all of its network traffic between the client and the
 server.
 
-By default, all new MySQL databases have TLS activated. If you want to connect
+By default, all new Scalingo for MySQL® databases have TLS activated. If you want to connect
 to it, you have nothing to do. The `mysql` client will automatically first try
 to connect using TLS, and if it fails will try without TLS. If you want to
 ensure it connects using TLS, you can use the `--ssl-mode` option:
@@ -188,7 +188,7 @@ $ scalingo --app my-app addons
 
 ## Database Dashboard
 
-The MySQL dashboard is the central place for administrative tasks such as:
+The Scalingo for MySQL® dashboard is the central place for administrative tasks such as:
 
 - Monitor database and system stats
 - Upgrade the database engine version
@@ -217,7 +217,7 @@ On single node database, we need to stop the node in order to upgrade it which
 induces a downtime. The duration of this downtime depends on the amount of data
 in your database.
 
-When upgrading from MySQL 5.7 to 8.0, please check the mandatory
+When upgrading from MySQ®L 5.7 to 8.0, please check the mandatory
 [prerequisites]({% post_url databases/mysql/2000-01-01-mysql-8-prerequisites %}). Upgrading to MySQL 8.0 is mandatory to benefit from MySQL high availability via business plans.
 
 {% warning %}
@@ -308,7 +308,7 @@ Automated backups are listed in the database specific dashboard.
 ### Manual Database Backup
 
 If you wish to manually backup your database, please follow [How to dump and
-restore my MySQL database on Scalingo]({% post_url
+restore my Scalingo for MySQL® database]({% post_url
 databases/mysql/2000-01-01-dump-restore %}) guide.
 
 {% include encryption_at_rest.md %}

--- a/src/_posts/databases/mysql/2000-01-01-workbench.md
+++ b/src/_posts/databases/mysql/2000-01-01-workbench.md
@@ -1,5 +1,5 @@
 ---
-title: Access your MySQL database with Workbench
+title: Access your MySQL® database with Workbench
 nav: MySQL Workbench
 modified_at: 2022-04-28 00:00:00
 tags: databases mysql workbench tunnel
@@ -8,15 +8,15 @@ index: 3
 
 ## Requirements
 
-Databases hosted on Scalingo are not by default directly available on the
+Scalingo for MySQL® databases are not by default directly available on the
 Internet. To access it, a solution is to setup an [encrypted tunnel]({% post_url
 platform/databases/2000-01-01-access %}).
 
-MySQL Workbench lets you configure this tunnel. We will guide through the steps
-to configure the connection to a Scalingo hosted MySQL through an encrypted
+MySQL® Workbench lets you configure this tunnel. We will guide through the steps
+to configure the connection to a Scalingo for MySQL® addon through an encrypted
 tunnel.
 
-## Configuration of MySQL
+## Database Configuration
 
 ### Authentication
 

--- a/src/_posts/databases/postgresql/2000-01-01-dump-restore.md
+++ b/src/_posts/databases/postgresql/2000-01-01-dump-restore.md
@@ -1,5 +1,5 @@
 ---
-title: How to dump and restore my PostgreSQL database on Scalingo
+title: How to dump and restore my Scalingo for PostgreSQL®
 nav: Dump and Restore
 modified_at: 2023-07-26 00:00:00
 tags: databases postgresql tunnel
@@ -90,7 +90,7 @@ The advantage of this method is the network.
 From your workstation you don't always have a good bandwidth. From our infrastructure,
 data transfers will be way faster.
 
-You need to install the PostgreSQL CLI tools in the one-off before executing `pg_dump` or `pg_restore`:
+You need to install the PostgreSQL® CLI tools in the one-off before executing `pg_dump` or `pg_restore`:
 
 ```bash
 $ scalingo --app my-app run bash

--- a/src/_posts/databases/postgresql/2000-01-01-extensions.md
+++ b/src/_posts/databases/postgresql/2000-01-01-extensions.md
@@ -1,5 +1,5 @@
 ---
-title: Managing PostgreSQL Extensions
+title: Managing PostgreSQL® Extensions
 nav: Extensions
 modified_at: 2022-02-24 00:00:00
 tags: databases postgresql extensions
@@ -8,9 +8,9 @@ index: 3
 
 {% include info_command_line_tool.md %}
 
-PostgreSQL is a database engine which is extensible thanks to
+PostgreSQL® is a database engine which is extensible thanks to
 a large set of extensions. A lot of them are installed alongside
-your PostgreSQL but you need to enable those manually according
+your Scalingo for PostgreSQL® instance, but you need to enable those manually according
 to your need.
 
 ## Enable a Specific Extension
@@ -73,7 +73,7 @@ PostGIS extension requires at least a "Starter 512M" plan to work.
 			<tr>
 				<td>dblink</td>
 				<td>1.2</td>
-				<td>connect to other PostgreSQL databases from within a database</td>
+				<td>connect to other PostgreSQL® databases from within a database</td>
 			</tr>
 			<tr>
 				<td>dict_int</td>
@@ -168,7 +168,7 @@ PostGIS extension requires at least a "Starter 512M" plan to work.
 			<tr>
 				<td>timescaledb</td>
 				<td>2.6.0</td>
-				<td>turns PostgreSQL into a time series database</td>
+				<td>turns PostgreSQL® into a time series database</td>
 			</tr>
 			<tr>
 				<td>unaccent</td>

--- a/src/_posts/databases/postgresql/2000-01-01-start.md
+++ b/src/_posts/databases/postgresql/2000-01-01-start.md
@@ -1,5 +1,5 @@
 ---
-title: PostgreSQL
+title: Scalingo for PostgreSQL®
 nav: Introduction
 modified_at: 2023-06-22 00:00:00
 tags: databases postgresql addon
@@ -8,11 +8,11 @@ index: 1
 
 {% include info_command_line_tool.md %}
 
-PostgreSQL is the official addon provided by Scalingo, details on the available plans can be found [here](https://scalingo.com/databases/postgresql). This addon gives your app instant access to a PostgreSQL database running in its own Docker container.
+Scalingo for PostgreSQL® is the official PostgreSQL® addon provided by Scalingo, details on the available plans can be found [here](https://scalingo.com/databases/postgresql). This addon gives your app instant access to a PostgreSQL® database running in its own Docker container.
 
-## Adding PostgreSQL to Your App
+## Adding Scalingo for PostgreSQL® to Your App
 
-You can add the PostgreSQL addon through the **dashboard** or through the **command line interface**. The capacity of your database is elastic, you will be able to upgrade it later.
+You can add the Scalingo for PostgreSQL® addon through the **dashboard** or through the **command line interface**. The capacity of your database is elastic, you will be able to upgrade it later.
 
 ### Through the Dashboard
 
@@ -45,17 +45,17 @@ To find out what other plans are available:
 $ scalingo addons-plans postgresql
 ```
 
-## PostgreSQL Cluster Setup
+## Scalingo for PostgreSQL® Cluster Setup
 
-If using a Business plan for your PostgreSQL addon, we setup a PostgreSQL
+If using a Business plan for your Scalingo for PostgreSQL® addon, we setup a PostgreSQL®
 cluster. This cluster has the following configuration:
 
-- multiple PostgreSQL nodes in a private network: the amount of memory per node
+- multiple PostgreSQL® nodes in a private network: the amount of memory per node
   depends on the plan,
 - a couple of HAProxy as entrypoint to your cluster private network: one is the
   leader and the other is just here as a backup in case of failing leader.
 
-The communication between the PostgreSQL nodes is encrypted.
+The communication between the PostgreSQL® nodes is encrypted.
 
 ## Getting your Connection URI
 
@@ -97,12 +97,12 @@ platform/databases/2000-01-01-access %}) guide.
 
 ### Force TLS Connections
 
-PostgreSQL [support
+PostgreSQL® [support
 TLS](https://www.postgresql.org/docs/current/static/ssl-tcp.html) to
 encrypt all of its network traffic between the client and the
 server.
 
-By default, all new PostgreSQL databases have TLS activated. If you want to
+By default, all new Scalingo for PostgreSQL® databases have TLS activated. If you want to
 connect to it, you have nothing to do. `psql` will automatically first try to
 connect using TLS, and if it fails will try without TLS. `psql` will display an
 informative message if you succeed to connect using TLS:
@@ -178,7 +178,7 @@ $ scalingo --app my-app addons
 
 ## Database Dashboard
 
-The PostgreSQL dashboard is the central place for administrative tasks such as:
+The Scalingo for PostgreSQL® dashboard is the central place for administrative tasks such as:
 
 - Monitor database and system stats
 - Upgrade the database engine version
@@ -283,15 +283,15 @@ ALTER DEFAULT PRIVILEGES FOR USER <database> IN SCHEMA public GRANT SELECT ON SE
 
 ### Running Queries
 
-The "Running Queries" tab displays the queries being executed on your database. It may be useful to understand the usage of your PostgreSQL database.
+The "Running Queries" tab displays the queries being executed on your database. It may be useful to understand the usage of your PostgreSQL® database.
 
-Some of these queries are considered "idled" by PostgreSQL. In order to display these queries you need to enable them with the toggle on the "Running Queries" tab. These idle queries should not be considered a _bad thing_. As stated on the PostgreSQL [mailing list](https://postgrespro.com/list/id/CAC6ry0LFHv+eMjpde_3jqfSnG9hg2O6s=9VTwLh2jiYydXSqGg@mail.gmail.com):
+Some of these queries are considered "idled" by PostgreSQL®. In order to display these queries you need to enable them with the toggle on the "Running Queries" tab. These idle queries should not be considered a _bad thing_. As stated on the PostgreSQ®L [mailing list](https://postgrespro.com/list/id/CAC6ry0LFHv+eMjpde_3jqfSnG9hg2O6s=9VTwLh2jiYydXSqGg@mail.gmail.com):
 
 > "idle" means the client is not currently executing a query nor in a transaction. If [the start date] is 2 days old, that just means the last query to be executed on that connection was two days ago. [...] It's generally desirable for a connection pool to have a few idle connections so queries don't suffer the latency of establishing a new connection.
 
 ## Backups
 
-Scalingo PostgreSQL databases offer two way of backing up the data.
+Scalingo for PostgreSQL® databases offer two way of backing up the data.
 
 ### Point-in-Time Recovery
 
@@ -323,7 +323,7 @@ Automated backups are listed in the database specific dashboard.
 
 1. Go to your app on [Scalingo Dashboard](https://my.scalingo.com/apps)
 2. Click on **Addons** tab
-3. Click **Link to dashboard** which will take you to the **PostgreSQL dashboard**
+3. Click **Link to dashboard** which will take you to the **Scalingo for PostgreSQL® dashboard**
 4. Click on **Backups** tab
 5. Download the backup you want
 
@@ -339,11 +339,11 @@ You can see the memory usage of your database on the "Metrics" tab of your web d
 {% assign img_url = "https://cdn.scalingo.com/documentation/screenshot_database_postgresql_metrics.png" %}
 {% include mdl_img.html %}
 
-PostgreSQL tends to use all the available memory if there is enough indices to fill the memory. If there is too many indices to fit into the memory, some of them are stored on the disk. In this situation, queries needing these indices will be slowed down. PostgreSQL first needs to load the indices from the disk into the RAM which takes some time. The memory usage on the "Metrics" tab of your web dashboard would always be at 100% in such situation.
+PostgreSQL® tends to use all the available memory if there is enough indices to fill the memory. If there is too many indices to fit into the memory, some of them are stored on the disk. In this situation, queries needing these indices will be slowed down. PostgreSQL® first needs to load the indices from the disk into the RAM which takes some time. The memory usage on the "Metrics" tab of your web dashboard would always be at 100% in such situation.
 
 ## Client Customization
 
-You can customize the PostgreSQL client by adding a `.psqlrc` in your app directory.
+You can customize the PostgreSQL® client by adding a `.psqlrc` in your app directory.
 
 For example:
 ```

--- a/src/_posts/databases/postgresql/timescaledb/2000-01-01-dump-restore.md
+++ b/src/_posts/databases/postgresql/timescaledb/2000-01-01-dump-restore.md
@@ -13,7 +13,7 @@ index: 2
 
 You can use the command `pg_dump` as explained
 [on our documentation]({% post_url databases/postgresql/2000-01-01-dump-restore %}).
-But you cannot restore it on a PostgreSQL using TimescaleDB hosted on Scalingo.
+But you cannot restore it on a PostgreSQL® instance using TimescaleDB hosted on Scalingo.
 
 The only dump available to make restorable backups on Scalingo hosted TimescaleDB
 are the [on demand backups]({% post_url databases/postgresql/2000-01-01-start %}#on-demand-backups).
@@ -26,7 +26,7 @@ backups are still working normally.
 ## Restore
 
 The backup restoration on TimescaleDB requires a specific process to be done on
-the PostgreSQL database as it is explained on
+the PostgreSQL® database as it is explained on
 [TimescaleDB official documentation](https://docs.timescale.com/timescaledb/latest/how-to-guides/backup-and-restore/pg-dump-and-restore/#restoring-an-entire-database-from-backup).
 A temporary database should be used for the backup restore and the following
 command should be executed using admin rights:
@@ -42,7 +42,7 @@ process must be done by an operator of the support.
 
 Several points are important to take into account.
 
-Make sure you keep track of which versions of PostgreSQL and TimescaleDB you are
+Make sure you keep track of which versions of PostgreSQL® and TimescaleDB you are
 running during backup process. For more information, see "Troubleshooting version mismatches" of
 [official documentation](https://docs.timescale.com/timescaledb/latest/how-to-guides/backup-and-restore/pg-dump-and-restore/#tshoot-version-mismatch).
 

--- a/src/_posts/databases/postgresql/timescaledb/2000-01-01-intro.md
+++ b/src/_posts/databases/postgresql/timescaledb/2000-01-01-intro.md
@@ -6,11 +6,11 @@ tags: timescale databases postgresql extensions
 index: 1
 ---
 
-TimescaleDB is a PostgreSQL extension for the support of time series data.
+TimescaleDB is a ® extension for the support of time series data.
 This extension adds several features and functions. You can find more information
-on the [official documentation](https://docs.timescale.com/api/latest). TimescaleDB is available in Scalingo PostgreSQL databases starting with the version 13.6.0-1.
+on the [official documentation](https://docs.timescale.com/api/latest). TimescaleDB is available in Scalingo for PostgreSQL® databases starting with the version 13.6.0-1.
 
-To enable TimescaleDB, provision a [new PostgreSQL database]({% post_url databases/postgresql/2000-01-01-start %}#adding-postgresql-to-your-app) and execute the following SQL command:
+To enable TimescaleDB, provision a [new Scalingo for PostgreSQL® database]({% post_url databases/postgresql/2000-01-01-start %}#adding-postgresql-to-your-app) and execute the following SQL command:
 
 ```sql
 CREATE EXTENSION timescaledb;

--- a/src/_posts/databases/redis/2000-01-01-data-import.md
+++ b/src/_posts/databases/redis/2000-01-01-data-import.md
@@ -6,9 +6,9 @@ tags: databases redis dump restore migration
 index: 3
 ---
 
-This tutorial aims at transferring all the data from a remote Redis® database
-(from another provider) to a Redis® instance provisioned through the [Scalingo
-Redis Addon]({% post_url databases/redis/2000-01-01-start %}).
+This tutorial aims at transferring all the data from a remote Redis®* database
+(from another provider) to a Redis®* instance provisioned through the [Scalingo
+For Redis® Addon]({% post_url databases/redis/2000-01-01-start %}).
 
 {% include info_command_line_tool.md %}
 

--- a/src/_posts/databases/redis/2000-01-01-data-import.md
+++ b/src/_posts/databases/redis/2000-01-01-data-import.md
@@ -39,3 +39,5 @@ At that point, the replication process has started. Its duration is relative to
 the amount of data contained on the remote database. It's usually a matter of seconds.
 
 Note that the `riot-redis` tool is powerful and includes various arguments. All the information is on the [documentation page](https://developer.redis.com/riot/riot-redis/). You may want to have a look at the `--mode live` option for continuous replication. It could be useful for a 0-downtime migration.
+
+*Redis is a registered trademark of Redis Ltd. Any rights therein are reserved to Redis Ltd. Any use by Scalingo is for referential purposes only and does not indicate any sponsorship, endorsement or affiliation between Redis and Scalingo.

--- a/src/_posts/databases/redis/2000-01-01-data-import.md
+++ b/src/_posts/databases/redis/2000-01-01-data-import.md
@@ -1,26 +1,26 @@
 ---
-title: Importing Data From an External Redis Database
+title: Importing Data From an External Redis® Database
 nav: Importing Data
 modified_at: 2023-02-17 00:00:00
 tags: databases redis dump restore migration
 index: 3
 ---
 
-This tutorial aims at transferring all the data from a remote Redis database
-(from another provider) to a Redis instance provisioned through the [Scalingo
+This tutorial aims at transferring all the data from a remote Redis® database
+(from another provider) to a Redis® instance provisioned through the [Scalingo
 Redis Addon]({% post_url databases/redis/2000-01-01-start %}).
 
 {% include info_command_line_tool.md %}
 
 ## Requirements
 
-The remote Redis instance should be accessible on the Internet.
+The remote Redis® instance should be accessible on the Internet.
 
-These instructions require Redis Input/Output Tools (RIOT) to be installed. This is a set of tools developed by the Redis team. The installation instructions are available on [this page](https://developer.redis.com/riot/riot-redis).
+These instructions require Redis® Input/Output Tools (RIOT) to be installed. This is a set of tools developed by the Redis® team. The installation instructions are available on [this page](https://developer.redis.com/riot/riot-redis).
 
 ## Install RIOT in a One-Off Container
 
-You first need to install RIOT in a one-off container of your application. RIOT needs a Java Runtime Environment (JRE) to work. When JRE and RIOT are installed, we can replicate the Redis running on an external server:
+You first need to install RIOT in a one-off container of your application. RIOT needs a Java Runtime Environment (JRE) to work. When JRE and RIOT are installed, we can replicate the Redis® running on an external server:
 
 ```sh
 $ scalingo --app my-app run bash
@@ -33,7 +33,7 @@ $ scalingo --app my-app run bash
 [00:00] Scalingo ~ $ ./riot-redis-*/bin/riot-redis --uri $REDIS_SOURCE_URL replicate --uri $SCALINGO_REDIS_URL
 ```
 
-The `REDIS_SOURCE_URL` variable must contain the connection string to the external Redis instance. For Redis URI syntax see [here](https://github.com/lettuce-io/lettuce-core/wiki/Redis-URI-and-connection-details#uri-syntax).
+The `REDIS_SOURCE_URL` variable must contain the connection string to the external Redis® instance. For Redis® URI syntax see [here](https://github.com/lettuce-io/lettuce-core/wiki/Redis-URI-and-connection-details#uri-syntax).
 
 At that point, the replication process has started. Its duration is relative to
 the amount of data contained on the remote database. It's usually a matter of seconds.

--- a/src/_posts/databases/redis/2000-01-01-dump-restore.md
+++ b/src/_posts/databases/redis/2000-01-01-dump-restore.md
@@ -88,3 +88,5 @@ exit
 ```
 
 After exiting the one-off container, the dump is lost. You have to do something with it in the container.
+
+*Redis is a registered trademark of Redis Ltd. Any rights therein are reserved to Redis Ltd. Any use by Scalingo is for referential purposes only and does not indicate any sponsorship, endorsement or affiliation between Redis and Scalingo.

--- a/src/_posts/databases/redis/2000-01-01-dump-restore.md
+++ b/src/_posts/databases/redis/2000-01-01-dump-restore.md
@@ -1,5 +1,5 @@
 ---
-title: How to dump and restore my Redis database on Scalingo
+title: How to dump and restore my Scalingo for Redis® database
 nav: Dump and Restore
 modified_at: 2023-07-26 00:00:00
 tags: databases redis tunnel
@@ -10,7 +10,7 @@ index: 2
 
 There are different ways to dump a Scalingo hosted database. The first one involves dumping the data on your local workstation and the second one involves doing the same operation from within a Scalingo one-off container (see [application tasks]({% post_url platform/app/2000-01-01-tasks %})).
 
-Redis backups cannot be restored on Scalingo. To restore a Redis backup, one need to get access to the database file system which is not possible on Scalingo. However it is possible to [import data from an external Redis database]({% post_url databases/redis/2000-01-01-data-import %}).
+Redis® backups cannot be restored on Scalingo for Redis® databases. To restore a Redis® backup, one need to get access to the database file system which is not possible on Scalingo. However it is possible to [import data from an external Redis® database]({% post_url databases/redis/2000-01-01-data-import %}).
 
 ## Dump From Your Local Workstation
 
@@ -65,7 +65,7 @@ $ redis-cli -h localhost -p 10000 -a <password> --rdb ./dump.rdb
 
 You can dump your database remotely using [the command-line-tool]({% post_url platform/cli/2000-01-01-start %}) and a one-off container (see [application tasks]({% post_url platform/app/2000-01-01-tasks %})). The advantage of this method is the network. From your workstation you don't always have a good bandwidth. From our infrastructure, data transfers will be way faster.
 
-You need to install the Redis CLI tools in the one-off before executing `redis-cli`:
+You need to install the Redis® CLI tools in the one-off before executing `redis-cli`:
 
 ```sh
 $ scalingo --app my-app run bash

--- a/src/_posts/databases/redis/2000-01-01-dump-restore.md
+++ b/src/_posts/databases/redis/2000-01-01-dump-restore.md
@@ -10,7 +10,7 @@ index: 2
 
 There are different ways to dump a Scalingo hosted database. The first one involves dumping the data on your local workstation and the second one involves doing the same operation from within a Scalingo one-off container (see [application tasks]({% post_url platform/app/2000-01-01-tasks %})).
 
-Redis® backups cannot be restored on Scalingo for Redis® databases. To restore a Redis® backup, one need to get access to the database file system which is not possible on Scalingo. However it is possible to [import data from an external Redis® database]({% post_url databases/redis/2000-01-01-data-import %}).
+Redis®* backups cannot be restored on Scalingo for Redis® databases. To restore a Redis® backup, one need to get access to the database file system which is not possible on Scalingo. However it is possible to [import data from an external Redis® database]({% post_url databases/redis/2000-01-01-data-import %}).
 
 ## Dump From Your Local Workstation
 

--- a/src/_posts/databases/redis/2000-01-01-start.md
+++ b/src/_posts/databases/redis/2000-01-01-start.md
@@ -1,5 +1,5 @@
 ---
-title: Redis
+title: Scalingo for Redis®
 nav: Introduction
 modified_at: 2023-06-22 00:00:00
 tags: databases redis addon
@@ -8,12 +8,12 @@ index: 1
 
 {% include info_command_line_tool.md %}
 
-Redis is the official addon provided by Scalingo, details on the available plans can be found [here](https://scalingo.com/databases/redis). This addon gives your app instant access to a Redis database running in its own Docker container.
+Scalingo for Redis® is the official Redis® addon provided by Scalingo. Details on the available plans can be found [here](https://scalingo.com/databases/redis). This addon gives your app instant access to a Redis® database running in its own Docker container.
 
 
-## Adding Redis to Your app
+## Adding Scalingo for Redis® to Your app
 
-You can add the Redis addon through the dashboard or through the command line interface. The capacity of your database is elastic, you will be able to upgrade it later.
+You can add the Scalingo for Redis® addon through the dashboard or through the command line interface. The capacity of your database is elastic, you will be able to upgrade it later.
 
 ### Through the Dashboard
 
@@ -38,7 +38,7 @@ $ scalingo --app my-app addons-add redis redis-starter-1024
 ```
 
 This command will provision the application `my-app` with a `redis-starter-1024`
-Redis database plan.
+Scalingo for Redis® database plan.
 
 To find out what other plans are available:
 
@@ -46,16 +46,16 @@ To find out what other plans are available:
 $ scalingo addons-plans redis
 ```
 
-## Redis Cluster Setup
+## Scalingo for Redis® Cluster Setup
 
-If using a Business plan for your Redis addon, we setup a Redis cluster. This
+If using a Business plan for your Scalingo for Redis® addon, we setup a Redis® cluster. This
 cluster has the following configuration:
 
-- multiple Redis nodes in a private network: the amount of memory per node
+- multiple Redis® nodes in a private network: the amount of memory per node
   depends on the plan,
-- a couple of HAProxy as entrypoint to the Redis private network: one is the
+- a couple of HAProxy as entrypoint to the Redis® private network: one is the
   leader and the other is just here as a backup in case of failing leader.
-- three Redis sentinels to initiate the election of a new leader if the current
+- three Redis® sentinels to initiate the election of a new leader if the current
   leader fails.
 
 ## Getting Your Connection URI
@@ -99,31 +99,31 @@ database dashboard and click on the toggle button:
 Note that you must have configured your application to use TLS when connecting
 to the database.
 
-## Redis Configuration
+## Scalingo for Redis® Configuration
 
 ### Number of Databases
 
-Each Redis instance can use 5 databases (numbered from 0, the default DB, to 4).
+Each Redis® instance can use 5 databases (numbered from 0, the default DB, to 4).
 
 ### Idle Connections Timeout
 
-Redis configuration:
+Redis® configuration:
 
 ```
 timeout 150
 ```
 
 It means that if a connection has not been used during 150 seconds, it will be automatically closed
-by Redis. This is done to avoid accumulating staled connections. You must ensure that your
-application code handles gracefully potential timeouts in Redis connections.
+by Redis®. This is done to avoid accumulating staled connections. You must ensure that your
+application code handles gracefully potential timeouts in Redis® connections.
 
 ### Persistence Mode
 
-Redis does not write all the operations requested by users on disk instantly, the write operations
+Redis® does not write all the operations requested by users on disk instantly, the write operations
 are done asynchronously by following different rules. There are two
 [persistence](https://redis.io/topics/persistence) modes: snapshot and strong persistence. They both
 represent a different trade-off in terms of performance and reliability. As such, you must take
-great care in your Redis persistence mode settings.
+great care in your Redis® persistence mode settings.
 
 #### Snapshot Persistence aka RDB
 
@@ -139,30 +139,30 @@ It means that in the scope of an incident, recent data are lost.
 
 #### Strong Persistence aka AOF
 
-The second mode provides Redis with the highest level of persistence (also called AOF). Any command
-impacting the dataset will be saved synchronously in a file. In case of incident, Redis replays the
+The second mode provides Redis® with the highest level of persistence (also called AOF). Any command
+impacting the dataset will be saved synchronously in a file. In case of incident, Redis® replays the
 logged operations to reconstruct the database dataset.
 
-The typical use case is when using Redis as a key-value store. We can imagine the comments on a blog
-post page being stored in a Redis list. Losing comments because of an unexpected Redis restart is
+The typical use case is when using Redis® as a key-value store. We can imagine the comments on a blog
+post page being stored in a Redis® list. Losing comments because of an unexpected Redis® restart is
 not acceptable and activating AOF mode sounds like a good idea.
 
 ### Cache Mode
 
-The last available configuration is related to how long data are stored in Redis. When cache mode is
-activated and the memory is full, Redis will automatically drop the less recently used data to free
+The last available configuration is related to how long data are stored in Redis®. When cache mode is
+activated and the memory is full, Redis® will automatically drop the less recently used data to free
 up memory for most recent data. Be cautious as any data can be deleted.
 
 {% warning %}
-Don't use your Redis instance to store important information in cache mode.
+Don't use your Redis® instance to store important information in cache mode.
 {% endwarning %}
 
-The typical use case is Scalingo's homepage and blog. It uses Redis as a cache for HTML fragments.
-In such case, we can afford using the oldest data stored in Redis, and re-compute them if needed.
+The typical use case is Scalingo's homepage and blog. It uses Redis® as a cache for HTML fragments.
+In such case, we can afford using the oldest data stored in Redis®, and re-compute them if needed.
 
-This feature uses [two settings](https://redis.io/topics/lru-cache) of Redis:
+This feature uses [two settings](https://redis.io/topics/lru-cache) of Redis®:
 
-- `maxmemory`: Amount of data Redis accepts before dropping some of them. It is set at the value of
+- `maxmemory`: Amount of data Redis® accepts before dropping some of them. It is set at the value of
   the memory available of the database plan you have chosen.
 - `maxmemory-policy`: Set at `allkeys-lru`, which means ‘Least Recently Used’ keys will be evicted
   first if the `maxmemory` amount is reached.
@@ -205,7 +205,7 @@ $ scalingo --app my-app addons
 
 ## Database Dashboard
 
-The Redis dashboard is the central place for administrative tasks such as:
+The Scalingo for Redis® dashboard is the central place for administrative tasks such as:
 
 - Monitor database and system stats
 - Upgrade the database engine version
@@ -272,13 +272,13 @@ Beware that no downgrade is possible once your database has been upgraded.
 
 ### Database Users
 
-Scalingo does not leverage yet the ACL feature introduced in Redis 6. Hence Scalingo Redis databases have a single default user with a password generated by Scalingo. The list of ACL of this default user are:
+Scalingo does not leverage yet the ACL feature introduced in Redis® 6. Hence Scalingo Redis® databases have a single default user with a password generated by Scalingo. The list of ACL of this default user are:
 
 ```
 user default on <password> ~* &* +@all
 ```
 
-It is not possible to create another user on a Redis database.
+It is not possible to create another user on a Redis® database.
 
 ## Backups
 
@@ -294,7 +294,7 @@ Automated backups are listed in the database specific dashboard.
 
 1. Go to your app on [Scalingo Dashboard](https://my.scalingo.com/apps)
 2. Click on **Addons** tab
-3. Click **Link to dashboard** which will take you to the **Redis dashboard**
+3. Click **Link to dashboard** which will take you to the **Redis® dashboard**
 4. Click on **Backups** tab
 5. Download the backup you want
 

--- a/src/_posts/databases/redis/2000-01-01-start.md
+++ b/src/_posts/databases/redis/2000-01-01-start.md
@@ -8,7 +8,7 @@ index: 1
 
 {% include info_command_line_tool.md %}
 
-Scalingo for Redis® is the official Redis® addon provided by Scalingo. Details on the available plans can be found [here](https://scalingo.com/databases/redis). This addon gives your app instant access to a Redis® database running in its own Docker container.
+Scalingo for Redis® is the official Redis®* addon provided by Scalingo. Details on the available plans can be found [here](https://scalingo.com/databases/redis). This addon gives your app instant access to a Redis® database running in its own Docker container.
 
 
 ## Adding Scalingo for Redis® to Your app

--- a/src/_posts/databases/redis/2000-01-01-start.md
+++ b/src/_posts/databases/redis/2000-01-01-start.md
@@ -302,3 +302,5 @@ Automated backups are listed in the database specific dashboard.
 {% include mdl_img.html %}
 
 {% include encryption_at_rest.md %}
+
+*Redis is a registered trademark of Redis Ltd. Any rights therein are reserved to Redis Ltd. Any use by Scalingo is for referential purposes only and does not indicate any sponsorship, endorsement or affiliation between Redis and Scalingo.

--- a/src/_posts/languages/meteorjs/2000-01-01-start.md
+++ b/src/_posts/languages/meteorjs/2000-01-01-start.md
@@ -152,11 +152,11 @@ it only in staging/pre-production environments.
 As a real time framework, the number of scaling constraints is higher than another more classical
 framework. Each instance is keeping some stateful information and each instance has to be able to
 get instantly the most up-to-date data. To achieve that, the two common processes used are the
-_sticky sessions_ and the _oplog_ feature of MongoDB.
+_sticky sessions_ and the _oplog_ feature of MongoDB®.
 
 ### Oplog
 
-__Oplog__ is a MongoDB feature which logs all the operations achieved on a MongoDB cluster. __Meteor__
+__Oplog__ is a MongoDB® feature which logs all the operations achieved on a MongoDB® cluster. __Meteor__
 uses this feature to sync different instances of an application.
 
 {% note %}

--- a/src/_posts/languages/meteorjs/2000-01-01-telescope.md
+++ b/src/_posts/languages/meteorjs/2000-01-01-telescope.md
@@ -31,9 +31,9 @@ Git repository detected: remote scalingo added
 → 'git push scalingo master' to deploy your app
 ```
 
-## Allocate a MongoDB database
+## Allocate a Scalingo for MongoDB® database
 
-The Meteor framework uses extensively MongoDB as a database. Hence you need to
+The Meteor framework uses extensively MongoDB® as a database. Hence you need to
 provision a new instance of this database to your application.
 
 ```bash

--- a/src/_posts/languages/meteorjs/2000-01-01-tutorial.md
+++ b/src/_posts/languages/meteorjs/2000-01-01-tutorial.md
@@ -23,9 +23,9 @@ $ git init .
 $ git commit -m "Init meteor application"
 ```
 
-## Create your application and provision a MongoDB database
+## Create your application and provision a Scalingo for MongoDB® database
 
-The Meteor framework uses extensively MongoDB as a database. Hence you need to
+The Meteor framework uses extensively MongoDB® as a database. Hence you need to
 provision a new instance of this database to your application.
 
 ```bash

--- a/src/_posts/languages/php/2000-01-01-codeigniter.md
+++ b/src/_posts/languages/php/2000-01-01-codeigniter.md
@@ -36,7 +36,7 @@ $config['log_threshold'] = 1;
 ```
 
 You probably also need to configure a SQL database. You first need to provision a new database such
-as [MySQL]({% post_url databases/mysql/2000-01-01-start %}). Then configure CodeIgniter in
+as [Scalingo for MySQL®]({% post_url databases/mysql/2000-01-01-start %}). Then configure CodeIgniter in
 `application/config/database.php`:
 
 ```php

--- a/src/_posts/languages/php/2000-01-01-laravel.md
+++ b/src/_posts/languages/php/2000-01-01-laravel.md
@@ -51,8 +51,8 @@ scalingo env-set APP_URL=https://my-app.osc-fr1.scalingo.io
 
 ### Database Connection
 
-Your application also requires a database, often a SQL database like MySQL
-or PostgreSQL. Configuration is similar, replace `mysql://` by `postgresql://`.
+Your application also requires a database, often a SQL database like MySQL®
+or PostgreSQL®. Configuration is similar, replace `mysql://` by `postgresql://`.
 
 First, a [Scalingo for MySQL®]({% post_url
 databases/mysql/2000-01-01-start %}) or [Scalingo for PostgreSQL®]({% post_url

--- a/src/_posts/languages/php/2000-01-01-laravel.md
+++ b/src/_posts/languages/php/2000-01-01-laravel.md
@@ -54,9 +54,9 @@ scalingo env-set APP_URL=https://my-app.osc-fr1.scalingo.io
 Your application also requires a database, often a SQL database like MySQL
 or PostgreSQL. Configuration is similar, replace `mysql://` by `postgresql://`.
 
-First, a [MySQL]({% post_url
-databases/mysql/2000-01-01-start %}) or [PostgreSQL]({% post_url
-databases/postgresql/2000-01-01-start %}) has to be added to your
+First, a [Scalingo for MySQL®]({% post_url
+databases/mysql/2000-01-01-start %}) or [Scalingo for PostgreSQL®]({% post_url
+databases/postgresql/2000-01-01-start %}) database has to be added to your
 application. This addon will inject the environment variable `SCALINGO_MYSQL_URL`
 or `SCALINGO_POSTGRESQL_URL` and alias it to `DATABASE_URL`. We recommend using the
 alias.

--- a/src/_posts/languages/php/2019-02-08-php-session-redis.md
+++ b/src/_posts/languages/php/2019-02-08-php-session-redis.md
@@ -1,5 +1,5 @@
 ---
-title: PHP Session with Redis
+title: PHP Session with Redis®
 nav: Session with Redis
 modified_at: 2019-03-22 00:00:00
 tags: php redis
@@ -20,7 +20,7 @@ deployment, the sessions would be lost as new containers start with a fresh file
 ## Solutions
 
 One of the solution could be to store the session in a cookie (with encryption to prevent the user
-from modifying it). An other one is to store the session in a database. [Redis]({% post_url
+from modifying it). An other one is to store the session in a database. [Scalingo for Redis®]({% post_url
 databases/redis/2000-01-01-start %}) is especially suitable in such case.
 
 {% note %}
@@ -30,7 +30,7 @@ with the Laravel framework: [Laravel
 documentation](https://laravel.com/docs/5.8/session).
 {% endnote %}
 
-On Scalingo, the PHP Redis extension is available. Activate it by modifying the `composer.json`
+On Scalingo, the PHP Redis® extension is available. Activate it by modifying the `composer.json`
 with:
 
 ```json
@@ -42,7 +42,7 @@ with:
 }
 ```
 
-Then, configure PHP to use the Redis session handler. Once again, modify the `composer.json` with:
+Then, configure PHP to use the Redi® session handler. Once again, modify the `composer.json` with:
 
 ```json
 {
@@ -62,4 +62,4 @@ Customize the `session.save_path` value with the content of the `SCALINGO_REDIS_
 variable of your application. More information is available on the [official
 repository](https://github.com/phpredis/phpredis/#php-session-handler).
 
-Finally, redeploy your application. It is now handling PHP session through the Redis database!
+Finally, redeploy your application. It is now handling PHP session through the Redis® database!

--- a/src/_posts/languages/python/2000-01-01-celery-flask.md
+++ b/src/_posts/languages/python/2000-01-01-celery-flask.md
@@ -20,14 +20,14 @@ $ . venv/bin/activate
 
 ## Application infrastructure
 
-Our goal is to create two applications communicating via Redis using the Celery
+Our goal is to create two applications communicating via Redis® using the Celery
 platform:
 
 * The Celery app will provide a custom hello task.
 * The Flask app will provide a web server that will send a task to the Celery
 app and display the answer in a web page.
 
-The Redis connection URL will be send using the `REDIS_URL` environment variable.
+The Redis® connection URL will be send using the `REDIS_URL` environment variable.
 
 ## Create a Celery server
 
@@ -185,7 +185,7 @@ $ git commit -m "Base Celery and flask application"
 $ scalingo create my-app
 ```
 
-## Add a Redis addon to your app
+## Add a Scalingo for Redis® addon to your app
 
 ```bash
 $ scalingo --app my-app addons-add redis redis-sandbox

--- a/src/_posts/languages/python/2020-11-23-SQLAlchemy.md
+++ b/src/_posts/languages/python/2020-11-23-SQLAlchemy.md
@@ -1,9 +1,9 @@
 ---
-title: "SQLAlchemy: PostgreSQL connection URI"
+title: "SQLAlchemy: PostgreSQL® connection URI"
 nav: SQLAlchemy
 modified_at: 2021-11-23 00:00:00
 ---
 
-To connect to PostgreSQL most frameworks accept a connection URI that begins with `postgres://`, this is not the case with SQLAlchemy that requires the connection URI to begin with `postgresql://`.
+To connect to PostgreSQL® most frameworks accept a connection URI that begins with `postgres://`, this is not the case with SQLAlchemy that requires the connection URI to begin with `postgresql://`.
 
 To handle this situation we added this feature in our buildpack: if we detect that you're using SQLAlchemy (to do so we check the presence of `sqlalchemy` in the files `requirements.txt` or `Pipfile`), we're adding a new environment variables `SCALINGO_POSTGRESQL_ALCHEMY_URL` with the right format.

--- a/src/_posts/languages/python/django/2000-01-01-start.md
+++ b/src/_posts/languages/python/django/2000-01-01-start.md
@@ -102,10 +102,10 @@ $ scalingo create myapp
 
 Nothing to do
 
-### MySQL
+### MySQL®
 
 By default, only the PostgreSQL driver is installed, you need to replace
-it by the MySQL driver.
+it by the MySQL® driver.
 
 ```bash
 pip uninstall psycopg

--- a/src/_posts/languages/python/django/2000-01-01-start.md
+++ b/src/_posts/languages/python/django/2000-01-01-start.md
@@ -98,13 +98,13 @@ $ scalingo create myapp
 * Select the __Addons__ category
 * Choose the database you want to use
 
-### PostgreSQL
+### PostgreSQL®
 
 Nothing to do
 
 ### MySQL®
 
-By default, only the PostgreSQL driver is installed, you need to replace
+By default, only the PostgreSQL® driver is installed, you need to replace
 it by the MySQL® driver.
 
 ```bash

--- a/src/_posts/languages/ruby/2000-01-01-delayed-job.md
+++ b/src/_posts/languages/ruby/2000-01-01-delayed-job.md
@@ -19,16 +19,16 @@ for your project and you should have a look at
 To get started using delayed_job you need to configure your application.
 
 ```ruby
-# With MySQL or PostgreSQL
+# With MySQL® or PostgreSQL®
 gem 'delayed_job_active_record'
 
-# OR if you're using MongoDB
+# OR if you're using MongoDB®
 gem 'delayed_job_mongoid'
 ```
 
 Then, run `bundle install` to install the gem.
 
-If you are using MySQL or PostgreSQL, you also need to apply migrations to your
+If you are using MySQL® or PostgreSQL®, you also need to apply migrations to your
 database:
 
 ```bash

--- a/src/_posts/languages/ruby/2000-01-01-sidekiq.md
+++ b/src/_posts/languages/ruby/2000-01-01-sidekiq.md
@@ -8,12 +8,12 @@ tags: ruby gem async jobs sidekiq
 ## What is `sidekiq`?
 
 Sidekiq lets you run background tasks with your Rails application. It uses a
-Redis database as a queue to process background jobs.
+Redis® database as a queue to process background jobs.
 
 ## Requirements
 
-Your application should have access to a Redis instance, like the one provided by
-the [Redis Addon]({% post_url databases/redis/2000-01-01-start %}).
+Your application should have access to a Redis® instance, like the one provided by
+the [Scalingo for Redis® Addon]({% post_url databases/redis/2000-01-01-start %}).
 
 ## Adding `sidekiq` to your Project
 
@@ -44,7 +44,7 @@ end
 ```
 
 These instruction will configure Sidekiq to use your local database when
-working locally, and configure the Redis instance from the environment variable
+working locally, and configure the Redis® instance from the environment variable
 `REDIS_URL` when used in production, deployed on the platform.
 
 ## Adding 'worker' container type in your Procfile

--- a/src/_posts/languages/ruby/rails/2000-01-01-redis-cache.md
+++ b/src/_posts/languages/ruby/rails/2000-01-01-redis-cache.md
@@ -1,11 +1,11 @@
 ---
-title: Using Redis as Rails Cache Store
+title: Using Redis® as Rails Cache Store
 nav: Redis as Cache Store
 modified_at: 2021-09-24 00:00:00
 tags: ruby rails databases redis cache
 ---
 
-The Redis database is often use for cache purpose with Rails deployments. Hence you might want to clear 
+The Redis® database is often use for cache purpose with Rails deployments. Hence you might want to clear 
 its content after
 each deployment. One solution could be to empty it in a [postdeploy hook]({% post_url
 platform/app/2000-01-01-postdeploy-hook %}). Another solution can be to prefix the cache key with
@@ -23,7 +23,7 @@ config.cache_store = :redis_cache_store, {
 }
 ```
 
-By default, Redis databases on Scalingo have a [timeout]({% post_url databases/redis/2000-01-01-start %}#idle-connections-timeout).
+By default, Scalingo for Redis® databases have a [timeout]({% post_url databases/redis/2000-01-01-start %}#idle-connections-timeout).
 
 If you don't want to depend on the timeout of the server, you may want to
 change the client connection timeout. You can do it like this:
@@ -48,4 +48,4 @@ config.cache_store = :redis_cache_store, {
 }
 ```
 
-This simple trick will automatically invalidate the cache after each successful deployment. You'd certainly also want to enable Redis *cache mode* on its Dashboard on Scalingo to avoid filling your Redis database completely and tell Redis to drop old and unused keys.
+This simple trick will automatically invalidate the cache after each successful deployment. You'd certainly also want to enable Redis® *cache mode* on its Dashboard on Scalingo to avoid filling your Redis® database completely and tell Redis® to drop old and unused keys.

--- a/src/_posts/languages/ruby/rails/2000-01-01-start.md
+++ b/src/_posts/languages/ruby/rails/2000-01-01-start.md
@@ -63,7 +63,7 @@ Then set the following environment variable:
 
 ### MongoDB®
 
-To use a MongoDB database your need to add the gem `mongoid` to your `Gemfile`.
+To use a MongoDB® database your need to add the gem `mongoid` to your `Gemfile`.
 Please refer to [this guide]({% post_url languages/ruby/2000-01-01-mongoid %}).
 
 ## Setup Your Application Logging

--- a/src/_posts/languages/ruby/rails/2000-01-01-start.md
+++ b/src/_posts/languages/ruby/rails/2000-01-01-start.md
@@ -42,11 +42,11 @@ Git repository detected: remote scalingo added
 Note for SQL databases: at the boot of the database, Scalingo creates a database. If you need a specific configuration of charset or collation, you need to configure it before executing the first database migration.
 {% endnote %}
 
-### PostgreSQL
+### PostgreSQL®
 
 Add the gem `pg` to your `Gemfile`
 
-### MySQL
+### MySQL®
 
 Add the gem `mysql` to your `Gemfile`:
 
@@ -61,7 +61,7 @@ Then set the following environment variable:
 
 {% include info_environment_how_to.md %}
 
-### MongoDB
+### MongoDB®
 
 To use a MongoDB database your need to add the gem `mongoid` to your `Gemfile`.
 Please refer to [this guide]({% post_url languages/ruby/2000-01-01-mongoid %}).

--- a/src/_posts/platform/app/2000-01-01-regions-migration.md
+++ b/src/_posts/platform/app/2000-01-01-regions-migration.md
@@ -37,7 +37,7 @@ on the region `osc-fr1` to the region `osc-secnum-fr1`.
 {% note %}
 There are currently a bunch of addons that are not migrated during a migration. Please contact the support if you need to migrate an application having such addons:
 
-- InfluxDB database
+- Scalingo for InfluxDB® database
 - VPN addons
 - TCP addon
 {% endnote %}

--- a/src/_posts/platform/databases/2000-01-01-access.md
+++ b/src/_posts/platform/databases/2000-01-01-access.md
@@ -54,7 +54,7 @@ you can download various CLI tools for all databases available at Scalingo:
 {% include dbclient_fetcher.md %}
 
 {% warning %}
-The `redis-cli` can NOT be used if Force TLS is enabled on the Redis database. It results in an error message `I/O error`.
+The `redis-cli` can NOT be used if Force TLS is enabled on the Redis® database. It results in an error message `I/O error`.
 {% endwarning %}
 
 ## Connect to the Database

--- a/src/_posts/platform/databases/2000-01-01-adminer.md
+++ b/src/_posts/platform/databases/2000-01-01-adminer.md
@@ -5,8 +5,8 @@ modified_at: 2022-04-28 00:00:00
 tags: databases addon adminer
 ---
 
-[Adminer](https://www.adminer.org/) is a web application to administrate various databases (MySQL,
-PostgreSQL, MongoDB and Elasticsearch). It can be seen as a phpMyAdmin for more than just MySQL
+[Adminer](https://www.adminer.org/) is a web application to administrate various databases (MySQL®,
+PostgreSQL®, MongoDB® and Elasticsearch®). It can be seen as a phpMyAdmin for more than just MySQL®
 databases.
 
 The application is available on the platform to use alongside your databases:

--- a/src/_posts/platform/databases/2000-01-01-duplicate.md
+++ b/src/_posts/platform/databases/2000-01-01-duplicate.md
@@ -22,7 +22,7 @@ ensures all the connection slots are actually used for production purposes.
 
 {% warning %}
 For technical reasons, the following strategy will only work with our
-PostgreSQL, MySQL, Redis and MongoDB addons. For other addons, please get in
+PostgreSQL, MySQL, Scalingo for Redis® and MongoDB addons. For other addons, please get in
 touch with our support.
 {% endwarning %}
 

--- a/src/_posts/platform/databases/2000-01-01-duplicate.md
+++ b/src/_posts/platform/databases/2000-01-01-duplicate.md
@@ -22,7 +22,7 @@ ensures all the connection slots are actually used for production purposes.
 
 {% warning %}
 For technical reasons, the following strategy will only work with our
-PostgreSQL, MySQL, Scalingo for Redis® and MongoDB addons. For other addons, please get in
+Scalingo for PostgreSQL®, Scalingo for MySQL®, Scalingo for Redis® and Scalingo for MongoDB® addons. For other addons, please get in
 touch with our support.
 {% endwarning %}
 

--- a/src/_posts/platform/databases/2000-01-01-intro.md
+++ b/src/_posts/platform/databases/2000-01-01-intro.md
@@ -18,15 +18,15 @@ your data are.
 
 ### SQL
 
-* [PostgreSQL]({% post_url databases/postgresql/2000-01-01-start %})
-* [MySQL]({% post_url databases/mysql/2000-01-01-start %})
+* [Scalingo for PostgreSQL®]({% post_url databases/postgresql/2000-01-01-start %})
+* [Scalingo for MySQL®]({% post_url databases/mysql/2000-01-01-start %})
 
 ### NoSQL
 
-* [MongoDB]({% post_url databases/mongodb/2000-01-01-start %})
+* [Scalingo for MongoDB®]({% post_url databases/mongodb/2000-01-01-start %})
 * [Scalingo for Redis®]({% post_url databases/redis/2000-01-01-start %})
-* [Elasticsearch]({% post_url databases/elasticsearch/2000-01-01-start %})
-* [InfluxDB]({% post_url databases/influxdb/2000-01-01-start %})
+* [Scalingo for Elasticsearch®]({% post_url databases/elasticsearch/2000-01-01-start %})
+* [Scalingo for InfluxDB®]({% post_url databases/influxdb/2000-01-01-start %})
 
 ## Backups Retention Policy
 
@@ -75,15 +75,15 @@ Moreover, we also encrypt all communications between the members of cluster:
 
 Most of our high availability setups contain a HAProxy as entry point to the actual database nodes. This HAProxy has a few timeouts configured which may impact your application, especially if you reuse connections. The concerned databases are:
 
-- Elasticsearch:
+- Scalingo for Elasticsearch®:
   - Timeout when the client is inactive: 1 minute.
   - Timeout when the server is inactive: 2 minutes.
   - Maximum allowed time to wait for a complete HTTP request: 5 seconds.
-- PostgreSQL
+- Scalingo for PostgreSQL®:
   - Timeout when the client is inactive: 1 day.
   - Timeout when the server is inactive: 30 minutes.
   - Inactivity timeout on the client side for half-closed connections: 5 minutes.
-- Scalingo for Redis®
+- Scalingo for Redis®:
   - Timeout when the client is inactive: 5 minutes.
   - Timeout when the server is inactive: 5 minutes.
   - Inactivity timeout on the client side for half-closed connections: 1 hour.

--- a/src/_posts/platform/databases/2000-01-01-intro.md
+++ b/src/_posts/platform/databases/2000-01-01-intro.md
@@ -24,7 +24,7 @@ your data are.
 ### NoSQL
 
 * [MongoDB]({% post_url databases/mongodb/2000-01-01-start %})
-* [Redis]({% post_url databases/redis/2000-01-01-start %})
+* [Scalingo for Redis®]({% post_url databases/redis/2000-01-01-start %})
 * [Elasticsearch]({% post_url databases/elasticsearch/2000-01-01-start %})
 * [InfluxDB]({% post_url databases/influxdb/2000-01-01-start %})
 
@@ -83,7 +83,7 @@ Most of our high availability setups contain a HAProxy as entry point to the act
   - Timeout when the client is inactive: 1 day.
   - Timeout when the server is inactive: 30 minutes.
   - Inactivity timeout on the client side for half-closed connections: 5 minutes.
-- Redis
+- Scalingo for Redis®
   - Timeout when the client is inactive: 5 minutes.
   - Timeout when the server is inactive: 5 minutes.
   - Inactivity timeout on the client side for half-closed connections: 1 hour.

--- a/src/_posts/platform/databases/2000-01-01-intro.md
+++ b/src/_posts/platform/databases/2000-01-01-intro.md
@@ -58,7 +58,7 @@ Connections" feature in the web dashboard of your addon:
 {% include mdl_img.html %}
 
 {% note %}
-The default behaviour is slightly different for Elasticsearch and InfluxDB.
+The default behaviour is slightly different for Elasticsearch® and InfluxDB®.
 These databases cannot listen to both TLS and non-TLS connections at the same
 time. Hence, by default, these database do not listen on the TLS port. You need
 to enable the "Force TLS Connections" feature to reach these databases using

--- a/src/_posts/platform/databases/2000-01-01-restore-backup.md
+++ b/src/_posts/platform/databases/2000-01-01-restore-backup.md
@@ -30,6 +30,6 @@ This downloads the last successful backup. In order to restore the downloaded ba
 - [PostgreSQL]({% post_url databases/postgresql/2000-01-01-start %}#backups)
 - [MySQL]({% post_url databases/mysql/2000-01-01-start %}#backups)
 - [MongoDB]({% post_url databases/mongodb/2000-01-01-start %}#backups)
-- [Redis]({% post_url databases/redis/2000-01-01-start %}#backups)
+- [Scalingo for Redis®]({% post_url databases/redis/2000-01-01-start %}#backups)
 - [Elasticsearch]({% post_url databases/elasticsearch/2000-01-01-start %}#backups)
 - [InfluxDB]({% post_url databases/influxdb/2000-01-01-start %}#backups)

--- a/src/_posts/platform/databases/2000-01-01-restore-backup.md
+++ b/src/_posts/platform/databases/2000-01-01-restore-backup.md
@@ -27,9 +27,9 @@ $ scalingo --app my-app run bash
 
 This downloads the last successful backup. In order to restore the downloaded backup, instructions are available in each database type page:
 
-- [PostgreSQL]({% post_url databases/postgresql/2000-01-01-start %}#backups)
-- [MySQL]({% post_url databases/mysql/2000-01-01-start %}#backups)
-- [MongoDB]({% post_url databases/mongodb/2000-01-01-start %}#backups)
+- [Scalingo for PostgreSQL®]({% post_url databases/postgresql/2000-01-01-start %}#backups)
+- [Scalingo for MySQ®L]({% post_url databases/mysql/2000-01-01-start %}#backups)
+- [Scalingo for MongoDB®]({% post_url databases/mongodb/2000-01-01-start %}#backups)
 - [Scalingo for Redis®]({% post_url databases/redis/2000-01-01-start %}#backups)
-- [Elasticsearch]({% post_url databases/elasticsearch/2000-01-01-start %}#backups)
-- [InfluxDB]({% post_url databases/influxdb/2000-01-01-start %}#backups)
+- [Scalingo for Elasticsearch®]({% post_url databases/elasticsearch/2000-01-01-start %}#backups)
+- [Scalingo for InfluxDB®]({% post_url databases/influxdb/2000-01-01-start %}#backups)

--- a/src/_posts/platform/databases/2000-01-01-sqlite.md
+++ b/src/_posts/platform/databases/2000-01-01-sqlite.md
@@ -32,6 +32,6 @@ SQLite would not be a good fit.
 
 Instead of using SQLite, we are providing you the choice among our ['Database as a Service' addons](https://scalingo.com/databases)
 
-* MongoDB
-* PostgreSQL
-* MySQL
+* MongoDB®
+* PostgreSQL®
+* MySQL®

--- a/src/_posts/platform/getting-started/2000-01-01-getting-started-with-elk.md
+++ b/src/_posts/platform/getting-started/2000-01-01-getting-started-with-elk.md
@@ -16,17 +16,17 @@ minutes.
 
 The ELK stack is based on three major components:
 
-* Elasticsearch
+* Elasticsearch®
 * Logstash
 * Kibana
 
-**Elasticsearch** is a distributed full-text search engine, able to store JSON
+**Elasticsearch®** is a distributed full-text search engine, able to store JSON
 document and index them efficiently, it is responsible for the storage of all
 the incoming data.
 
 **Logstash** is a data processing pipeline, any source sends data as input. It
 is able to format and modify data on the fly before forwarding it to
-the chosen destination (usually an Elasticsearch database).
+the chosen destination (usually an Elasticsearch® database).
 
 **Kibana** is a powerful web-based data visualization tool providing
 everything you need to explore your data and build useful and efficient
@@ -35,7 +35,7 @@ dashboards.
 ## Logstash
 
 Let's start by bootstrapping the Logstash container. This instance will take
-data from an authenticated input and send them to an Elasticsearch
+data from an authenticated input and send them to an Elasticsearch®
 database. This is the *EL* part in *ELK*.
 
 To get started, you can use [our boilerplate](https://github.com/Scalingo/logstash-boilerplate):
@@ -51,13 +51,13 @@ Next, create an application on Scalingo that will run our Logstash app:
 $ scalingo create my-awesome-logstash
 ```
 
-Add the Elasticsearch addon to this application:
+Add the Scalingo for Elasticsearch® addon to this application:
 
 ```bash
 $ scalingo --app my-awesome-logstash addons-add elasticsearch elasticsearch-starter-1024
 ```
 
-All the Elasticsearch plans are described [here](https://scalingo.com/addons/scalingo-elasticsearch).
+All the Scalingo for Elasticsearch® plans are described [here](https://scalingo.com/addons/scalingo-elasticsearch).
 
 Of course, not everyone should be able to send data to your Logstash instance, it should be
 protected via HTTP basic auth. It is already handled in the boilerplate but the
@@ -73,7 +73,7 @@ Logstash is greedy in memory, it requires at least a container of size L, config
 $ scalingo --app my-awesome-logstash scale web:1:L
 ```
 
-Edit the `logstash.conf` file to change the index name of the Elasticsearch
+Edit the `logstash.conf` file to change the index name of the Elasticsearch®
 output. The goal is to make it fit semantically to the data which will be
 stored:
 
@@ -106,7 +106,7 @@ $ curl --request POST 'https://my-awesome-logstash-user:iloveunicorns@my-awesome
 ok
 ```
 
-It's time to verify all the indices that are stored in the Elasticsearch
+It's time to verify all the indices that are stored in the Elasticsearch®
 database:
 
 ```bash
@@ -178,10 +178,10 @@ scalingo --app my-awesome-logstash env | grep SCALINGO_ELASTICSEARCH_URL
 
 Then, a username and a password should be defined to configure Kibana authentication.
 
-**Note**: a new Elasticsearch database will be provisionned. You can safely delete it if you use the one from Logstash as described above.
+**Note**: a new Scallingo for Elasticsearch® database will be provisionned. You can safely delete it if you use the one from Logstash as described above.
 
 Once deployed, index patterns need to be configured. This is required to inform
-Kibana about the indices of Elasticsearch it need to look at.
+Kibana about the indices of Elasticsearch® it need to look at.
 
 {% assign img_url = "https://cdn.scalingo.com/documentation/elk/index-creation.png"%}
 {% include mdl_img.html %}
@@ -194,9 +194,9 @@ should appear in the Discover tab of Kibana dashboard.
 {% assign img_url = "https://cdn.scalingo.com/documentation/elk/success.png" %}
 {% include mdl_img.html %}
 
-### With TLS connection on Elasticsearch
+### With TLS connection on Elasticsearch®
 
-If your Elasticsearch addon has the Force TLS option enabled, you must
+If your Scalingo for Elasticsearch® addon has the Force TLS option enabled, you must
 set the environment variable `ELASTICSEARCH_TLS_CA_URL` on your Kibana
 application with the URL of our CA certificate. The CA certificate URL is available on the database
 dashboard.
@@ -331,7 +331,7 @@ ELASTICSEARCH_AUTH_PASSWORD=password
 Now you have to configure your indices life cycle. This is based on your
 indices names.
 Create a file named `log-clean.yml`. This configuration parses the indices
-names stored in Elasticsearch and removes the ones that are too old.
+names stored in Elasticsearch® and removes the ones that are too old.
 
 ```yaml
 actions:

--- a/src/_posts/platform/getting-started/2000-01-01-getting-started-with-grafana.md
+++ b/src/_posts/platform/getting-started/2000-01-01-getting-started-with-grafana.md
@@ -37,7 +37,7 @@ We now need to slightly configure the Scalingo application. This
 application needs to use the [multi-buildpacks]({% post_url
 platform/deployment/buildpacks/2000-01-01-multi %}).
 
-You also must add a PostgreSQL addon to your application. Last, configure a
+You also must add a Scalingo for PostgreSQL® addon to your application. Last, configure a
 few Grafana specific environment variables by heading to your application web
 dashboard:
 

--- a/src/_posts/platform/getting-started/2000-01-01-getting-started-with-metabase.md
+++ b/src/_posts/platform/getting-started/2000-01-01-getting-started-with-metabase.md
@@ -17,7 +17,7 @@ under 5 minutes.
 ### Planning your Deployment
 
 - Metabase requires its own database to store its configuration and some metadata.
-  We usually advise to use a [PostgreSQL Starter/Business 512 addon](https://scalingo.com/databases/postgresql)
+  We usually advise to use a [Scalingo for PostgreSQL® Starter/Business 512 addon](https://scalingo.com/databases/postgresql)
   for this purpose.
 
 - Depending on several factors such as the amount of data stored in your

--- a/src/_posts/platform/getting-started/2000-01-01-getting-started-with-wordpress.md
+++ b/src/_posts/platform/getting-started/2000-01-01-getting-started-with-wordpress.md
@@ -55,7 +55,7 @@ Follow these instructions to get started:
 
 2. Create the application on Scalingo
 
-   Create the application through the dashboard with a MySQL addon or with the [Scalingo CLI](http://cli.scalingo.com):
+   Create the application through the dashboard with a Scalingo for MySQL® addon or with the [Scalingo CLI](http://cli.scalingo.com):
 
    ```bash
    scalingo create my-app
@@ -103,7 +103,7 @@ Follow these instructions to get started:
    Then, update your application environment through the dashboard or with the
    [Scalingo CLI](http://cli.scalingo.com) `scalingo env-set VARIABLE_NAME=VALUE`:
 
-   * `DATABASE_URL`: Connection string to the MySQL database - `mysql://localhost:3306/wp-bedrock` - Automatically added with the Scalingo MySQL addon
+   * `DATABASE_URL`: Connection string to the MySQL® database - `mysql://localhost:3306/wp-bedrock` - Automatically added with the Scalingo MySQL® addon
    * `WP_ENV`: Set to environment (`development`, `staging`, `production`)
    * `WP_HOME`: Full URL to WordPress home (https://my-app.osc-fr1.scalingo.io)
    * `WP_SITEURL`: Full URL to WordPress including subdirectory (https://my-app.osc-fr1.scalingo.io/wp)
@@ -230,9 +230,9 @@ To do that, add the following line to your `config/application.php`:
 Config::define('AUTOMATIC_UPDATER_DISABLED', true);
 ```
 
-### TLS Connection to MySQL
+### TLS Connection to Scalingo for MySQL®
 
-If you configured your MySQL with [Force TLS]({% post_url
+If you configured your Scalingo for MySQL® with [Force TLS]({% post_url
 databases/mysql/2000-01-01-start %}#force-tls-connections), it is mandatory
 that your application connects to the database using TLS. With WordPress, you
 need to add the following line in your `config/application.php`:

--- a/src/_posts/platform/getting-started/2000-01-01-how-to-migrate-from-heroku.md
+++ b/src/_posts/platform/getting-started/2000-01-01-how-to-migrate-from-heroku.md
@@ -67,9 +67,9 @@ $ git push scalingo master
 ### Database Migration
 
 - Once you have set your Scalingo addons according to those you had on Heroku, you need to migrate your database by dumping it from Heroku and restoring it to Scalingo. 
-  * [Dump and restore a MongoDB database]({% post_url databases/mongodb/2000-01-01-dump-restore %})
-  * [Dump and restore a PostgreSQL database]({% post_url databases/postgresql/2000-01-01-dump-restore %})
-  * [Dump and restore a MySQL database]({% post_url databases/mysql/2000-01-01-dump-restore %})
+  * [Dump and restore a Scalingo for MongoDB® database]({% post_url databases/mongodb/2000-01-01-dump-restore %})
+  * [Dump and restore a Scalingo for PostgreSQL® database]({% post_url databases/postgresql/2000-01-01-dump-restore %})
+  * [Dump and restore a Scalingo for MySQL® database]({% post_url databases/mysql/2000-01-01-dump-restore %})
 
 ### Where to Go Next?
 

--- a/src/_posts/platform/internals/2000-01-01-recovery-management.md
+++ b/src/_posts/platform/internals/2000-01-01-recovery-management.md
@@ -59,5 +59,5 @@ This redundancy ensure there will always be sufficient data to recover a catastr
 The RPO determines the maximum acceptable amount of data loss measured in time.
 It depends of the type of database you are using:
 
-* MySQL, MongoDB, Elasticsearch, Scalingo for Redis®, InfluxDB: last daily backup: at worst 24h of data loss
-* PostgreSQL: continuous backuping, at worst: 30 minutes of data loss
+* Scalingo for MySQL®, Scalingo for MongoDB®, Scalingo for Elasticsearch®, Scalingo for Redis®, Scalingo for InfluxDB®: last daily backup: at worst 24h of data loss
+* Scalingo for PostgreSQL®: continuous backuping, at worst: 30 minutes of data loss

--- a/src/_posts/platform/internals/2000-01-01-recovery-management.md
+++ b/src/_posts/platform/internals/2000-01-01-recovery-management.md
@@ -59,5 +59,5 @@ This redundancy ensure there will always be sufficient data to recover a catastr
 The RPO determines the maximum acceptable amount of data loss measured in time.
 It depends of the type of database you are using:
 
-* MySQL, MongoDB, Elasticsearch, Redis, InfluxDB: last daily backup: at worst 24h of data loss
+* MySQL, MongoDB, Elasticsearch, Scalingo for Redis®, InfluxDB: last daily backup: at worst 24h of data loss
 * PostgreSQL: continuous backuping, at worst: 30 minutes of data loss


### PR DESCRIPTION
We need to add the different trademarks of the databases we use at Scalingo. This should be visible in our documentation.