### PR TITLE
docs(ruby): typo in 'MAX_THREADS' variable name

### DIFF
--- a/src/_posts/languages/ruby/2000-01-01-start.md
+++ b/src/_posts/languages/ruby/2000-01-01-start.md
@@ -156,7 +156,7 @@ end
 ```
 
 Thus you can change the global settings by modifying the environment
-variables `WEB_CONCURRENCY` and `MAX_THREAD` and restarting your app.
+variables `WEB_CONCURRENCY` and `MAX_THREADS` and restarting your app.
 
 ## WEB_CONCURRENCY
 


### PR DESCRIPTION
Fix #2767