### PR TITLE
Update url to get an API token from Datadog

### DIFF
--- a/src/_posts/platform/app/2000-01-01-log-drain.md
+++ b/src/_posts/platform/app/2000-01-01-log-drain.md
@@ -97,7 +97,7 @@ scalingo --app my-app log-drains-add --type datadog \
 ```
 Parameters:
 * `token`: Datadog API key you can find
-[here](https://app.datadoghq.com/account/settings#api).
+[here](https://app.datadoghq.eu/personal-settings/application-keys).
 * `region`: `eu` or `us` depending on your Datadog account region.
 
 #### OVH Hosted Graylog


### PR DESCRIPTION
The url to get an API token from Datadog is invalid