### PR TITLE
chore(postgresql): specify new timscaledb in lastest PG changelog

### DIFF
--- a/src/changelog/databases/_posts/2024-12-04-postgresql-15.10.0-1.md
+++ b/src/changelog/databases/_posts/2024-12-04-postgresql-15.10.0-1.md
@@ -11,7 +11,8 @@ Changelog:
   - v13.18
 
 - Extension: `postgis` is now at version 3.5.0
-- Extension: `vector` is now at version 0.8.0 (PostgreSQL v15 only)
+- Extension: `timescaledb` is now at version  2.17.2 (from PostgreSQL v14)
+- Extension: `vector` is now at version 0.8.0 (from PostgreSQL v15)
 
 Docker images on [Docker Hub](https://hub.docker.com/r/scalingo/postgresql):
 


### PR DESCRIPTION
In reference to this slack conversation, complet the last PG changelog to specify the new TimescaleDB extension version.
https://scalingo.slack.com/archives/C01PFD3GBU7/p1733750659141439

This information is actually available on our X page and not in our documentation!