### PR TITLE
docs(environment): hostname composed of app name and container type

### DIFF
--- a/src/_posts/platform/app/2000-01-01-environment.md
+++ b/src/_posts/platform/app/2000-01-01-environment.md
@@ -118,7 +118,7 @@ additional variable `$PORT` is defined.
 * `CONTAINER_SIZE`: Name of the size of the container `M`, `L`, `XL` etc.
 * `CONTAINER_MEMORY`: Available RAM memory of the container (in bytes)
 * `APP`: Name of the application deployed
-* `HOSTNAME`: Alias for `APP`
+* `HOSTNAME`: The full application hostname (ex: `[APP].[region].scalingo.io`)
 * `STACK`: Name of the stack the application deployed is using
 * `REGION_NAME`: Name of the region where the application is deployed
 

--- a/src/_posts/platform/app/2000-01-01-environment.md
+++ b/src/_posts/platform/app/2000-01-01-environment.md
@@ -112,13 +112,13 @@ variables defined in the application configuration but is also injecting a set o
 environment variables in its environment. In the case of `web` containers, an
 additional variable `$PORT` is defined.
 
-* `PORT`: Port number your server has to bind on.
+* `PORT`: Port number your server has to bind on
 * `CONTAINER`: Type and index of the container, `web-1` or `worker-1` for instance
-* `CONTAINER_VERSION`: Version of the container started, usually the Git commit SHA.
-* `CONTAINER_SIZE`: Name of the size of the container `M`, `L`, `XL` etc.
+* `CONTAINER_VERSION`: Version of the container started, usually the Git commit SHA
+* `CONTAINER_SIZE`: Name of the size of the container `M`, `L`, `XL`, etc
 * `CONTAINER_MEMORY`: Available RAM memory of the container (in bytes)
 * `APP`: Name of the application deployed
-* `HOSTNAME`: The full application hostname (ex: `[APP].[region].scalingo.io`)
+* `HOSTNAME`: The container application hostname based on the application name and the container type (e.g. `my-app-web-1`)
 * `STACK`: Name of the stack the application deployed is using
 * `REGION_NAME`: Name of the region where the application is deployed
 


### PR DESCRIPTION
Hello

Suggestion for the docs : looks like `HOST` is not exactly an alias for `APP` but the full qualified domain name.