### PR TITLE
[STORY-648] docs: DB users passwords are between 24 and 64 characters long

### DIFF
--- a/src/_posts/databases/elasticsearch/2000-01-01-start.md
+++ b/src/_posts/databases/elasticsearch/2000-01-01-start.md
@@ -81,7 +81,7 @@ You can get environment variables from the dashboard or the command line interfa
 $ scalingo --app my-app env | grep ELASTIC
 
 ELASTICSEARCH_URL=$SCALINGO_ELASTICSEARCH_URL
-SCALINGO_ELASTICSEARCH_URL=http://my-app-3030:MpIxXstskccB3Ab2iwKH@my-app-3030.elasticsearch.a.osc-fr1.scalingo-dbs.com:30995
+SCALINGO_ELASTICSEARCH_URL=http://my-app-3030:YANs3y07m5_KJC2MSDGebh8tx1lliFWh2Yb239zVqGQvbElWDjIN7QWspVH92Ul8@my-app-3030.elasticsearch.a.osc-fr1.scalingo-dbs.com:30995
 ```
 
 ## Remote access your database
@@ -102,7 +102,7 @@ scalingo --app <application name> run curl http://<user>:<password>@<host>:<port
 **Example**
 
 If my application's name is 'my-app' and it has the environment variable
-`SCALINGO_ELASTICSEARCH_URL = "http://my-app-123:H_grwjqBteMMrVye442Zw6@my-app-123.elasticsearch.a.osc-fr1.scalingo-dbs.com:30000/my-app-123"`
+`SCALINGO_ELASTICSEARCH_URL = "http://my-app-123:YANs3y07m5_KJC2MSDGebh8tx1lliFWh2Yb239zVqGQvbElWDjIN7QWspVH92Ul8@my-app-123.elasticsearch.a.osc-fr1.scalingo-dbs.com:30000/my-app-123"`
 
 You can run:
 

--- a/src/_posts/databases/influxdb/2000-01-01-start.md
+++ b/src/_posts/databases/influxdb/2000-01-01-start.md
@@ -68,7 +68,7 @@ You can get environment variables from the dashboard or the command-line interfa
 $ scalingo --app my-app env
 
 INFLUX_URL=$SCALINGO_INFLUX_URL
-SCALINGO_INFLUX_URL=http://sample_influxdb_3707:RCtlmiQDXuXosYJ4mIOP@my-app-3707.influxdb.a.osc-fr1.scalingo-dbs.com:31061/sample_influxdb_3707
+SCALINGO_INFLUX_URL=http://sample_influxdb_3707:YANs3y07m5_KJC2MSDGebh8tx1lliFWh2Yb239zVqGQvbElWDjIN7QWspVH92Ul8@my-app-3707.influxdb.a.osc-fr1.scalingo-dbs.com:31061/sample_influxdb_3707
 ```
 
 ## Remote access your database

--- a/src/_posts/databases/mongodb/2000-01-01-compass.md
+++ b/src/_posts/databases/mongodb/2000-01-01-compass.md
@@ -28,14 +28,14 @@ application from the [web dashboard](https://dashboard.scalingo.com) or from the
 
 ```bash
 $ scalingo --app my-app env-get MONGO_URL
-mongodb://my-app-7093:EsEjseivpacatVoogfijbiapgadTyg@c393a9e3-42fe-4e33-9e6c-8ee815e9af88.my-app-7093.mongo.a.osc-fr1.scalingo-dbs.com:31312/my-app-7093?replicaSet=my-app-7093-rs0&ssl=true
+mongodb://my-app-7093:YANs3y07m5_KJC2MSDGebh8tx1lliFWh2Yb239zVqGQvbElWDjIN7QWspVH92Ul8@c393a9e3-42fe-4e33-9e6c-8ee815e9af88.my-app-7093.mongo.a.osc-fr1.scalingo-dbs.com:31312/my-app-7093?replicaSet=my-app-7093-rs0&ssl=true
 ```
 
 In this case:
 * Hostname: c393a9e3-42fe-4e33-9e6c-8ee815e9af88.my-app-7093.mongo.a.osc-fr1.scalingo-dbs.com
 * Port: 31312
 * User: my-app-7093
-* Password: EsEjseivpacatVoogfijbiapgadTyg
+* Password: YANs3y07m5_KJC2MSDGebh8tx1lliFWh2Yb239zVqGQvbElWDjIN7QWspVH92Ul8
 * Database: my-app-7093
 
 ### Connection via an Encrypted Tunnel

--- a/src/_posts/databases/mongodb/2000-01-01-robo3t.md
+++ b/src/_posts/databases/mongodb/2000-01-01-robo3t.md
@@ -27,7 +27,7 @@ application.
 
 ```
 $ scalingo env | grep MONGO_URL
-MONGO_URL=mongodb://sample-node-meanjs-7093:EsEjseivpacatVoogfijbiapgadTyg@c393a9e3-42fe-4e33-9e6c-8ee815e9af88.sample-node-meanjs-7093.mongodb.a.osc-fr1.scalingo-dbs.com:31312/sample-node-meanjs-7093
+MONGO_URL=mongodb://sample-node-meanjs-7093:YANs3y07m5_KJC2MSDGebh8tx1lliFWh2Yb239zVqGQvbElWDjIN7QWspVH92Ul8@c393a9e3-42fe-4e33-9e6c-8ee815e9af88.sample-node-meanjs-7093.mongodb.a.osc-fr1.scalingo-dbs.com:31312/sample-node-meanjs-7093
 ```
 
 In this case:
@@ -35,7 +35,7 @@ In this case:
 * Hostname: c393a9e3-42fe-4e33-9e6c-8ee815e9af88.sample-node-meanjs-7093.mongodb.a.osc-fr1.scalingo-dbs.com
 * Port: 31312
 * User: sample-node-meanjs-7093
-* Password: EsEjseivpacatVoogfijbiapgadTyg
+* Password: YANs3y07m5_KJC2MSDGebh8tx1lliFWh2Yb239zVqGQvbElWDjIN7QWspVH92Ul8
 * Database: sample-node-meanjs-7093
 
 Fill the fields accordingly:

--- a/src/_posts/databases/mongodb/2000-01-01-start.md
+++ b/src/_posts/databases/mongodb/2000-01-01-start.md
@@ -78,7 +78,7 @@ You can get those variables from the Dashboard or the command-line interface.
 $ scalingo --app my-app env | grep MONGO
 
 MONGO_URL=$SCALINGO_MONGO_URL
-SCALINGO_MONGO_URL=mongodb://my-app-3030:2rj5FYoiKRFp8eZhpMz7@my-app-3030.mongo.a.osc-fr1.scalingo-dbs.com:30949/my-app-3030
+SCALINGO_MONGO_URL=mongodb://my-app-3030:YANs3y07m5_KJC2MSDGebh8tx1lliFWh2Yb239zVqGQvbElWDjIN7QWspVH92Ul8@my-app-3030.mongo.a.osc-fr1.scalingo-dbs.com:30949/my-app-3030
 ```
 
 ## Remote access your database

--- a/src/_posts/databases/mysql/2000-01-01-connecting.md
+++ b/src/_posts/databases/mysql/2000-01-01-connecting.md
@@ -74,7 +74,7 @@ still remains applicable.
    ```
    The output should look like:
    ```bash
-   mysql://my_app_wxyz:Q7X7CU2vGjFiLZrA43OG@7e10d74b-c766-40b3-8dad-ce9cfa461311.my-app-wxyz.mysql.a.osc-fr1.scalingo-dbs.com:31000/my_app_wxyz?useSSL=true&verifyServerCertificate=false
+   mysql://my_app_wxyz:Q7X7CU2vGjFiLZrA43OG@YANs3y07m5_KJC2MSDGebh8tx1lliFWh2Yb239zVqGQvbElWDjIN7QWspVH92Ul8.my-app-wxyz.mysql.a.osc-fr1.scalingo-dbs.com:31000/my_app_wxyz?useSSL=true&verifyServerCertificate=false
    ```
 
 

--- a/src/_posts/databases/mysql/2000-01-01-managing.md
+++ b/src/_posts/databases/mysql/2000-01-01-managing.md
@@ -214,7 +214,7 @@ method you use:
   - Can only contain alphanumerical characters and underscores (`_`)
   - Must start with a letter
 - Password:
-  - Must be between 8 and 64 characters long.
+  - Must be between 24 and 64 characters long.
   - Must not contain the character `"` or `'`
 
 #### Using the Database Dashboard

--- a/src/_posts/databases/postgresql/2000-01-01-connecting.md
+++ b/src/_posts/databases/postgresql/2000-01-01-connecting.md
@@ -74,7 +74,7 @@ still remains applicable.
    ```
    The output is:
    ```bash
-   postgresql://my_app_wxyz:ptojfrxzRi-lDfDYyahe@my-app-wxyz.postgresql.a.osc-fr1.scalingo-dbs.com:31000/my_app_wxyz?sslmode=prefer
+   postgresql://my_app_wxyz:YANs3y07m5_KJC2MSDGebh8tx1lliFWh2Yb239zVqGQvbElWDjIN7QWspVH92Ul8@my-app-wxyz.postgresql.a.osc-fr1.scalingo-dbs.com:31000/my_app_wxyz?sslmode=prefer
    ```
 
 

--- a/src/_posts/databases/postgresql/2000-01-01-managing.md
+++ b/src/_posts/databases/postgresql/2000-01-01-managing.md
@@ -218,7 +218,7 @@ method used:
   - Can only contain alphanumerical characters and underscores (`_`)
   - Must start with a letter
 - Password:
-  - Must be between 8 and 64 characters long.
+  - Must be between 24 and 64 characters long.
   - Must not contain the character `"` or `'`
 
 #### Using the Database Dashboard

--- a/src/_posts/databases/redis/2000-01-01-start.md
+++ b/src/_posts/databases/redis/2000-01-01-start.md
@@ -81,7 +81,7 @@ You can get environment variables from the dashboard or the command line interfa
 $ scalingo --app my-app env | grep REDIS
 
 REDIS_URL=$SCALINGO_REDIS_URL
-SCALINGO_REDIS_URL=redis://my-app-3030:l2ebPNwe-IWVJmV8OlLX@my-app-3030.redis.a.osc-fr1.scalingo-dbs.com:30996
+SCALINGO_REDIS_URL=redis://my-app-3030:YANs3y07m5_KJC2MSDGebh8tx1lliFWh2Yb239zVqGQvbElWDjIN7QWspVH92Ul8@my-app-3030.redis.a.osc-fr1.scalingo-dbs.com:30996
 ```
 
 ## Remote Access Your Database


### PR DESCRIPTION
Specify DB users passwords are between 24 and 64 characters long.
Enforce 64 characters longs DB users passwords in examples.