### PR TITLE
feat(java-war-buildpack): release of webapp-runner 10.1.16.0

### DIFF
--- a/src/_posts/platform/deployment/2000-01-01-deploy-java-jar-war.md
+++ b/src/_posts/platform/deployment/2000-01-01-deploy-java-jar-war.md
@@ -1,7 +1,7 @@
 ---
 title: Deployment of JAR and WAR archives
 nav: Deploy JAR/WAR
-modified_at: 2023-11-27 12:00:00
+modified_at: 2024-01-02 12:00:00
 index: 8
 tags: deployment, java, jar, war
 ---
@@ -97,12 +97,11 @@ By default, Tomcat is installed with the last version of the webapp-runner. If
 you want to use another version, you can defined the environment variable
 `JAVA_WEBAPP_RUNNER_VERSION`. The available versions are:
 
-- `8.5.11.3`
-- `8.5.51.0`
-- `9.0.52.1`
-- `9.0.68.1`
-- `9.0.80.0`
-- `9.0.83.0` (default)
+| Version | `JAVA_WEBAPP_RUNNER_VERSION` |
+| ------: | ---------------------------: |
+| `8.5`   | Up to `8.5.51.0`             |
+| `9.0`   | Up to `9.0.83.1`             |
+| `10.1`  | Up to `10.1.16.0` (default)  |
 
 The 8.5.x versions are installing Tomcat 8, and the 9.0.x releases are
 installing Tomcat 9.0:

--- a/src/_posts/platform/deployment/2000-01-01-deploy-java-jar-war.md
+++ b/src/_posts/platform/deployment/2000-01-01-deploy-java-jar-war.md
@@ -97,11 +97,11 @@ By default, Tomcat is installed with the last version of the webapp-runner. If
 you want to use another version, you can defined the environment variable
 `JAVA_WEBAPP_RUNNER_VERSION`. The available versions are:
 
-| Version | `JAVA_WEBAPP_RUNNER_VERSION` |
-| ------: | ---------------------------: |
-| `8.5`   | Up to `8.5.51.0`             |
-| `9.0`   | Up to `9.0.83.1`             |
-| `10.1`  | Up to `10.1.16.0` (default)  |
+| Tomcat Version | `JAVA_WEBAPP_RUNNER_VERSION` |
+| -------------: | ---------------------------- |
+| `8.5`          | Up to `8.5.51.0`             |
+| `9.0`          | Up to `9.0.83.1`             |
+| `10.1`         | Up to `10.1.16.0` (default)  |
 
 The 8.5.x versions are installing Tomcat 8, and the 9.0.x releases are
 installing Tomcat 9.0:

--- a/src/_posts/platform/deployment/2000-01-01-deploy-java-jar-war.md
+++ b/src/_posts/platform/deployment/2000-01-01-deploy-java-jar-war.md
@@ -103,13 +103,11 @@ scalingo --app my-app env-set JAVA_WEBAPP_RUNNER_VERSION=10.1.16.0
 
 The latest available versions currently are:
 
-| Tomcat Version | `scalingo-20`     | `scalingo-22`     |
-| -------------: | ----------------: | ----------------: |
-| `8.5`          | up to `8.5.51.0`  | up to `8.5.51.0`  |
-| **`9.0`**      | up to `9.0.83.1`  | up to `9.0.83.1`  |
-| **`10.1`**     | up to `10.1.16.0` | up to `10.1.16.0` |
-
-The default version on both `scalingo-20` and `scalingo-22` is `9.0.83.1`.
+| Tomcat Version | Latest version    | Note    |
+| -------------: | ----------------: | ------- |
+| `8.5`          | up to `8.5.68.1`  |         |
+| **`9.0`**      | up to `9.0.83.1`  | default |
+| **`10.1`**     | up to `10.1.16.0` |         |
 
 {% note %}
 Even though we still support this version, we strongly advise against using the

--- a/src/_posts/platform/deployment/2000-01-01-deploy-java-jar-war.md
+++ b/src/_posts/platform/deployment/2000-01-01-deploy-java-jar-war.md
@@ -1,7 +1,7 @@
 ---
 title: Deployment of JAR and WAR archives
 nav: Deploy JAR/WAR
-modified_at: 2024-01-02 12:00:00
+modified_at: 2024-01-03 12:00:00
 index: 8
 tags: deployment, java, jar, war
 ---
@@ -101,9 +101,18 @@ use another version, you can define the environment variable
 scalingo --app my-app env-set JAVA_WEBAPP_RUNNER_VERSION=10.1.16.0
 ```
 
-The available versions currently are:
+The latest available versions currently are:
 
-| Tomcat Version | Latest version | Notes   |
-| -------------: | -------------- | ------- |
-| `9.0`          | `9.0.83.1`     | default |
-| `10.1`         | `10.1.16.0`    |         |
+| Tomcat Version | `scalingo-20`     | `scalingo-22`     |
+| -------------: | ----------------: | ----------------: |
+| `8.5`          | up to `8.5.51.0`  | up to `8.5.51.0`  |
+| **`9.0`**      | up to `9.0.83.1`  | up to `9.0.83.1`  |
+| **`10.1`**     | up to `10.1.16.0` | up to `10.1.16.0` |
+
+The default version on both `scalingo-20` and `scalingo-22` is `9.0.83.1`.
+
+{% note %}
+Even though we still support this version, we strongly advise against using the
+`8.5` version, which has been released a while ago. If you are still using it,
+please consider migrating to a more recent version.
+{% endnote %}

--- a/src/_posts/platform/deployment/2000-01-01-deploy-java-jar-war.md
+++ b/src/_posts/platform/deployment/2000-01-01-deploy-java-jar-war.md
@@ -93,21 +93,17 @@ $ scalingo --app my-app env-set JAVA_VERSION=1.9
 
 ### Webapp Runner / Tomcat version selection
 
-By default, Tomcat is installed with the last version of the webapp-runner. If
-you want to use another version, you can defined the environment variable
-`JAVA_WEBAPP_RUNNER_VERSION`. The available versions are:
-
-| Tomcat Version | `JAVA_WEBAPP_RUNNER_VERSION` |
-| -------------: | ---------------------------- |
-| `8.5`          | Up to `8.5.51.0`             |
-| `9.0`          | Up to `9.0.83.1`             |
-| `10.1`         | Up to `10.1.16.0` (default)  |
-
-The 8.5.x versions are installing Tomcat 8, and the 9.0.x releases are
-installing Tomcat 9.0:
+By default, the latest `9.0.x` version of Tomcat is installed. If you want to
+use another version, you can define the environment variable
+`JAVA_WEBAPP_RUNNER_VERSION`, like so:
 
 ```sh
-# Install Tomcat 8
-
-$ scalingo env-set JAVA_WEBAPP_RUNNER_VERSION=8.5.11.3
+scalingo --app my-app env-set JAVA_WEBAPP_RUNNER_VERSION=10.1.16.0
 ```
+
+The available versions currently are:
+
+| Tomcat Version | Latest version | Notes   |
+| -------------: | -------------- | ------- |
+| `9.0`          | `9.0.83.1`     | default |
+| `10.1`         | `10.1.16.0`    |         |

--- a/src/changelog/buildpacks/_posts/2024-01-02-java-tomcat-webapp-runner-10.1.16.0.md
+++ b/src/changelog/buildpacks/_posts/2024-01-02-java-tomcat-webapp-runner-10.1.16.0.md
@@ -1,0 +1,10 @@
+---
+modified_at: 2024-01-02 12:00:00
+title: 'Java - Release Webapp Runner (Tomcat) version 9.0.83.1 and 10.1.16.0'
+github: 'https://github.com/Scalingo/java-war-buildpack'
+---
+
+Changelog:
+
+ * Tomcat `9.0.83.1` is now available.
+ * Tomcat `10.1.16.0` is now available and the default version.

--- a/src/changelog/buildpacks/_posts/2024-01-03-java-tomcat-webapp-runner-10.1.16.0.md
+++ b/src/changelog/buildpacks/_posts/2024-01-03-java-tomcat-webapp-runner-10.1.16.0.md
@@ -1,10 +1,10 @@
 ---
-modified_at: 2024-01-02 12:00:00
+modified_at: 2024-01-03 12:00:00
 title: 'Java - Release Webapp Runner (Tomcat) version 9.0.83.1 and 10.1.16.0'
 github: 'https://github.com/Scalingo/java-war-buildpack'
 ---
 
 Changelog:
 
- * Tomcat `9.0.83.1` is now available.
- * Tomcat `10.1.16.0` is now available and the default version.
+ * Tomcat `9.0.83.1` is now available. It's also the new default version.
+ * Tomcat `10.1.16.0` is now available.


### PR DESCRIPTION
Related to https://github.com/Scalingo/java-war-buildpack/issues/21 and https://github.com/Scalingo/java-war-buildpack/pull/22