### PR TITLE
fix: MySQL Updating the Default User Password

### DIFF
--- a/src/_posts/databases/mysql/2000-01-01-managing.md
+++ b/src/_posts/databases/mysql/2000-01-01-managing.md
@@ -314,13 +314,11 @@ You will be able to view and copy it only once.
 
 ### Updating the Default User Password
 
-To change the default user password, contact [support@scalingo.com](support@scalingo.com) as this can only be done by the Scalingo team.
+To change the default user password, contact support as this can only be done by the Scalingo team.
 
 {% note %}
 The default user is created along with the addon and included in the default environment variable `SCALINGO_MYSQL_URL`.
 {% endnote %}
-
-
 
 ### Deleting an Existing User
 

--- a/src/_posts/databases/mysql/2000-01-01-managing.md
+++ b/src/_posts/databases/mysql/2000-01-01-managing.md
@@ -312,6 +312,16 @@ You will be able to view and copy it only once.
    User "my_user" created with password "YANs3y07m5_KJC2MSDGebh8tx1lliFWh2Yb239zVqGQvbElWDjIN7QWspVH92Ul8".
    ```
 
+### Updating the Default User Password
+
+To change the default user password, contact [support@scalingo.com](support@scalingo.com) as this can only be done by the Scalingo team.
+
+{% note %}
+The default user is created along with the addon and included in the default environment variable `SCALINGO_MYSQL_URL`.
+{% endnote %}
+
+
+
 ### Deleting an Existing User
 
 #### Using the Database Dashboard


### PR DESCRIPTION
A new subsection "Updating the Default User Password" in "Managing Your Scalingo for MySQL® Addon" page

Fixes #2905 