### PR TITLE
fix(stacks): release of scalingo-20:v13 and scalingo-22:v10

### DIFF
--- a/src/_includes/scalingo_20_stack_packages.md
+++ b/src/_includes/scalingo_20_stack_packages.md
@@ -58,7 +58,7 @@
 |             gcc-10-base:amd64 |          10.5.0-1ubuntu1~20.04 |
 |                         gcc-9 |         9.4.0-1ubuntu1~20.04.2 |
 |              gcc-9-base:amd64 |         9.4.0-1ubuntu1~20.04.2 |
-|                   ghostscript |          9.50~dfsg-5ubuntu4.11 |
+|                   ghostscript |          9.50~dfsg-5ubuntu4.12 |
 |      gir1.2-freedesktop:amd64 |         1.64.1-1~ubuntu20.04.1 |
 |    gir1.2-gdkpixbuf-2.0:amd64 |         2.40.0+dfsg-3ubuntu0.5 |
 |         gir1.2-glib-2.0:amd64 |         1.64.1-1~ubuntu20.04.1 |
@@ -210,8 +210,8 @@
 |              libgpgme11:amd64 |              1.13.1-7ubuntu2.2 |
 |                 libgpm2:amd64 |                       1.20.7-5 |
 |          libgraphite2-3:amd64 |                1.3.13-11build1 |
-|                  libgs9:amd64 |          9.50~dfsg-5ubuntu4.11 |
-|                 libgs9-common |          9.50~dfsg-5ubuntu4.11 |
+|                  libgs9:amd64 |          9.50~dfsg-5ubuntu4.12 |
+|                 libgs9-common |          9.50~dfsg-5ubuntu4.12 |
 |        libgssapi-krb5-2:amd64 |                1.17-6ubuntu4.4 |
 |      libgssapi3-heimdal:amd64 |          7.7.0+dfsg-1ubuntu1.4 |
 |           libharfbuzz0b:amd64 |               2.6.4-1ubuntu4.2 |
@@ -360,7 +360,7 @@
 |         librsvg2-common:amd64 |        2.48.9-1ubuntu0.20.04.4 |
 |            librsvg2-dev:amd64 |        2.48.9-1ubuntu0.20.04.4 |
 |                librtmp1:amd64 | 2.4+20151223.gitfa8646d.1-2build1 |
-|              libruby2.7:amd64 |              2.7.0-5ubuntu1.12 |
+|              libruby2.7:amd64 |              2.7.0-5ubuntu1.13 |
 |              libsasl2-2:amd64 |         2.1.27+dfsg-2ubuntu0.1 |
 |                  libsasl2-dev |         2.1.27+dfsg-2ubuntu0.1 |
 |        libsasl2-modules:amd64 |         2.1.27+dfsg-2ubuntu0.1 |
@@ -579,9 +579,9 @@
 |             ruby-power-assert |                        1.1.7-1 |
 |                ruby-test-unit |                        3.3.5-1 |
 |                   ruby-xmlrpc |                        0.3.0-2 |
-|                       ruby2.7 |              2.7.0-5ubuntu1.12 |
-|             ruby2.7-dev:amd64 |              2.7.0-5ubuntu1.12 |
-|                   ruby2.7-doc |              2.7.0-5ubuntu1.12 |
+|                       ruby2.7 |              2.7.0-5ubuntu1.13 |
+|             ruby2.7-dev:amd64 |              2.7.0-5ubuntu1.13 |
+|                   ruby2.7-doc |              2.7.0-5ubuntu1.13 |
 |          rubygems-integration |                           1.16 |
 |                           sed |                          4.7-1 |
 |                sensible-utils |                    0.0.12+nmu1 |
@@ -618,3 +618,4 @@
 |                           zip |                   3.0-11build1 |
 |                  zlib1g:amd64 |       1:1.2.11.dfsg-2ubuntu1.5 |
 |              zlib1g-dev:amd64 |       1:1.2.11.dfsg-2ubuntu1.5 |
+|                          zstd |          1.4.4+dfsg-3ubuntu0.1 |

--- a/src/_includes/scalingo_22_stack_packages.md
+++ b/src/_includes/scalingo_22_stack_packages.md
@@ -55,7 +55,7 @@
 |                        gcc-11 |          11.4.0-1ubuntu1~22.04 |
 |             gcc-11-base:amd64 |          11.4.0-1ubuntu1~22.04 |
 |             gcc-12-base:amd64 |          12.3.0-1ubuntu1~22.04 |
-|                   ghostscript |        9.55.0~dfsg1-0ubuntu5.6 |
+|                   ghostscript |        9.55.0~dfsg1-0ubuntu5.7 |
 |      gir1.2-freedesktop:amd64 |                       1.72.0-1 |
 |    gir1.2-gdkpixbuf-2.0:amd64 |         2.42.8+dfsg-1ubuntu0.3 |
 |         gir1.2-glib-2.0:amd64 |                       1.72.0-1 |
@@ -210,8 +210,8 @@
 |              libgpgme11:amd64 |            1.16.0-1.2ubuntu4.2 |
 |                 libgpm2:amd64 |                1.20.7-10build1 |
 |          libgraphite2-3:amd64 |                 1.3.14-1build2 |
-|                  libgs9:amd64 |        9.55.0~dfsg1-0ubuntu5.6 |
-|                 libgs9-common |        9.55.0~dfsg1-0ubuntu5.6 |
+|                  libgs9:amd64 |        9.55.0~dfsg1-0ubuntu5.7 |
+|                 libgs9-common |        9.55.0~dfsg1-0ubuntu5.7 |
 |        libgssapi-krb5-2:amd64 |              1.19.2-2ubuntu0.3 |
 |           libharfbuzz0b:amd64 |               2.7.4-1ubuntu3.1 |
 |                libheif1:amd64 |                 1.12.0-2build1 |
@@ -291,8 +291,8 @@
 |                 libmpc3:amd64 |                  1.2.1-2build1 |
 |               libmpdec3:amd64 |                  2.5.1-2build2 |
 |                libmpfr6:amd64 |                  4.1.0-3build3 |
-|            libmysqlclient-dev |        8.0.36-0ubuntu0.22.04.1 |
-|        libmysqlclient21:amd64 |        8.0.36-0ubuntu0.22.04.1 |
+|            libmysqlclient-dev |        8.0.37-0ubuntu0.22.04.3 |
+|        libmysqlclient21:amd64 |        8.0.37-0ubuntu0.22.04.3 |
 |          libncurses-dev:amd64 |                 6.3-2ubuntu0.1 |
 |             libncurses5:amd64 |                 6.3-2ubuntu0.1 |
 |             libncurses6:amd64 |                 6.3-2ubuntu0.1 |
@@ -358,7 +358,7 @@
 |         librsvg2-common:amd64 |         2.52.5+dfsg-3ubuntu0.2 |
 |            librsvg2-dev:amd64 |         2.52.5+dfsg-3ubuntu0.2 |
 |                librtmp1:amd64 | 2.4+20151223.gitfa8646d.1-2build4 |
-|              libruby3.0:amd64 |               3.0.2-7ubuntu2.5 |
+|              libruby3.0:amd64 |               3.0.2-7ubuntu2.6 |
 |              libsasl2-2:amd64 |        2.1.27+dfsg2-3ubuntu1.2 |
 |                  libsasl2-dev |        2.1.27+dfsg2-3ubuntu1.2 |
 |        libsasl2-modules:amd64 |        2.1.27+dfsg2-3ubuntu1.2 |
@@ -389,9 +389,9 @@
 |              libtasn1-6:amd64 |                 4.18.0-4build1 |
 |                  libthai-data |                 0.1.29-1build1 |
 |                libthai0:amd64 |                 0.1.29-1build1 |
-|             libtiff-dev:amd64 |               4.3.0-6ubuntu0.8 |
-|                libtiff5:amd64 |               4.3.0-6ubuntu0.8 |
-|              libtiffxx5:amd64 |               4.3.0-6ubuntu0.8 |
+|             libtiff-dev:amd64 |               4.3.0-6ubuntu0.9 |
+|                libtiff5:amd64 |               4.3.0-6ubuntu0.9 |
+|              libtiffxx5:amd64 |               4.3.0-6ubuntu0.9 |
 |               libtinfo5:amd64 |                 6.3-2ubuntu0.1 |
 |               libtinfo6:amd64 |                 6.3-2ubuntu0.1 |
 |               libtirpc-common |               1.3.2-2ubuntu0.1 |
@@ -405,8 +405,8 @@
 |           libunistring2:amd64 |                          1.0-1 |
 |                libuuid1:amd64 |              2.37.2-4ubuntu3.4 |
 |                  libuv1:amd64 |              1.43.0-1ubuntu0.1 |
-|              libvpx-dev:amd64 |              1.11.0-2ubuntu2.2 |
-|                 libvpx7:amd64 |              1.11.0-2ubuntu2.2 |
+|              libvpx-dev:amd64 |              1.11.0-2ubuntu2.3 |
+|                 libvpx7:amd64 |              1.11.0-2ubuntu2.3 |
 |                libwebp7:amd64 |         1.2.2-2ubuntu0.22.04.2 |
 |           libwebpdemux2:amd64 |         1.2.2-2ubuntu0.22.04.2 |
 |             libwebpmux3:amd64 |         1.2.2-2ubuntu0.22.04.2 |
@@ -586,9 +586,9 @@
 |                 ruby-rubygems |                        3.3.5-2 |
 |                  ruby-webrick |                        1.7.0-3 |
 |                   ruby-xmlrpc |               0.3.2-1ubuntu0.1 |
-|                       ruby3.0 |               3.0.2-7ubuntu2.5 |
-|             ruby3.0-dev:amd64 |               3.0.2-7ubuntu2.5 |
-|                   ruby3.0-doc |               3.0.2-7ubuntu2.5 |
+|                       ruby3.0 |               3.0.2-7ubuntu2.6 |
+|             ruby3.0-dev:amd64 |               3.0.2-7ubuntu2.6 |
+|                   ruby3.0-doc |               3.0.2-7ubuntu2.6 |
 |          rubygems-integration |                           1.18 |
 |                           sed |                   4.8-1ubuntu2 |
 |                sensible-utils |                         0.0.17 |
@@ -623,3 +623,4 @@
 |                           zip |                   3.0-12build2 |
 |                  zlib1g:amd64 |       1:1.2.11.dfsg-2ubuntu9.2 |
 |              zlib1g-dev:amd64 |       1:1.2.11.dfsg-2ubuntu9.2 |
+|                          zstd |             1.4.8+dfsg-3build1 |

--- a/src/changelog/base_image/_posts/2024-06-18-scalingo-20-v13-scalingo-22-v10.md
+++ b/src/changelog/base_image/_posts/2024-06-18-scalingo-20-v13-scalingo-22-v10.md
@@ -1,0 +1,19 @@
+---
+modified_at: 2024-06-18 12:00:00
+title: 'Stack scalingo-22 v10, scalingo-20 v13, scalingo-22-minimal:v9 and scalingo-20-minimal:v12'
+---
+
+This new versions contain the following changes:
+
+* Full `apt-get upgrade` for all stacks
+* Add `zstd`
+
+For a comprehensive list of packages installed in the different stacks, please refer to our documentation:
+
+* [scalingo-20]({% post_url platform/internals/stacks/2000-01-01-scalingo-20-stack %}#ubuntu-packages)
+* [scalingo-22]({% post_url platform/internals/stacks/2000-01-01-scalingo-22-stack %}#ubuntu-packages)
+
+As always, the Docker images are available on Docker Hub:
+
+* [scalingo-20](https://hub.docker.com/r/scalingo/scalingo-20)
+* [scalingo-22](https://hub.docker.com/r/scalingo/scalingo-22)


### PR DESCRIPTION
Images (`scalingo-20:v13`, `scalingo-22:v10`, `scalingo-20-minimal:v12` and `scalingo-22-minimal:v9`) have been built and pushed to the registry.

They also have been successfully tested.

Fix https://github.com/Scalingo/appsdeck-builder/issues/406
