### PR TITLE
docs(nginx): remove not implemented feature

### DIFF
--- a/src/_posts/platform/deployment/buildpacks/2000-01-01-nginx.md
+++ b/src/_posts/platform/deployment/buildpacks/2000-01-01-nginx.md
@@ -119,12 +119,3 @@ The application deployment output will look like:
 -----> Cloning custom buildpack: https://github.com/Scalingo/nginx-buildpack.git#master
 -----> Bundling NGINX 1.10.1
 ```
-
-## Multiple Configuration Files
-
-You may want to use multiple configuration files in your application. This is
-possible with the `NGINX_INCLUDES` environment variable:
-
-```bash
-scalingo --app my-app env-set NGINX_INCLUDES="./conf/nginx-1.conf ./conf/nginx-2.conf"
-```


### PR DESCRIPTION
This feature does not exist in the Nginx buildpack (https://github.com/search?q=repo%3AScalingo%2Fnginx-buildpack%20NGINX_INCLUDES&type=code). Let's remove this section.

It was added a while back (#758) but lots of things are wrong about this addition. Let's forget about this 