### PR TITLE
fix(platform): Fix typo

### DIFF
--- a/src/_posts/platform/app/2000-01-01-sticky-sessions.md
+++ b/src/_posts/platform/app/2000-01-01-sticky-sessions.md
@@ -1,5 +1,5 @@
 ---
-title: "Sticky Sessions - Session Affiniy"
+title: "Sticky Sessions - Session Affinity"
 nav: "Sticky Sessions"
 modified_at: 2018-03-21 00:00:00
 tags: app routing


### PR DESCRIPTION
Fix minor typo in the title of the [Sticky Sessions](https://doc.scalingo.com/platform/app/sticky-sessions) documentation page.