### PR TITLE
Update 2000-01-01-detecting-https-requests.md

### DIFF
--- a/src/_posts/platform/app/2000-01-01-detecting-https-requests.md
+++ b/src/_posts/platform/app/2000-01-01-detecting-https-requests.md
@@ -37,7 +37,7 @@ import (
 )
 
 func isHTTPS(req *http.Request) bool {
-  return req.Header.Get("X-Forwarded-Proto" == "https") || req.URL.Scheme == "https"
+  return req.Header.Get("X-Forwarded-Proto") == "https" || req.URL.Scheme == "https"
 }
 
 func main() {

--- a/src/_posts/platform/app/2000-01-01-detecting-https-requests.md
+++ b/src/_posts/platform/app/2000-01-01-detecting-https-requests.md
@@ -1,6 +1,6 @@
 ---
 title: Detecting HTTPS requests
-modified_at: 2015-03-23 00:00:00
+modified_at: 2024-08-23 00:00:00
 tags: internals routing request https
 index: 22
 ---


### PR DESCRIPTION
Fix this error:
```sh
./main.go:11:10: invalid operation: req.Header.Get("X-Forwarded-Proto" == "https") || req.URL.Scheme == "https" (mismatched types string and untyped bool)
./main.go:11:25: cannot use "X-Forwarded-Proto" == "https" (untyped bool constant false) as string value in argument to req.Header.Get
```