### PR TITLE
fix: Fix database duplicate example script

### DIFF
--- a/src/_posts/platform/databases/2000-01-01-duplicate.md
+++ b/src/_posts/platform/databases/2000-01-01-duplicate.md
@@ -72,7 +72,7 @@ scalingo --app "${DUPLICATE_SOURCE_APP}" --addon "${addon_id}" \
 # Get the name of the backup file:
 backup_file_name="$( tar --list --file="${archive_name}" \
                      | tail -n 1 \
-                     | cut -d "/" -f 1 )"
+                     | cut -d "/" -f 2 )"
 
 # Extract the archive containing the downloaded backup:
 tar --extract --verbose --file="${archive_name}" --directory="/app/"


### PR DESCRIPTION
Hi there,

I have been using the example script on this page to copy my database (thanks for providing the script!):
https://doc.scalingo.com/platform/databases/duplicate

Overall the script is fine, but I ran into a small issue: when retrieving the backup filename from the TAR archive, we need the filename part *after* the leading slash (second field) and not the one before (first field). Hence we should use `cut -f 2` instead of `cut -f 1`.

```sh
$ tar --list --file=backup.tar.gz  | tail -n 1 | cut -d "/" -f 2
tar: Removing leading `/' from member names
20240503001956_*****************.pgsql
```