### PR TITLE
Fix url for metabase deploy link

### DIFF
--- a/src/_posts/platform/getting-started/2000-01-01-getting-started-with-metabase.md
+++ b/src/_posts/platform/getting-started/2000-01-01-getting-started-with-metabase.md
@@ -33,7 +33,7 @@ under 5 minutes.
 Click the One-Click Deploy button below to automatically deploy Metabase with
 your Scalingo account:
 
-[![Deploy](https://cdn.scalingo.com/deploy/button.svg)](https://dashboard.scalingo.com/create/app?source=https://github.com/Scalingo/metabase-scalingo)
+[![Deploy](https://cdn.scalingo.com/deploy/button.svg)](https://my.scalingo.com/deploy?source=https://github.com/Scalingo/metabase-scalingo#master)
 
 ### Using the Command Line
 


### PR DESCRIPTION
Current link to deploy metabase does not work:

<img width="798" alt="Capture d’écran 2024-01-24 à 11 46 42" src="https://github.com/Scalingo/documentation/assets/5627688/42649bc5-0959-4992-a28c-dbc605841c3b">

Using link from https://github.com/Scalingo/metabase-scalingo/blob/master/README.md fixes this:

<img width="790" alt="Capture d’écran 2024-01-24 à 11 47 51" src="https://github.com/Scalingo/documentation/assets/5627688/4fb7edde-08b4-473c-bd4e-cd1299fdddff">
