### PR TITLE
chore(changelog): update composer 2.6.5 to 2.6.6

### DIFF
--- a/src/changelog/buildpacks/_posts/2023-12-11-php-composer-2.6.6.md
+++ b/src/changelog/buildpacks/_posts/2023-12-11-php-composer-2.6.6.md
@@ -1,0 +1,9 @@
+---
+modified_at: 2023-12-11 12:00:00
+title: 'PHP - Release Composer version 2.6.6'
+github: 'https://github.com/Scalingo/php-buildpack'
+---
+
+Changelog:
+
+* [Composer 2.6.6](https://github.com/composer/composer/releases/tag/2.6.6)


### PR DESCRIPTION
Packages have been generated and uploaded on ObjectStorage:
- `scalingo-20`: https://semver.scalingo.com/composer-scalingo-20/versions
- `scalingo-22`: https://semver.scalingo.com/composer-scalingo-22/versions

Fix https://github.com/Scalingo/php-buildpack/issues/383