### PR TITLE
chore(ruby-buildpack): sync with upstream v260

### DIFF
--- a/src/changelog/buildpacks/_posts/2023-10-30-ruby.md
+++ b/src/changelog/buildpacks/_posts/2023-10-30-ruby.md
@@ -1,0 +1,9 @@
+---
+modified_at: 2023-10-30 16:00:00
+title: 'Ruby - JRuby 9.4.2.0, 9.4.3.0 and 9.4.4.0'
+github: 'https://github.com/Scalingo/ruby-buildpack'
+---
+
+Changelog
+* JRuby 9.4.2.0, 9.4.3.0 and 9.4.4.0 are now available
+* Buildpack improvements


### PR DESCRIPTION
Fix https://github.com/Scalingo/ruby-buildpack/issues/52