### PR TITLE
[STORY-444] PG15 is now the default version deployed

### DIFF
--- a/src/_posts/databases/postgresql/2000-01-01-accessing.md
+++ b/src/_posts/databases/postgresql/2000-01-01-accessing.md
@@ -1,7 +1,7 @@
 ---
 title: Accessing Your Scalingo for PostgreSQL® Addon
 nav: Accessing
-modified_at: 2024-06-21 09:00:00
+modified_at: 2024-08-23 09:00:00
 tags: databases postgresql addon
 index: 4
 ---
@@ -29,8 +29,8 @@ depends on your needs and preferences.
 
    ---> Download and extract the database CLI
    ---> Database CLI installed:
-   psql (PostgreSQL) 15.7
-   psql (15.7, server 15.7 (Debian 15.7-1.pgdg120+1))
+   psql (PostgreSQL) 15.8
+   psql (15.8, server 15.8 (Debian 15.8-1.pgdg120+1))
    SSL connection (protocol: TLSv1.3, cipher: TLS_AES_256_GCM_SHA384, bits: 256, compression: off)
    Type "help" for help.
 
@@ -55,7 +55,7 @@ depends on your needs and preferences.
    ```text
    ---> Download and extract the database CLI
    ---> Database CLI installed:
-   psql (PostgreSQL) 14.6
+   psql (PostgreSQL) 15.8
    ```
 
    If you ever need a specific version, just add it as a second parameter:

--- a/src/_posts/databases/postgresql/2000-01-01-overview.md
+++ b/src/_posts/databases/postgresql/2000-01-01-overview.md
@@ -60,11 +60,9 @@ operation (database upgrade, for example) or because of a platform issue.
 
 ### Available Version
 
-The latest version of PostgreSQL® available is **`15.7.0-2`**.
+The latest and default version of PostgreSQL® available is **`15.8.0-1`**.
 
-The default version when attaching a PostgreSQL® addon to your
-application is **14.12.0-1**.
-
+Three last major versions are officially maintained: v15, v14 and v13.
 
 ### Available Extensions
 

--- a/src/changelog/databases/_posts/2024-07-23-postgresql-15-default.md
+++ b/src/changelog/databases/_posts/2024-07-23-postgresql-15-default.md
@@ -1,0 +1,8 @@
+---
+modified_at: 2024-08-23 09:00:00
+title: 'PostgreSQL - New Default Major Version: v15'
+---
+
+PostgreSQL 15 is now the default deployed version when a new addon is created.
+
+Docker images on [Docker Hub](https://hub.docker.com/r/scalingo/postgresql):

--- a/src/changelog/databases/_posts/2024-07-23-postgresql-15.8.0-1.md
+++ b/src/changelog/databases/_posts/2024-07-23-postgresql-15.8.0-1.md
@@ -1,5 +1,5 @@
 ---
-modified_at: 2024-08-22 09:00:00
+modified_at: 2024-08-23 09:00:00
 title: 'PostgreSQL - 15.8, 14.13, 13.16 and postgis_sfcgal'
 ---
 


### PR DESCRIPTION
- **[STORY-444] PostgreSQL 15 is now the default version deployed on the platform**
- **Update references from PG 15.7 to PG 15.8**
