### PR TITLE
fix(sidekiq): add missing `redis-namespace` gem

### DIFF
--- a/src/_posts/languages/ruby/2000-01-01-sidekiq.md
+++ b/src/_posts/languages/ruby/2000-01-01-sidekiq.md
@@ -1,7 +1,7 @@
 ---
 title: Using Sidekiq to Handle Background Tasks
 nav: Sidekiq
-modified_at: 2016-05-02 10:39:00
+modified_at: 2023-12-12 00:00:00
 tags: ruby gem async jobs sidekiq
 ---
 
@@ -21,7 +21,8 @@ To get started using Sidekiq, you need to configure your application. Add the
 following to your `Gemfile`:
 
 ```ruby
-gem 'sidekiq'
+gem "sidekiq"
+gem "redis-namespace"
 ```
 
 Then, run `bundle install` to install the gem.


### PR DESCRIPTION
Without this, when the application starts, it crashes with the following error:

```
ERROR: Your Redis configuration uses the namespace 'sidekiq-staging' but the redis-namespace gem is not included in the Gemfile.Add the gem to your Gemfile to continue using a namespace. Otherwise, remove the namespace parameter.
```