### PR TITLE
feat(css): Update h2 font-size to make documentation more readable

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -96,14 +96,14 @@ module.exports = {
         },
       ],
       "sc-title-2": [
-        "24px",
+        "26px",
         {
           lineHeight: "28px",
           letterSpacing: "-0.04em",
         },
       ],
       "sc-title-2-2": [
-        "24px",
+        "26px",
         {
           lineHeight: "40px",
         },


### PR DESCRIPTION
Set h2 to 26px

ticket: https://github.com/Scalingo/documentation/issues/2621