### PR TITLE
feat(postgresql): add Upgrading page for PostgreSQL

### DIFF
--- a/redirections.yml
+++ b/redirections.yml
@@ -605,6 +605,9 @@
   -
     old: "/databases/mysql/workbench"
     new: "/databases/mysql/accessing"
+  -
+    old: "/databases/postgresql/managing#upgrading"
+    new: "/databases/postgresql/upgrading"
 obsolete:
   - "/how-to-migrate-from-cloudcontrol/"
   - "/how-to-migrate-from-shelly-cloud/"

--- a/src/_posts/databases/postgresql/2000-01-01-managing.md
+++ b/src/_posts/databases/postgresql/2000-01-01-managing.md
@@ -1,7 +1,7 @@
 ---
 title: Managing Your Scalingo for PostgreSQL® Addon
 nav: Managing
-modified_at: 2024-10-21 00:00:00
+modified_at: 2024-11-27 00:00:00
 tags: databases postgresql addon
 index: 5
 ---
@@ -102,67 +102,6 @@ your data and fits your application workload.
 2. Run `terraform plan` and check if the result looks good
 3. If so, run `terraform apply`
 
-
-## Upgrading
-
-Upgrading your PostgreSQL® addon consists in changing the database version for
-a newer one.
-
-When the database vendor releases a new version of your database engine, we
-take some time to study it and test it thoroughly before making it available.
-Upgrading to this new version is still your choice. We don't do it
-automatically.
-
-{% warning %}
-Beware that no downgrade is possible once your database has been upgraded.
-{% endwarning %}
-
-Your database must be upgraded to the latest minor version before you can access the next major version. Each following major version will be suggested until you reach the latest version available on the platform.
-
-Let’s assume your database is currently on PostgreSQL® 13.5 and you want to upgrade to PostgreSQL® 15. First, upgrade your database to the latest version of the 13.x branch. Then, proceed to the latest version of the 14.x branch. Finally, upgrade to the latest version of the 15.x branch.
-
-During the upgrade, a downtime can unfortunately happen, depending on the Plan
-you are using and the upgrade:
-- **Starter Plans**: In all cases, we have to stop the node to upgrade it,
-  causing an inevitable downtime.
-- **Business Plans**: We are able to achieve zero-downtime upgrade of
-  minor version. In the case of major version upgrade, we need to completely
-  stop the nodes, hence causing an inevitable downtime.
-
-In both cases, once the operation is finished, the application is restarted.
-
-### Using the Database Dashboard
-
-1. From your web browser, [open your database dashboard]({% post_url databases/postgresql/2000-01-01-getting-started %}#accessing-the-scalingo-for-postgresql-dashboard)
-
-2. Select the **Settings** tab
-3. In the **Settings** submenu, select the **General** tab
-4. Locate the **Database Version** block
-5. If an upgrade is available, a button allows you to trigger the upgrade
-6. Click the button to launch the upgrade process
-
-{% note %}
-Upgrading a PostgreSQL® addon to a newer version is only available through the
-database dashboard.
-{% endnote %}
-
-### Details About Actions During a Major Upgrade
-
-This section details the actions executed during a major upgrade (e.g. from PostgreSQL® 14 to PostgreSQL® 15):
-
-1. The entire cluster is stopped. The database is unreachable.
-2. `pg_upgrade` is executed on the primary node. A pessimistic estimation of the duration of this operation is 1 minute per 10 GiB.
-3. The primary node is restarted. The database is reachable again. The application can normally use the database.
-4. SQL query `ANALYZE` in three stages is executed against your database to build up PostgreSQL statistics and ensure the query planner is making the right choice of indices.
-   - First stage should finish in a matter of seconds according to your data size and should allow most requests from your applications to be running at nominal performance.
-   - Second and third stages are incrementally longer but allow PostgreSQL to build up again full internal statistics about the database data and its structure, ensuring a full recovery of performance from before the upgrade.
-5. A base backup is asynchronously done to make [point-in-time recovery]({% post_url databases/postgresql/2000-01-01-backing-up %}) possible again.
-6. The follower is built from scratch, based on the primary node data (database lives in degraded replication mode until its full recovery).
-
-{% warning %}
-After a major upgrade, it is expected to have a period of reduced performance during the phasis 4, 5 and 6 as the running primary is sollicitated for these
-internal tasks. The duration depends of the quantity of stored data managed by PostgreSQL.
-{% endwarning %}
 
 ## Managing Users
 

--- a/src/_posts/databases/postgresql/2000-01-01-upgrading.md
+++ b/src/_posts/databases/postgresql/2000-01-01-upgrading.md
@@ -1,0 +1,227 @@
+---
+title: Upgrading Your Scalingo for PostgreSQL® Addon
+nav: Upgrading
+modified_at: 2024-11-27 12:00:00
+tags: databases postgresql addon
+index: 6
+---
+
+In Scalingo terminology, ***upgrading*** a Scalingo for PostgreSQL® addon
+designates the operation consisting in changing the database version for a
+newer one.
+
+We disinguish two main cases:
+- a ***minor-upgrade*** designates an incremental release with a change in the
+  tenths digit of the version number (e.g. `13.3.4` to `13.5.0`). It usually
+  provides bugs or security fixes as well as minor additional features.
+- a ***major-upgrade*** designates an incremental release with a change in the
+  main version number (e.g. `13.x.y` to `14.0.0`). Major-upgrades often provide
+  significant changes and new features that **can** break backward
+  compatibility.
+
+While we usually advise to stick to the latest minor-upgrade available to
+benefit from bug and security fixes, we also **strongly** advise to take
+extra-care when major-upgrading your Scalingo for PostgreSQL® addon ([more
+about this below](#best-practices-when-managing-major-upgrades)).
+
+When the database vendor releases a new version of your database engine, we
+take some time to study it and test it thoroughly before making it available.
+Upgrading to this new version is still your choice. We never do it
+automatically.
+
+{% warning %}
+Beware that no downgrade is possible once your database has been upgraded.
+{% endwarning %}
+
+## Understanding the Minor-Upgrade Process
+
+### Prerequisites
+
+There are no prerequisites for minor-upgrades.
+
+### Process
+
+#### For Starter Plans
+
+1. The instance is stopped. The database is unreachable.
+2. We restart the instance with the version targeted.
+3. Once the instance restarted, the database is reachable again.
+
+#### For Business Plans
+
+1. The standby instance is stopped. The primary instance is still running, so
+   the database is still reachable.
+2. We restart the standby instance with the targeted version.
+3. When the standby instance is ready, a failover is done to make it primary.
+   The old primary becomes the standby instance. During this operation, the
+   connection can be lost during a few milliseconds. The database is still
+   reachable.
+4. The new standby instance is restarted with the targeted version.
+5. Once restaretd, the cluster is fully upgraded and fully operational again.
+
+### Downtime
+
+- When using a Starter plan, we have to completely stop the node to upgrade it,
+  causing an inevitable downtime. In such a case, we usually roughly estimate
+  the overall downtime of the operation by assuming 1 minute of unavailibility
+  per 10GiB of data. This remains a rather conservative estimation and our
+  experience tends to show that it often takes less time.
+- When using a Business plan, minor-upgrades are achieved without any downtime.
+
+In all cases, the application is restarted once the operation is finished. This
+shouldn't cause any additional downtime.
+
+
+## Understanding the Major-Upgrade Process
+
+### Prerequisites
+
+To get access to the next major version, your database must first be upgraded
+to the latest minor version. Each following major version will be suggested
+until you reach the latest version available on the platform.
+
+Let’s assume your database is currently on PostgreSQL® 13.5 and you want to
+upgrade to PostgreSQL® 15. First, upgrade your database to the latest version
+of the 13.x branch. Then, proceed to the latest version of the 14.x branch.
+Finally, upgrade to the latest version of the 15.x branch.
+
+### Process
+
+#### For Starter Plans
+
+1. The node is stopped. The database is unreachable.
+2. A new primary node is booted with the targeted version.
+3. `pg_upgrade` is executed on this new node.
+4. The node is restarted. The database is reachable again and the application
+   can use it normally.
+5. The `ANALYZE` SQL command is executed against the database to build up
+   PostgreSQL® statistics. PostgreSQL® uses these statistics to determine
+   the most efficient execution plans for queries.
+6. A base backup is asynchronously done to make [point-in-time recovery]({% post_url databases/postgresql/2000-01-01-backing-up %}#understanding-point-in-time-recovery-backups)
+   available again.
+
+#### For Business Plans
+
+1. The entire cluster is stopped. The database is unreachable.
+2. A new primary node is booted with the targeted version.
+3. `pg_upgrade` is executed on this new node.
+4. The primary node is restarted. The database is reachable again and the
+   application can use it normally.
+5. The `ANALYZE` SQL command is executed against the database to build up
+   PostgreSQL® statistics. PostgreSQL® uses these statistics to determine
+   the most efficient execution plans for queries.
+6. A base backup is asynchronously done to make [point-in-time recovery]({% post_url databases/postgresql/2000-01-01-backing-up %}#understanding-point-in-time-recovery-backups)
+   available again.
+7. The standby node is rebuilt from scratch, based on the primary node data.
+   This means the database lives in a degraded state until the end of the
+   replication process.
+
+{% warning %}
+After a major-upgrade, expect a period of reduced performance during phasis 4,
+5 and 6 as the running primary is sollicitated for these internal tasks. The
+duration depends of the quantity of data stored in your Scalingo for
+PostgreSQL® addon.
+{% endwarning %}
+
+### Downtime
+
+With both Starter and Business plans, we have to completely stop the node(s) to
+upgrade them, causing an inevitable downtime.
+
+We usually roughly estimate the overall downtime of the operation by assuming
+1 minute of unavailibility per 10GiB of data. This remains a raw estimation and
+our experience tends to show that it often takes less time.
+
+In all cases, the application is restarted once the operation is finished. This
+shouldn't cause any additional downtime.
+
+### Best Practices When Managing Major-Upgrades
+
+Since major-upgrades can introduce some breaking changes, we **strongly**
+advise to take extra care when dealing with them:
+
+- First, carefully read the changelogs provided by PostgreSQL® (we usually link
+  them in our respective changelog entries). Identifying noticeable changes,
+  especially ones that may have a negative impact on your database or app, will
+  allow you to update your application accordingly.
+
+- We also generally advise to test the changes in a [Review App]({% post_url platform/app/2000-01-01-review-apps %}).
+
+  The use of Review Apps can be deactivated on your production application, [as
+  we recommend]({% post_url platform/app/2000-01-01-review-apps %}#configuration-of-review-apps)
+  in our documentation. In general, it is recommended that you carry out this
+  process on a staging application using the same code repository, but linked
+  to a database with no production or customer data. Once you have activated
+  the Review Apps feature, you can create a pull request in which you can
+  modify the `scalingo.json` manifest file to force the deployment of a
+  specific version of PostgreSQL®. The full process is as follow:
+
+  1. Create a new app dedicated to this major-upgrade.
+  2. Link this app to your application's code repository.
+  3. Make sure to enable Review Apps for this application.
+  4. Leverage the [`scalingo.json` manifest file]({% post_url platform/app/2000-01-01-app-manifest %})
+     to:
+     - Specify the version of the database addon you require. This version
+       should match the one you are using in your production environment.
+     - Ideally ask the platform to fill your database with **testing data**,
+       using a [`first-deploy` script]({% post_url platform/app/2000-01-01-app-manifest %}#deployment-hooks).
+
+     Here is an example of a manifest file asking the platform to provision a
+     PostgreSQL `14.6.0` addon and to run the `db-seed.sh` script after the
+     first deployment (the script must be included in your codebase):
+     ```json
+     {
+       "addons": [
+         {
+           "plan": "postgresql:postgresql-starter-512",
+           "options": {
+             "version": "14.6.0"
+           }
+         }
+       ],
+
+       "env": {
+         "CANONICAL_HOST_URL": {
+           "generator": "url"
+         }
+       },
+
+       "scripts": {
+         "first-deploy": "bash -c db-seed.sh"
+       }
+     }
+     ```
+  5. Create a new Pull Request from the repository hosting your application's
+     code. A new Review App is created with the appropriate database version.
+     If you have a `first-deploy` script in your `scalingo.json` manifest, it's
+     executed.
+  6. (optional): If you couldn't use a `first-deploy` script, it's now
+     time to fill your database with your test dataset.
+  7. Once filled with testing data, upgrade your database until it reaches the
+     targeted version.
+  8. Execute your tests scenarii on the Review App. This should help you
+     validate the changes, or identify the required fixes before sending them
+     to production.
+  9. Once done, close the Pull Request to automatically destroy the linked
+     Review App. You can now plan the production upgrade.
+
+- [Create a manual backup]({% post_url databases/postgresql/2000-01-01-backing-up %}#creating-a-manual-backup)
+  of your current production database just before making the move in your
+  production environment.
+
+
+## Upgrading
+
+{% note %}
+Upgrading a PostgreSQL® addon to a newer version is only available through the
+database dashboard.
+{% endnote %}
+
+### Using the Database Dashboard
+
+1. From your web browser, open your [database dashboard]({% post_url databases/postgresql/2000-01-01-getting-started %}#accessing-the-scalingo-for-postgresql-dashboard)
+2. Click the **Overview** tab
+3. Locate the **Database Upgrade** block
+4. If an upgrade is available, the text in the block explains what will be
+   done.
+5. To launch the upgrade, click the **Upgrade to …** button

--- a/src/_posts/databases/postgresql/2000-01-01-upgrading.md
+++ b/src/_posts/databases/postgresql/2000-01-01-upgrading.md
@@ -49,9 +49,10 @@ There are no prerequisites for minor-upgrades.
 4. The application is restarted to ensure proper connexions. This shouldn't
    cause any additional downtime.
 
-Since we have to completely stop the node to upgrade it, a downtime is
-inevitable. We usually roughly estimate to a few seconds (2-10 seconds),
-depending on the platform load.
+Since we have to completely stop the instance, **a downtime is inevitable**.
+
+We usually roughly estimate the downtime caused by the operation to a few
+seconds (2 to 10 seconds), depending on the platform load.
 
 #### For Business Plans
 
@@ -67,8 +68,9 @@ depending on the platform load.
 6. The application is restarted to ensure proper connexions. This shouldn't
    cause any additional downtime.
 
-When using a Business plan, minor-upgrades are achieved without any downtime,
-thanks to failover mechanism included.
+Minor-upgrades of Business plans are **usually achieved without any downtime**.
+Note that a few milliseconds downtime can still occur during the failover.
+
 
 ## Understanding the Major-Upgrade Process
 


### PR DESCRIPTION
STORY-1091
This PR creates a new page in Database/PostgreSQL describing the different upgrades and information about them. This should ease the communication with customers when we deprecate a PostgreSQL version and "force" them to upgrade.
I hope this will also be helpful for support.