### PR TITLE
Mention Linux Containers instead of Docker

### DIFF
--- a/src/_posts/platform/internals/stacks/2000-01-01-stacks.md
+++ b/src/_posts/platform/internals/stacks/2000-01-01-stacks.md
@@ -1,16 +1,13 @@
 ---
 title: Stacks
 nav: Stacks
-modified_at: 2023-06-22 00:00:00
+modified_at: 2025-01-21 00:00:00
 index: 1
 ---
 
-Applications on Scalingo are executed inside a Docker container. This base
-Docker image is maintained by Scalingo and based on a Docker image of a
-well-known Linux distribution.
+Applications on Scalingo run inside Linux containers. These containers are built on a base image maintained by Scalingo, which itself is derived from the official Docker image of a well-known Linux distribution.
 
-Scalingo currently supports two stacks based on Ubuntu. The corresponding base
-Docker images are open source and can be found on the Docker hub:
+Scalingo currently supports two stacks based on Ubuntu LTS. The corresponding base Docker images are open source and can be found on the Docker hub:
 
 <div class="overflow-horizontal-content" markdown="1">
 | Name | Base Distribution | Supported Until | Docker Hub |
@@ -27,7 +24,7 @@ all stacks.
 
 The default stack for all newly created applications is `scalingo-22`.
 
-These base Docker images are used for all applications hosted on the
+These base images are used for all applications hosted on the
 platform, as a result, it is a *generic image* which is *unspecialized*.
 That's why they are based on a stable **Ubuntu LTS** environment.
 
@@ -39,10 +36,10 @@ post_url platform/cli/2000-01-01-start %}):
 ```shell
 scalingo --app my-app apps-info
 +----------------+-------------+
-|    SETTINGS    |    VALUE    |
+|	SETTINGS	|	VALUE	|
 +----------------+-------------+
 [...]
-| Stack          | scalingo-22 |
+| Stack      	| scalingo-22 |
 [...]
 +----------------+-------------+
 ```
@@ -70,8 +67,8 @@ scalingo stacks
 ```
 
 It is advisable to first test this change on a staging application. You may
-already have such staging application hosted on Scaling. In such situation, the
-above-mentioned migration steps can be applied on it.
+already have such staging application hosted on Scalingo. In such situation, the
+above-mentioned migration steps can be applied to it.
 
 Otherwise, a nice solution to test the stack upgrade without affecting your
 currently running application is to create a [review app]({% post_url
@@ -90,10 +87,10 @@ with the method described above.
 
 ## The Build Process
 
-Each time any user deploys a new release of their applications, a new Docker
+Each time any user deploys a new release of their applications, a new container
 image is created. A new layer is added on top of the base
 image. It's built using the buildpack and contains the application code and all
-its dependencies. When the build is done, the resulting Docker image is sent to
+its dependencies. When the build is done, the resulting image is sent to
 our private repository and our orchestrator will use it subsequently to actually
 run the application in our infrastructure.
 
@@ -112,7 +109,7 @@ You'll find:
 * Node.js, Ruby, Perl, Python, Java
 * ImageMagick
 
-The advantage of using a single base Docker image is that **once it has been
+The advantage of using a single base image is that **once it has been
 fetched on a hosting node, we're done**. Even if we sacrifice a few megabytes
 of disk space, when a new container starts, only the application layer is
 fetched and nothing else.

--- a/src/_posts/platform/internals/stacks/2000-01-01-stacks.md
+++ b/src/_posts/platform/internals/stacks/2000-01-01-stacks.md
@@ -36,10 +36,10 @@ post_url platform/cli/2000-01-01-start %}):
 ```shell
 scalingo --app my-app apps-info
 +----------------+-------------+
-|	SETTINGS	|	VALUE	|
+|    SETTINGS    |    VALUE    |
 +----------------+-------------+
 [...]
-| Stack      	| scalingo-22 |
+| Stack          | scalingo-22 |
 [...]
 +----------------+-------------+
 ```


### PR DESCRIPTION
Replace references to Docker with more generic references to Linux containers.