### PR TITLE
feat(analytics) Add plausible tracker, adding a custom `app` event

### DIFF
--- a/src/_includes/organisms/head.html
+++ b/src/_includes/organisms/head.html
@@ -9,7 +9,7 @@
   {% include organisms/google_tag_manager_head.html %}
   {% endconditionaltrackers %}
   {% include organisms/favicons.html %}
-  <script defer data-domain="scalingo.com" src="https://plausible.io/js/script.js"></script>
+  <script defer data-domain="scalingo.com" event-app="documentation" src="https://plausible.io/js/script.pageview-props.js"></script>
   <link rel="stylesheet" href="https://use.typekit.net/ajl3atf.css">
   <link rel="stylesheet" href="/assets/style.css">
   <link rel="stylesheet" href="{{ "style.css" | asset_pack_path }}">


### PR DESCRIPTION
Adding a custom `app` event in order to be abe to segregate by `app` in the plausible project

https://github.com/Scalingo/documentation/issues/2353