### PR TITLE
fix(cli): add missing `--app` flag for backups commands

### DIFF
--- a/src/_posts/platform/cli/2000-01-01-features.md
+++ b/src/_posts/platform/cli/2000-01-01-features.md
@@ -1,6 +1,6 @@
 ---
 title: Features
-modified_at: 2023-01-05 15:00:00
+modified_at: 2025-01-07 12:00:00
 tags: cli interface app
 index: 3
 ---
@@ -108,19 +108,19 @@ scalingo --app my-app --addon addon-uuid logs
 
 ```bash
 # List backups
-scalingo --addon addon-uuid backups
+scalingo --app my-app --addon addon-uuid backups
 
 # Download backup
-scalingo --addon addon-uuid backups-download --backup $BACKUP_ID
+scalingo --app my-app --addon addon-uuid backups-download --backup $BACKUP_ID
 
 # Download last backup
-scalingo --addon addon-uuid backups-download
+scalingo --app my-app --addon addon-uuid backups-download
 
 # Set output path
-scalingo --addon addon-uuid backups-download --output tmp
+scalingo --app my-app --addon addon-uuid backups-download --output tmp
 
 # Do not show the progress bar and loading messages
-scalingo --addon addon-uuid backups-download --silent
+scalingo --app my-app --addon addon-uuid backups-download --silent
 ```
 
 ## Read and watch the logs


### PR DESCRIPTION
Fix missing `--app my-app` flag with the `backups` command.