### PR TITLE
Precision on cors actions by scalingo

### DIFF
--- a/src/_posts/platform/app/2000-01-01-cors.md
+++ b/src/_posts/platform/app/2000-01-01-cors.md
@@ -11,6 +11,8 @@ Cross-origin resource sharing (CORS) is a mechanism that allows some resources t
 another domain. This is usually the case for your application's assets such as fonts or images you
 download from a CDN. If not configured properly, you might have errors downloading these assets.
 
+As a note, the Scalingo platform does not inject or modify CORS headers in any way.
+
 On this documentation page, I will call _CDN_ the server where your assets are stored and _my-app_
 your application hosted on Scalingo.
 

--- a/src/_posts/platform/app/2000-01-01-cors.md
+++ b/src/_posts/platform/app/2000-01-01-cors.md
@@ -1,7 +1,7 @@
 ---
 title: Cross-Origin Resource Sharing (CORS)
 nav: CORS
-modified_at: 2018-04-05 00:00:00
+modified_at: 2023-12-06 00:00:00
 tags: app cors cross-origin
 ---
 
@@ -11,7 +11,7 @@ Cross-origin resource sharing (CORS) is a mechanism that allows some resources t
 another domain. This is usually the case for your application's assets such as fonts or images you
 download from a CDN. If not configured properly, you might have errors downloading these assets.
 
-As a note, the Scalingo platform does not inject or modify CORS headers in any way.
+The Scalingo platform does not inject or modify CORS headers in any way. This is the sole responsibility of the application.
 
 On this documentation page, I will call _CDN_ the server where your assets are stored and _my-app_
 your application hosted on Scalingo.


### PR DESCRIPTION
In this doc, it was unclear if Scalingo inject or modify the CORS header. It was confusing customers. So I added a precision to say that no