### PR TITLE
chore(PHP): update PHP start page

### DIFF
--- a/src/_posts/languages/php/2000-01-01-start.md
+++ b/src/_posts/languages/php/2000-01-01-start.md
@@ -1,21 +1,24 @@
 ---
 title: PHP on Scalingo
 nav: Introduction
-modified_at: 2024-01-26 12:00:00
+modified_at: 2024-02-08 12:00:00
 tags: php
 index: 1
 ---
 
 ## Detection
 
-Your application will be detected as a PHP application if:
+Your application is detected as a PHP application if:
 
-* a `composer.lock` file lives at the root of your project
-* or if an `index.php` file lives in the root directory (legacy app)
+* a `composer.lock` file is present in the root directory of your project
+* or if an `index.php` file is present in the root directory of your project
+  (*Classic* app)
+
 
 ## Stack
 
-A stack based on Nginx and PHP-FPM will be installed.
+A stack based on Nginx and PHP-FPM is installed.
+
 
 ## Default Configuration
 
@@ -26,6 +29,7 @@ available in the PHP buildpack:
 
 Reviewing them can give you useful inputs, such as the default values for
 parameters like `upload_max_filesize` or `post_max_size`.
+
 
 ## PHP Versions
 
@@ -64,14 +68,14 @@ The default PHP version on both `scalingo-20` and `scalingo-22` is the latest
 ```
 
 {% note %}
-  You should not specify a precise version such as `8.2.3` or you would miss
-  important updates. Instead, you should specify `~8.2.3` to install a version
-  `>=8.2.3 and <8.3.0` or specify `~8.2` to install a version `>=8.2 and
-  <9.0.0`.
+You should not specify a precise version such as `8.2.3` or you would miss
+important updates. Instead, you should specify `~8.2.3` to install a version
+`>=8.2.3 and <8.3.0` or specify `~8.2` to install a version `>=8.2 and <9.0.0`.
 
-  Further details about version constraints can be found in the
-  [Composer documentation](https://getcomposer.org/doc/articles/versions.md#writing-version-constraints)
+Further details about version constraints can be found in the
+[Composer documentation](https://getcomposer.org/doc/articles/versions.md#writing-version-constraints)
 {% endnote %}
+
 
 ## PHP Extensions and Dependencies
 
@@ -80,41 +84,38 @@ See our dedicated documentation pages:
 - [Working with PHP Dependencies]({% post_url languages/php/2000-01-01-dependencies %})
 - [Working with PHP Extensions]({% post_url languages/php/2000-01-01-extensions %})
 
+
 ## Officially Supported Frameworks
 
-Scalingo supports out-of-the-box many well-known frameworks. When using such
-frameworks, you have nothing special to configure in your `composer.json`,
-`git push` your code and everything will work!
+Scalingo supports many well-known frameworks. When using such frameworks, you
+have nothing special to configure in your `composer.json`, `git push` your code
+and everything will work!
 
-List of the frameworks:
+Here is a non-exhaustive list of frameworks known to work:
 
 * [Symfony]({% post_url languages/php/2000-01-01-symfony %})
 * [Laravel]({% post_url languages/php/2000-01-01-laravel %})
-* [Slim](https://sample-php-slim.scalingo.io/)
+* Laravel Lumen
+* Slim
 * CakePHP
-* Lumen
-* Zend Framework 2
-* Magento
-* Silex
-* CakePHP
-* Change 2
-* [CodeIgniter 3]({% post_url languages/php/2000-01-01-codeigniter %})
+* [CodeIgniter]({% post_url languages/php/2000-01-01-codeigniter %})
+* Laminas MVC
+
 
 ## Configuration Tweaks
 
 ### Setup Basic Authentication
 
 You may want to hide your application behind an authentication gateway.
-You can [configure HTTP basic auth]({% post_url
-languages/php/2000-01-01-basic-auth %}) for your application.
+You can [configure HTTP basic auth]({% post_url languages/php/2000-01-01-basic-auth %})
+for your application.
 
 ### PHP-FPM Concurrency
 
 The level of concurrency configured is defined automatically according to the
 size of the containers of your application. If you want to override this value,
 you can define the environment variable: `WEB_CONCURRENCY`. It directly
-modifies the
-[`pm.max_children`](https://www.php.net/manual/fr/install.fpm.configuration.php)
+modifies the [`pm.max_children`](https://www.php.net/manual/fr/install.fpm.configuration.php)
 parameter of PHP-FPM, defining the upper limit of how many workers handling
 incoming requests will be running. Each of these processes will be able to run
 1 request at a time.
@@ -161,7 +162,7 @@ improve the value of the `WEB_CONCURRENCY` value.
 ### Buildpack Custom Configuration
 
 {% note %}
-  [_What is a buildpack?_]({% post_url platform/deployment/buildpacks/2000-01-01-intro %})
+[_What is a buildpack?_]({% post_url platform/deployment/buildpacks/2000-01-01-intro %})
 {% endnote %}
 
 The buildpack allows you to configure precisely how your application is
@@ -376,8 +377,8 @@ variable.
 
 ## Warning: `.htaccess` Files
 
-Legacy projects often use `.htaccess` file in their project to modify the
-configuration of the Apache server. As the buildpack is based on Nginx and
+Classic PHP applications often use `.htaccess` file in their project to modify
+the configuration of the Apache server. As the buildpack is based on Nginx and
 PHP-FPM, these files are ineffective.
 
 Instead of using these files, you have to write directives for Nginx and
@@ -439,10 +440,10 @@ Then modify your `composer.json` to add `nginx-http-includes` and
 
 ## Example: URL Rewriting (e.g. WordPress)
 
-Here is an example of legacy `.htaccess` which won't work on Scalingo. You need
-to replace it with the Nginx configuration following the example.
+Here is an example of classic `.htaccess` which won't work on Scalingo.
+You need to replace it with the Nginx configuration following the example.
 
-Legacy `.htaccess` example:
+Classic `.htaccess` example:
 
 ```ApacheConf
 <IfModule mod_rewrite.c>

--- a/src/_posts/languages/php/2000-01-01-start.md
+++ b/src/_posts/languages/php/2000-01-01-start.md
@@ -1,7 +1,7 @@
 ---
 title: PHP on Scalingo
 nav: Introduction
-modified_at: 2024-02-08 12:00:00
+modified_at: 2024-02-09 12:00:00
 tags: php
 index: 1
 ---
@@ -96,6 +96,7 @@ Here is a non-exhaustive list of frameworks known to work on Scalingo:
 * CakePHP
 * [CodeIgniter]({% post_url languages/php/2000-01-01-codeigniter %})
 * Laminas MVC
+* Magento
 
 
 ## Configuration Tweaks

--- a/src/_posts/languages/php/2000-01-01-start.md
+++ b/src/_posts/languages/php/2000-01-01-start.md
@@ -85,13 +85,9 @@ See our dedicated documentation pages:
 - [Working with PHP Extensions]({% post_url languages/php/2000-01-01-extensions %})
 
 
-## Officially Supported Frameworks
+## Supported Frameworks
 
-Scalingo supports many well-known frameworks. When using such frameworks, you
-have nothing special to configure in your `composer.json`, `git push` your code
-and everything will work!
-
-Here is a non-exhaustive list of frameworks known to work:
+Here is a non-exhaustive list of frameworks known to work on Scalingo:
 
 * [Symfony]({% post_url languages/php/2000-01-01-symfony %})
 * [Laravel]({% post_url languages/php/2000-01-01-laravel %})


### PR DESCRIPTION
Frameworks list has been updated after conducting some tests.
*Legacy* apps are now called *Classic*, to keep homogeneity with the buildpack terminology.
Also rephrase a few sentences.

Fix #2378 