### PR TITLE
chore(php-buildpack,war): misc buildpacks updates

### DIFF
--- a/src/_posts/platform/deployment/2000-01-01-deploy-java-jar-war.md
+++ b/src/_posts/platform/deployment/2000-01-01-deploy-java-jar-war.md
@@ -1,7 +1,7 @@
 ---
 title: Deployment of JAR and WAR archives
 nav: Deploy JAR/WAR
-modified_at: 2024-08-05 12:00:00
+modified_at: 2024-09-20 12:00:00
 index: 8
 tags: deployment, java, jar, war
 ---
@@ -105,9 +105,9 @@ The latest available versions currently are:
 
 | Tomcat Version | Latest version    | Note    |
 | -------------: | ----------------: | ------- |
+| **`10.1`**     | up to `10.1.28.0` |         |
+| **`9.0`**      | up to `9.0.93.0`  | default |
 | `8.5`          | up to `8.5.68.1`  |         |
-| **`9.0`**      | up to `9.0.91.0`  | default |
-| **`10.1`**     | up to `10.1.25.0` |         |
 
 {% note %}
 Even though we still support this version, we strongly advise against using the

--- a/src/changelog/buildpacks/_posts/2024-09-20-java-tomcat-webapp-runner-9.0.93.0-10.1.28.0.md
+++ b/src/changelog/buildpacks/_posts/2024-09-20-java-tomcat-webapp-runner-9.0.93.0-10.1.28.0.md
@@ -1,0 +1,8 @@
+---
+modified_at: 2024-09-20 12:00:00
+title: 'Java - Release Webapp Runner (Tomcat) version 9.0.93.0 and 10.1.28.0'
+github: 'https://github.com/Scalingo/java-war-buildpack'
+---
+
+- Tomcat `9.0.93.0` and `10.1.28.0` are now available
+- Tomcat `9.0.93.0 ` is now the default version

--- a/src/changelog/buildpacks/_posts/2024-09-20-nginx-owasp-modsecurity-3.0.13.md
+++ b/src/changelog/buildpacks/_posts/2024-09-20-nginx-owasp-modsecurity-3.0.13.md
@@ -1,0 +1,12 @@
+---
+modified_at: 2024-09-20 12:00:00
+title: 'OWASP ModSecurity 3.0.13 is available'
+github: 'https://github.com/Scalingo/nginx-buildpack'
+---
+
+- OWASP ModSecurity `3.0.13` is now available
+- OWASP ModSecurity `3.0.13` is now the default version
+
+Changelog:
+
+* [OWASP ModSecurity 3.0.13](https://github.com/owasp-modsecurity/ModSecurity/blob/v3.0.13/CHANGES)

--- a/src/changelog/buildpacks/_posts/2024-09-20-php-mongodb-ext-1.19.4.md
+++ b/src/changelog/buildpacks/_posts/2024-09-20-php-mongodb-ext-1.19.4.md
@@ -1,0 +1,11 @@
+---
+modified_at: 2024-09-20 12:00:00
+title: 'PHP - Support of extension mongodb version 1.19.4'
+github: 'https://github.com/Scalingo/php-buildpack'
+---
+
+- Support for PHP extension `mongodb` `1.19.4`
+
+Changelog:
+
+* [MongoDB Driver 1.19.4](https://github.com/mongodb/mongo-php-driver/releases/tag/1.19.4)


### PR DESCRIPTION
- MongoDB packages have been uploaded to ObjectStorage for:
  - `scalingo-20`: PHP `7.4`, `8.0`, `8.1`, `8.2` and `8.3`
  - `scalingo-22`: PHP `8.1`, `8.2` and `8.3`.

- Java webapp-runner `9.0.93.0` and `10.1.28.0` have been uploaded to ObjectStorage.

- OWASP ModSecurity `3.0.13` packages have been uploaded to ObjectStorage for:
  - `scalingo-20`
  - `scalingo-22`

Fix https://github.com/Scalingo/php-buildpack/issues/457
Fix https://github.com/Scalingo/java-war-buildpack/issues/40
Fix https://github.com/Scalingo/nginx-buildpack/issues/63