### PR TITLE
chore(postgres): Bump timescale to 2.14.2

### DIFF
--- a/src/_includes/database_postgresql_extensions.md
+++ b/src/_includes/database_postgresql_extensions.md
@@ -48,7 +48,7 @@
 | `sslinfo`                      | `1.2`    | information about SSL certificates
 | `tablefunc`                    | `1.0`    | functions that manipulate whole tables, including crosstab
 | `tcn`                          | `1.0`    | Triggered change notifications
-| `timescaledb`                  | `2.11.1` | Enables scalable inserts and complex queries for time-series data (Apache 2 Edition)
+| `timescaledb`                  | `2.14.2` | Enables scalable inserts and complex queries for time-series data (Apache 2 Edition)
 | `tsm_system_rows`              | `1.0`    | TABLESAMPLE method which accepts number of rows as a limit
 | `tsm_system_time`              | `1.0`    | TABLESAMPLE method which accepts time in milliseconds as a limit
 | `unaccent`                     | `1.1`    | text search dictionary that removes accents

--- a/src/_posts/databases/postgresql/2000-01-01-overview.md
+++ b/src/_posts/databases/postgresql/2000-01-01-overview.md
@@ -11,7 +11,7 @@ index: 1
 PostgreSQL® is a free, open-source, community-managed object-relational
 database management system focusing on SQL compliance and extensibility. It is
 well-known for its performances, reliability and robustness, making it a very
-powerful database, able to hanlde small to huge workloads.
+powerful database, able to handle small to huge workloads.
 
 Besides the core features (ACID transactions, views, triggers, foreign keys,
 ...) PostgreSQL® also offers solutions for more specialized usages, such as
@@ -53,7 +53,7 @@ operation (database upgrade, for example) or because of a platform issue.
 
 ### Available Version
 
-The latest version of PostgreSQL® available is **`14.11.0-1`**.
+The latest version of PostgreSQL® available is **`14.11.0-2`**.
 
 This is also the default version when attaching a PostgreSQL® addon to your
 application.

--- a/src/changelog/databases/_posts/2024-04-24-postgresql-14.11.0-2.md
+++ b/src/changelog/databases/_posts/2024-04-24-postgresql-14.11.0-2.md
@@ -1,0 +1,15 @@
+---
+modified_at: 2024-04-24 00:00:00
+title: 'PostgreSQL - New Scalingo release: 14.11.0-2, 13.14.0-2 with TimescaleDB 2.14.2'
+---
+
+New default version: **14.11.0-2**.
+
+Changelog:
+
+- Upgrading TimescaleDB to the last version 2.14.2 on Postgres 13 and 14
+
+Docker images on [Docker Hub](https://hub.docker.com/r/scalingo/postgresql):
+
+* `scalingo/postgresql:14.11.0-2`
+* `scalingo/postgresql:13.14.0-2`


### PR DESCRIPTION
related to https://github.com/Scalingo/appsdeck-database/issues/2935