### PR TITLE
chore(changelog): update doc

### DIFF
--- a/src/_posts/languages/python/2000-01-01-start.md
+++ b/src/_posts/languages/python/2000-01-01-start.md
@@ -1,7 +1,7 @@
 ---
 title: Python
 nav: Introduction
-modified_at: 2024-03-13 12:00:00
+modified_at: 2024-03-28 12:00:00
 tags: python
 index: 1
 ---
@@ -24,9 +24,9 @@ The following versions of Python are available:
 | -------------: | --------------: | --------------: |
 | `3.12`         | up to `3.12.2`  | up to `3.12.2`  |
 | `3.11`         | up to `3.11.8`  | up to `3.11.8`  |
-| `3.10`         | up to `3.10.13` | up to `3.10.13` |
-| `3.9`          | up to `3.9.18`  | up to `3.9.18`  |
-| `3.8`          | up to `3.8.18`  | unsupported     |
+| `3.10`         | up to `3.10.14` | up to `3.10.14` |
+| `3.9`          | up to `3.9.19`  | up to `3.9.19`  |
+| `3.8`          | up to `3.8.19`  | unsupported     |
 
 {% note %}
 Even though we still support them, we strongly advise against using deprecated

--- a/src/_posts/languages/ruby/2000-01-01-start.md
+++ b/src/_posts/languages/ruby/2000-01-01-start.md
@@ -1,7 +1,7 @@
 ---
 title: Ruby
 nav: Introduction
-modified_at: 2023-12-26 00:00:00
+modified_at: 2024-03-28 12:00:00
 tags: ruby
 index: 1
 ---
@@ -91,7 +91,7 @@ version are also present if your require them for specific tests.
 ### MRI
 
 * `3.3.0`
-* `3.2.2`
+* `3.2.3`
 * `3.1.4`
 * `3.0.6`
 

--- a/src/changelog/buildpacks/_posts/2024-03-28-nodejs-18.20.0-20.12.0.md
+++ b/src/changelog/buildpacks/_posts/2024-03-28-nodejs-18.20.0-20.12.0.md
@@ -1,0 +1,7 @@
+---
+modified_at: 2024-03-28 12:00:00
+title: 'Node.js - Support for versions 20.12.0 and 18.20.0'
+github: 'https://github.com/Scalingo/nodejs-buildpack'
+---
+
+- Support for Node.js versions `18.20.0` and `20.12.0`

--- a/src/changelog/buildpacks/_posts/2024-03-28-php-mongodb-ext-1.18.0.md
+++ b/src/changelog/buildpacks/_posts/2024-03-28-php-mongodb-ext-1.18.0.md
@@ -1,0 +1,9 @@
+---
+modified_at: 2024-03-28 12:00:00
+title: 'PHP - Support of extension `mongodb` version 1.18.0'
+github: 'https://github.com/Scalingo/php-buildpack'
+---
+
+Changelog:
+
+* [MongoDB Driver 1.18.0](https://github.com/mongodb/mongo-php-driver/releases/tag/1.18.0)

--- a/src/changelog/buildpacks/_posts/2024-03-28-python-3.8.19-3.9.19-3.10.14.md
+++ b/src/changelog/buildpacks/_posts/2024-03-28-python-3.8.19-3.9.19-3.10.14.md
@@ -1,0 +1,11 @@
+---
+modified_at: 2024-03-28 12:00:00
+title: 'Python - New versions available: 3.10.14, 3.9.19 and 3.8.19'
+github: 'https://github.com/Scalingo/python-buildpack'
+---
+
+Changelogs:
+
+- [3.10.14](https://docs.python.org/3.10/whatsnew/changelog.html#python-3-10-14-final)
+- [3.9.19](https://docs.python.org/3.9/whatsnew/changelog.html#python-3-9-19-final)
+- [3.8.19](https://docs.python.org/3.8/whatsnew/changelog.html#python-3-8-19-final)

--- a/src/changelog/buildpacks/_posts/2024-03-28-python-3.8.19-3.9.19-3.10.14.md
+++ b/src/changelog/buildpacks/_posts/2024-03-28-python-3.8.19-3.9.19-3.10.14.md
@@ -4,8 +4,13 @@ title: 'Python - New versions available: 3.10.14, 3.9.19 and 3.8.19'
 github: 'https://github.com/Scalingo/python-buildpack'
 ---
 
-Changelogs:
+- Python version `3.8.19`, `3.9.19` and `3.10.14` are now available
+- Updated pip from `23.3.2` to `24.0`
+- Updated setuptools from `68.2.2` to `69.2.0`
+- Updated wheel from `0.42.0` to `0.43.0`
+- Updated pipenv from `2023.11.15` to `2023.12.1`
 
+Changelogs:
 - [3.10.14](https://docs.python.org/3.10/whatsnew/changelog.html#python-3-10-14-final)
 - [3.9.19](https://docs.python.org/3.9/whatsnew/changelog.html#python-3-9-19-final)
 - [3.8.19](https://docs.python.org/3.8/whatsnew/changelog.html#python-3-8-19-final)

--- a/src/changelog/buildpacks/_posts/2024-03-28-ruby-3.2.3.md
+++ b/src/changelog/buildpacks/_posts/2024-03-28-ruby-3.2.3.md
@@ -1,0 +1,13 @@
+---
+modified_at: 2024-03-28 12:00:00
+title: 'Ruby - 3.2.3 is available'
+github: 'https://github.com/Scalingo/ruby-buildpack'
+---
+
+- Ruby 3.2.3 is now available
+- Use of `SENSIBLE_DEFAULTS` environment variable is now deprecated
+- Bundler version installation is now based on both major and minor version
+
+Changelogs:
+
+* [3.2.3](https://www.ruby-lang.org/en/news/2024/01/18/ruby-3-2-3-released/)


### PR DESCRIPTION
For the MongoDB PHP extension, files have been generated for:
- `scalingo-20`: PHP `7.4`, `8.0`, `8.1`, `8.2` and `8.3`
- `scalingo-22`: PHP `8.1`, `8.2` and `8.3`

Files have been uploaded to ObjectStorage.

Fix https://github.com/Scalingo/php-buildpack/issues/416
Fix https://github.com/Scalingo/nodejs-buildpack/issues/104
Fix https://github.com/Scalingo/ruby-buildpack/issues/61
Fix https://github.com/Scalingo/python-buildpack/issues/95