### PR TITLE
feat(analytics) Add plausible tracker

### DIFF
--- a/src/_includes/organisms/head.html
+++ b/src/_includes/organisms/head.html
@@ -9,6 +9,7 @@
   {% include organisms/google_tag_manager_head.html %}
   {% endconditionaltrackers %}
   {% include organisms/favicons.html %}
+  <script defer data-domain="scalingo.com" src="https://plausible.io/js/script.js"></script>
   <link rel="stylesheet" href="https://use.typekit.net/ajl3atf.css">
   <link rel="stylesheet" href="/assets/style.css">
   <link rel="stylesheet" href="{{ "style.css" | asset_pack_path }}">


### PR DESCRIPTION
https://github.com/Scalingo/documentation/issues/2353

Tracker is directly added with the data-domain `scalingo.com` embed.

As, as far I am aware
- we do not having staging env for the docs
- plausible script will auto disable itself when on localhost