### PR TITLE
chore(nodejs,php): changelogs

### DIFF
--- a/src/changelog/buildpacks/_posts/2024-10-07-nodejs-20.18.0.md
+++ b/src/changelog/buildpacks/_posts/2024-10-07-nodejs-20.18.0.md
@@ -1,0 +1,10 @@
+---
+modified_at: 2024-10-07 12:00:00
+title: 'Node.js - Support for version 20.18.0'
+github: 'https://github.com/Scalingo/nodejs-buildpack'
+---
+
+- Node.js `20.18.0` is now available.
+
+Changelogs:
+- [Node.js 20.18.0](https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V20.md#20.18.0)

--- a/src/changelog/buildpacks/_posts/2024-10-07-php-phpredis-ext-6.1.0.md
+++ b/src/changelog/buildpacks/_posts/2024-10-07-php-phpredis-ext-6.1.0.md
@@ -1,0 +1,9 @@
+---
+modified_at: 2024-10-07 12:00:00
+title: 'PHP - Support of extension phpredis version 6.1.0'
+github: 'https://github.com/Scalingo/php-buildpack'
+---
+
+Changelog:
+
+* [phpredis 6.1.0](https://github.com/phpredis/phpredis/blob/develop/CHANGELOG.md#610---2024-10-04-github-pecl)


### PR DESCRIPTION
phpredis packages have been generated and uploaded to ObjectStorage:

- For `scalingo-20`: PHP `7.4`, `8.0`, `8.1`, `8.2` and `8.3`
- For `scalingo-22`: PHP `8.1`, `8.2` and `8.3`

Fix https://github.com/Scalingo/php-buildpack/issues/467
Fix https://github.com/Scalingo/nodejs-buildpack/issues/145