### PR TITLE
chore: release of Node.js 18.20.1, 20.18.2, 22.13.1 and 23.6.1

### DIFF
--- a/src/changelog/buildpacks/_posts/2025-01-23-nodejs-18.20.6-20.18.2-22.13.1-23.6.1.md
+++ b/src/changelog/buildpacks/_posts/2025-01-23-nodejs-18.20.6-20.18.2-22.13.1-23.6.1.md
@@ -1,0 +1,13 @@
+---
+modified_at: 2025-01-23 12:00:00
+title: 'Node.js - Support for versions 18.20.6, 20.18.2, 22.13.1 and 23.6.1'
+github: 'https://github.com/Scalingo/nodejs-buildpack'
+---
+
+- Node.js `18.20.6`, `20.18.2`, `22.13.1` and `23.6.1` are now available.
+
+Changelogs:
+- [Node.js 18.20.6](https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V18.md#18.20.6)
+- [Node.js 20.18.2](https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V20.md#20.18.2)
+- [Node.js 22.13.1](https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V22.md#22.13.1)
+- [Node.js 23.6.1](https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V23.md#23.6.1)


### PR DESCRIPTION
Fix https://github.com/Scalingo/nodejs-buildpack/issues/164