### PR TITLE
fix(nginx-buildpack): clean old versions

### DIFF
--- a/src/_includes/nginx_versions.md
+++ b/src/_includes/nginx_versions.md
@@ -1,15 +1,6 @@
 Scalingo supports the following versions of Nginx:
 
-| Nginx version | `scalingo-20`   | `scalingo-22`  |
-| ------------- | --------------: | -------------: |
-| `1.27`        | Up to `1.27.2`  | Up to `1.27.2` |
-| `1.26`        | Up to `1.26.2`  | Up to `1.26.2` |
-| `1.24`        | Up to `1.24.0`  | Up to `1.24.0` |
-| `1.22`        | Up to `1.22.1`  | Up to `1.22.1` |
-| `1.21`        | Up to `1.21.6`  | Up to `1.21.6` |
-| `1.20`        | Up to `1.20.2`  | Unsupported    |
-| `1.19`        | Up to `1.19.10` | Unsupported    |
-| `1.18`        | Up to `1.18.0`  | Unsupported    |
-| `1.17`        | Up to `1.17.10` | Unsupported    |
-| `1.16`        | Up to `1.16.0`  | Unsupported    |
-| `1.15`        | Up to `1.15.12` | Unsupported    |
+| Nginx version     | `scalingo-20`   | `scalingo-22`  |
+| ----------------- | --------------: | -------------: |
+| `1.27` (mainline) | Up to `1.27.2`  | Up to `1.27.2` |
+| `1.26` (stable)   | Up to `1.26.2`  | Up to `1.26.2` |


### PR DESCRIPTION
Fix #2865 