### PR TITLE
chore(nodejs-buildpack): sync with upstream v227

### DIFF
--- a/src/changelog/buildpacks/_posts/2023-10-30-nodejs-18.18.2-20.9.0-21.1.0.md
+++ b/src/changelog/buildpacks/_posts/2023-10-30-nodejs-18.18.2-20.9.0-21.1.0.md
@@ -1,0 +1,8 @@
+---
+modified_at: 2023-10-30 16:00:00
+title: 'Node.js - Support for versions up to 21.1.0, 20.9.0 and 18.18.2'
+github: 'https://github.com/Scalingo/nodejs-buildpack'
+---
+
+- Support for Node.js versions up to `18.18.2`, `20.9.0`, and `21.1.0`
+- Support for Yarn `3.6.4` and `4.0.0`


### PR DESCRIPTION
Fix https://github.com/Scalingo/nodejs-buildpack/issues/94