### PR TITLE
doc: specify Authentication database among Compass connection fields

### DIFF
--- a/src/_posts/databases/mongodb/2000-01-01-compass.md
+++ b/src/_posts/databases/mongodb/2000-01-01-compass.md
@@ -50,7 +50,7 @@ accordingly:
     scalingo-dbs.com:31312 (Hostname + Port)
 * Authentication
     * Authentication Method: Username / Password
-    * Authentication database: use the database defined by the parameter `authSource` in `SCALINGO_MONGO_URL` if present
+    * Authentication database: database name or authSource from `SCALINGO_MONGO_URL`
     * Authentication Mechanism: Default
 * TLS/SSL
     * SSL/TLS Connection: On
@@ -98,7 +98,7 @@ accordingly:
     * Direct Connection: Yes
 * Authentication
     * Authentication Method: Username / Password
-    * Authentication database: use the database defined by the parameter `authSource` in `SCALINGO_MONGO_URL` if present
+    * Authentication database: database name or authSource from `SCALINGO_MONGO_URL`
     * Authentication Mechanism: Default
 * TLS/SSL
     * SSL/TLS Connection: Default
@@ -125,7 +125,7 @@ accordingly:
     * Host: c393a9e3-42fe-4e33-9e6c-8ee815e9af88.my-app-7093.mongo.a.osc-fr1.scalingo-dbs.com:31312 (Hostname + Port)
 * Authentication
     * Authentication Method: Username / Password
-    * Authentication database: use the database defined by the parameter `authSource` in `SCALINGO_MONGO_URL` if present
+    * Authentication database: database name or authSource from `SCALINGO_MONGO_URL`
     * Authentication Mechanism: Default
 * TLS/SSL
     * SSL/TLS Connection: On

--- a/src/_posts/databases/mongodb/2000-01-01-compass.md
+++ b/src/_posts/databases/mongodb/2000-01-01-compass.md
@@ -49,7 +49,8 @@ accordingly:
     * Host: c393a9e3-42fe-4e33-9e6c-8ee815e9af88.my-app-7093.mongo.a.osc-fr1.
     scalingo-dbs.com:31312 (Hostname + Port)
 * Authentication
-    * Authentication Method: Username / Password / Authentication database
+    * Authentication Method: Username / Password
+    * Authentication database: use the database defined by the parameter `authSource` in `SCALINGO_MONGO_URL` if present
     * Authentication Mechanism: Default
 * TLS/SSL
     * SSL/TLS Connection: On
@@ -96,7 +97,8 @@ accordingly:
     * Host: 127.0.0.1:10000 (Hostname + Port)
     * Direct Connection: Yes
 * Authentication
-    * Authentication Method: Username / Password / Authentication database
+    * Authentication Method: Username / Password
+    * Authentication database: use the database defined by the parameter `authSource` in `SCALINGO_MONGO_URL` if present
     * Authentication Mechanism: Default
 * TLS/SSL
     * SSL/TLS Connection: Default
@@ -122,7 +124,8 @@ accordingly:
     * Connection String Scheme: mongodb
     * Host: c393a9e3-42fe-4e33-9e6c-8ee815e9af88.my-app-7093.mongo.a.osc-fr1.scalingo-dbs.com:31312 (Hostname + Port)
 * Authentication
-    * Authentication Method: Username / Password / Authentication database
+    * Authentication Method: Username / Password
+    * Authentication database: use the database defined by the parameter `authSource` in `SCALINGO_MONGO_URL` if present
     * Authentication Mechanism: Default
 * TLS/SSL
     * SSL/TLS Connection: On

--- a/src/_posts/databases/mongodb/2000-01-01-compass.md
+++ b/src/_posts/databases/mongodb/2000-01-01-compass.md
@@ -49,7 +49,7 @@ accordingly:
     * Host: c393a9e3-42fe-4e33-9e6c-8ee815e9af88.my-app-7093.mongo.a.osc-fr1.
     scalingo-dbs.com:31312 (Hostname + Port)
 * Authentication
-    * Authentication Method: Username / Password
+    * Authentication Method: Username / Password / Authentication database
     * Authentication Mechanism: Default
 * TLS/SSL
     * SSL/TLS Connection: On
@@ -96,7 +96,7 @@ accordingly:
     * Host: 127.0.0.1:10000 (Hostname + Port)
     * Direct Connection: Yes
 * Authentication
-    * Authentication Method: Username / Password
+    * Authentication Method: Username / Password / Authentication database
     * Authentication Mechanism: Default
 * TLS/SSL
     * SSL/TLS Connection: Default
@@ -122,7 +122,7 @@ accordingly:
     * Connection String Scheme: mongodb
     * Host: c393a9e3-42fe-4e33-9e6c-8ee815e9af88.my-app-7093.mongo.a.osc-fr1.scalingo-dbs.com:31312 (Hostname + Port)
 * Authentication
-    * Authentication Method: Username / Password
+    * Authentication Method: Username / Password / Authentication database
     * Authentication Mechanism: Default
 * TLS/SSL
     * SSL/TLS Connection: On


### PR DESCRIPTION
Within db-tunnel, the MongoDB connection configuration Compass requires the field `Authentication Database` to be filled.
As opposed to `Username` and `Password`, the field is not specified, and may takes time to guess it if you're not used 
to (like me).

![scrot-20250113-163310](https://github.com/user-attachments/assets/993ca41f-10aa-4a3b-8cc8-80737bbf4269)

Fix #2957 