### PR TITLE
chore(changelog): misc. buildpack updates

### DIFF
--- a/src/_posts/languages/php/2000-01-01-start.md
+++ b/src/_posts/languages/php/2000-01-01-start.md
@@ -1,7 +1,7 @@
 ---
 title: PHP on Scalingo
 nav: Introduction
-modified_at: 2024-08-30 12:00:00
+modified_at: 2024-09-30 12:00:00
 tags: php
 index: 1
 ---
@@ -39,9 +39,9 @@ The following PHP versions are available:
 
 | PHP Version | scalingo-20    | scalingo-22    |
 | ----------: | -------------: | -------------: |
-|   **`8.3`** | up to `8.3.11` | up to `8.3.11` |
-|   **`8.2`** | up to `8.2.23` | up to `8.2.23` |
-|   **`8.1`** | up to `8.1.29` | up to `8.1.29` |
+|   **`8.3`** | up to `8.3.12` | up to `8.3.12` |
+|   **`8.2`** | up to `8.2.24` | up to `8.2.24` |
+|   **`8.1`** | up to `8.1.30` | up to `8.1.30` |
 |   **`8.0`** | up to `8.0.30` |    unsupported |
 |   **`7.4`** | up to `7.4.32` |    unsupported |
 

--- a/src/_posts/languages/python/2000-01-01-start.md
+++ b/src/_posts/languages/python/2000-01-01-start.md
@@ -1,7 +1,7 @@
 ---
 title: Python
 nav: Introduction
-modified_at: 2024-09-09 12:00:00
+modified_at: 2024-10-01 12:00:00
 tags: python
 index: 1
 ---
@@ -22,7 +22,7 @@ The following versions of Python are available:
 
 | Python Version | scalingo-20     | scalingo-22     |
 | -------------: | --------------: | --------------: |
-| `3.12`         | up to `3.12.6`  | up to `3.12.6`  |
+| `3.12`         | up to `3.12.7`  | up to `3.12.7`  |
 | `3.11`         | up to `3.11.10` | up to `3.11.10` |
 | `3.10`         | up to `3.10.15` | up to `3.10.15` |
 | `3.9`          | up to `3.9.20`  | up to `3.9.20`  |

--- a/src/changelog/buildpacks/_posts/2024-09-30-java-23.0.0.md
+++ b/src/changelog/buildpacks/_posts/2024-09-30-java-23.0.0.md
@@ -1,0 +1,10 @@
+---
+modified_at: 2024-09-30 12:00:00
+title: 'Java - Support for JDK 23.0.0'
+github: 'https://github.com/Scalingo/buildpack-jvm-common'
+---
+
+- JDK version `23.0.0` is now available
+
+Changelog:
+- [JDK 23](https://openjdk.org/projects/jdk/23/)

--- a/src/changelog/buildpacks/_posts/2024-09-30-nginx-modsecurity-coreruleset-4.7.0.md
+++ b/src/changelog/buildpacks/_posts/2024-09-30-nginx-modsecurity-coreruleset-4.7.0.md
@@ -1,0 +1,10 @@
+---
+modified_at: 2024-09-30 12:00:00
+title: 'Nginx - Support for ModSecurity CoreRuleSet 4.7.0'
+github.com: 'https://github.com/Scalingo/nginx-buildpack'
+---
+
+Nginx ModSecurity CoreRuleSet `4.7.0` is now available.
+
+Changelogs:
+- [CoreRuleSet 4.7.0](https://github.com/coreruleset/coreruleset/releases/tag/v4.7.0)

--- a/src/changelog/buildpacks/_posts/2024-09-30-php-8.1.30-8.2.24-8.3.12.md
+++ b/src/changelog/buildpacks/_posts/2024-09-30-php-8.1.30-8.2.24-8.3.12.md
@@ -1,0 +1,13 @@
+---
+modified_at: 2024-09-30 12:00:00
+title: 'PHP - Support of versions 8.1.30, 8.2.24 and 8.3.12'
+github: 'https://github.com/Scalingo/php-buildpack'
+---
+
+PHP `8.1.30`, `8.2.24` and `8.3.12` are now available.
+
+Changelogs:
+
+- [PHP 8.1.30](https://www.php.net/ChangeLog-8.php#8.1.30)
+- [PHP 8.2.24](https://www.php.net/ChangeLog-8.php#8.2.24)
+- [PHP 8.3.12](https://www.php.net/ChangeLog-8.php#8.3.12)

--- a/src/changelog/buildpacks/_posts/2024-10-01-php-apcu-ext-5.1.24.md
+++ b/src/changelog/buildpacks/_posts/2024-10-01-php-apcu-ext-5.1.24.md
@@ -1,0 +1,9 @@
+---
+modified_at: 2024-10-01 12:00:00
+title: 'PHP - Support of extension `APCu` version 5.1.24'
+github: 'https://github.com/Scalingo/php-buildpack'
+---
+
+Changelog:
+
+* [APCu 5.1.24](https://github.com/krakjoe/apcu/releases/tag/v5.1.24)

--- a/src/changelog/buildpacks/_posts/2024-10-01-php-mongodb-ext-1.20.0.md
+++ b/src/changelog/buildpacks/_posts/2024-10-01-php-mongodb-ext-1.20.0.md
@@ -1,0 +1,11 @@
+---
+modified_at: 2024-10-01 12:00:00
+title: 'PHP - Support of extension mongodb version 1.20.0'
+github: 'https://github.com/Scalingo/php-buildpack'
+---
+
+- Support for PHP extension `mongodb` `1.20.0`
+
+Changelog:
+
+* [MongoDB Driver 1.20.0](https://github.com/mongodb/mongo-php-driver/releases/tag/1.20.0)

--- a/src/changelog/buildpacks/_posts/2024-10-01-python-3.12.7.md
+++ b/src/changelog/buildpacks/_posts/2024-10-01-python-3.12.7.md
@@ -1,0 +1,11 @@
+---
+modified_at: 2024-10-01 12:00:00
+title: 'Python - New version available: 3.12.7'
+github: 'https://github.com/Scalingo/python-buildpack'
+---
+
+- Python `3.12.7` is now available
+- The new default version is `3.12.7`
+
+Changelogs:
+- [3.12.7](https://docs.python.org/3.12/whatsnew/changelog.html)


### PR DESCRIPTION
STORY-933

PHP packages have been built for the following stacks:
- `scalingo-20`:
- * https://semver.scalingo.com/php-scalingo-20/resolve/~8.1
  * https://semver.scalingo.com/php-scalingo-20/resolve/~8.2
  * https://semver.scalingo.com/php-scalingo-20/resolve/~8.3
- `scalingo-22`:
  * https://semver.scalingo.com/php-scalingo-22/resolve/~8.1
  * https://semver.scalingo.com/php-scalingo-22/resolve/~8.2
  * https://semver.scalingo.com/php-scalingo-22/resolve/~8.3

MongoDB and APCu PHP ext packages have been built for:
- `scalingo-20`: PHP `7.4`, `8.0`, `8.1`, `8.2` and `8.3`
- `scalingo-22`: PHP `8.1`, `8.2` and `8.3`

Files have been uploaded to ObjectStorage.

* * *

Fix https://github.com/Scalingo/nginx-buildpack/issues/65
Fix https://github.com/Scalingo/buildpack-jvm-common/issues/50
Fix https://github.com/Scalingo/python-buildpack/issues/114
Fix https://github.com/Scalingo/php-buildpack/issues/459
Fix https://github.com/Scalingo/php-buildpack/issues/460
Fix https://github.com/Scalingo/php-buildpack/issues/461