### PR TITLE
chore(changelog): misc. buildpack updates

### DIFF
--- a/src/_posts/languages/php/2000-01-01-dependencies.md
+++ b/src/_posts/languages/php/2000-01-01-dependencies.md
@@ -1,7 +1,7 @@
 ---
 title: Managing Dependencies
 nav: Managing Dependencies
-modified_at: 2024-08-26 12:00:00
+modified_at: 2024-09-09 12:00:00
 tags: php
 index: 3
 ---
@@ -95,7 +95,7 @@ You can select the Composer version to install by specifying it in your
 
 Scalingo currently supports the following versions of Composer:
 
-- `2.7.8`
+- `2.7.9`
 - `2.6.6`
 - `2.2.24` (LTS)
 

--- a/src/_posts/languages/python/2000-01-01-start.md
+++ b/src/_posts/languages/python/2000-01-01-start.md
@@ -1,7 +1,7 @@
 ---
 title: Python
 nav: Introduction
-modified_at: 2024-08-08 12:00:00
+modified_at: 2024-09-09 12:00:00
 tags: python
 index: 1
 ---
@@ -22,11 +22,11 @@ The following versions of Python are available:
 
 | Python Version | scalingo-20     | scalingo-22     |
 | -------------: | --------------: | --------------: |
-| `3.12`         | up to `3.12.5`  | up to `3.12.5`  |
-| `3.11`         | up to `3.11.9`  | up to `3.11.9`  |
-| `3.10`         | up to `3.10.14` | up to `3.10.14` |
-| `3.9`          | up to `3.9.19`  | up to `3.9.19`  |
-| `3.8`          | up to `3.8.19`  | unsupported     |
+| `3.12`         | up to `3.12.6`  | up to `3.12.6`  |
+| `3.11`         | up to `3.11.10` | up to `3.11.10` |
+| `3.10`         | up to `3.10.15` | up to `3.10.15` |
+| `3.9`          | up to `3.9.20`  | up to `3.9.20`  |
+| `3.8`          | up to `3.8.20`  | unsupported     |
 
 {% note %}
 Even though we still support them, we strongly advise against using deprecated

--- a/src/changelog/buildpacks/_posts/2024-09-09-go-unmaintained-depencies-managers-deprecation.md
+++ b/src/changelog/buildpacks/_posts/2024-09-09-go-unmaintained-depencies-managers-deprecation.md
@@ -1,0 +1,10 @@
+---
+modified_at: 2024-09-09 12:00:00
+title: 'Go - Deprecation of dep, gb, glide, godep and govendor'
+github: 'https://github.com/Scalingo/go-buildpack'
+---
+
+- Unmaintained dependency managers such as `dep`, `gb`, `glide`, `godep` and
+  `govendor` are now deprecated.
+- Support for these dependency managers will be removed in March 2025.
+- Please migrate to Go modules as soon as possible.

--- a/src/changelog/buildpacks/_posts/2024-09-09-nginx-modsecurity-coreruleset-4.6.0.md
+++ b/src/changelog/buildpacks/_posts/2024-09-09-nginx-modsecurity-coreruleset-4.6.0.md
@@ -1,0 +1,10 @@
+---
+modified_at: 2024-09-09 12:00:00
+title: 'Nginx ModSecurity CoreRuleSet up to 4.6.0'
+github.com: 'https://github.com/Scalingo/nginx-buildpack'
+---
+
+Nginx ModSecurity CoreRuleSet `4.6.0` is now available.
+
+Changelogs:
+- [CoreRuleSet 4.6.0](https://github.com/coreruleset/coreruleset/releases/tag/v4.6.0)

--- a/src/changelog/buildpacks/_posts/2024-09-09-nodejs-22.8.0.md
+++ b/src/changelog/buildpacks/_posts/2024-09-09-nodejs-22.8.0.md
@@ -1,0 +1,10 @@
+---
+modified_at: 2024-09-09 12:00:00
+title: 'Node.js - Support for version 22.8.0'
+github: 'https://github.com/Scalingo/nodejs-buildpack'
+---
+
+- Node.js `22.8.0` is now available.
+
+Changelogs:
+- [Node.js 22.8.0](https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V22.md#22.8.0)

--- a/src/changelog/buildpacks/_posts/2024-09-09-php-composer-2.7.9.md
+++ b/src/changelog/buildpacks/_posts/2024-09-09-php-composer-2.7.9.md
@@ -1,0 +1,9 @@
+---
+modified_at: 2024-09-09 12:00:00
+title: 'PHP - Release of Composer versions 2.7.9'
+github: 'https://github.com/Scalingo/php-buildpack'
+---
+
+Changelog:
+
+* [Composer 2.7.9](https://github.com/composer/composer/releases/tag/2.7.9)

--- a/src/changelog/buildpacks/_posts/2024-09-09-python-3.8.20-3.9.20-3.10.15-3.11.10-3.12.6.md
+++ b/src/changelog/buildpacks/_posts/2024-09-09-python-3.8.20-3.9.20-3.10.15-3.11.10-3.12.6.md
@@ -1,0 +1,16 @@
+---
+modified_at: 2024-09-09 12:00:00
+title: 'Python - New versions available: 3.12.6, 3.11.10, 3.10.15, 3.9.20, and 3.8.20'
+github: 'https://github.com/Scalingo/python-buildpack'
+---
+
+- Python `3.12.6`, `3.11.10`, `3.10.15`, `3.9.20` and `3.8.20` are now available
+- The new default version is `3.12.6`
+- wheel `0.44.0` is now available
+
+Changelogs:
+- [3.12.6](https://docs.python.org/3.12/whatsnew/changelog.html)
+- [3.11.10](https://docs.python.org/3.11/whatsnew/changelog.html)
+- [3.10.15](https://docs.python.org/3.10/whatsnew/changelog.html)
+- [3.9.20](https://docs.python.org/3.9/whatsnew/changelog.html)
+- [3.8.20](https://docs.python.org/3.8/whatsnew/changelog.html)


### PR DESCRIPTION
Fix https://github.com/Scalingo/php-buildpack/issues/456
Fix https://github.com/Scalingo/python-buildpack/issues/112
Fix https://github.com/Scalingo/nodejs-buildpack/issues/141
Fix https://github.com/Scalingo/nginx-buildpack/issues/61
Fix https://github.com/Scalingo/go-buildpack/issues/44

For the Composer upgrade, files have been uploaded on ObjectStorage:

- `scalingo-20`: https://semver.scalingo.com/composer-scalingo-20/resolve/2.7.x
- `scalingo-22`: https://semver.scalingo.com/composer-scalingo-22/resolve/2.7.x
- `scalingo-20-minimal`: https://semver.scalingo.com/composer-scalingo-20-minimal/resolve/2.7.x
- `scalingo-22-minimal`: https://semver.scalingo.com/composer-scalingo-22-minimal/resolve/2.7.x
