### PR TITLE
docs(nodejs): fix `devDependencies` installation explanation

### DIFF
--- a/src/_posts/languages/nodejs/2000-01-01-start.md
+++ b/src/_posts/languages/nodejs/2000-01-01-start.md
@@ -1,7 +1,7 @@
 ---
 title: Node.js
 nav: Introduction
-modified_at: 2023-11-29 12:00:00
+modified_at: 2024-08-22 00:00:00
 tags: nodejs
 index: 1
 ---
@@ -92,19 +92,11 @@ Buildpack]({% post_url platform/deployment/buildpacks/2000-01-01-ssh-key %}),
 this buildpack will let you setup a private SSH key securely in the build
 environment.
 
-### Install devDependencies
+### devDependencies Installation
 
-By default, dependencies present in the `devDependencies` field are not
-installed since they should not be needed for production. If you want to
-install them, you'll need to set the `NPM_CONFIG_PRODUCTION` environment
-variable to false via our web interface or by using our CLI:
+By default, dependencies present in the `devDependencies` field are installed. At the end of the deployment, `devDependencies` are pruned. Hence only production dependencies are left in the image used for the runtime.
 
-```bash
-$ scalingo --app my-app env-set NPM_CONFIG_PRODUCTION=false
-```
-
-After setting the NPM_CONFIG_PRODUCTION environment variable, you have to
-redeploy your code.
+The pruning step can be skipped by setting the environment variable `YARN_PRODUCTION` to any value.
 
 ### Ensure you're Tracking all your Dependencies
 
@@ -359,7 +351,7 @@ To fix this issue, modify the `start` script by adding `-p $PORT`
 ### Standalone Mode
 The Next.js built image can be quite large, easily exceeding 500MB. If you encounter issues with the image size, you can try "standalone" mode.
 
-More information here: [Next.js in standalone mode]({% post_url languages/nodejs/2000-01-01-nextjs-standalone %}). 
+More information here: [Next.js in standalone mode]({% post_url languages/nodejs/2000-01-01-nextjs-standalone %}).
 
 
 ## Vite


### PR DESCRIPTION
Fix #2645