### PR TITLE
Improve documentation for Django

### DIFF
--- a/src/_posts/languages/python/django/2000-01-01-start.md
+++ b/src/_posts/languages/python/django/2000-01-01-start.md
@@ -310,27 +310,6 @@ the deployment).
   More information in [postdeploy hook section]({% post_url platform/app/2000-01-01-postdeploy-hook %})
 {% endnote %}
 
-### Collect static
-
-Previous hook is not good for collect static because the script is
-run in a one-off which is a copy of the final container. Therefore all
-files manipulation would be available only on the one-off and not
-in the actual container which will serve web request.
-
-To trigger script on the actual container, you will need to use
-post-compile hook.
-
-Add a file `bin/post_compile` with (note the missing .sh extension!):
-
-```bash
-#!/bin/sh
-
-export PYTHONPATH=/build/${REQUEST_ID}/.apt/usr/lib/python3/dist-packages/:${PYTHONPATH}
-
-# collect static
-python manage.py collectstatic --noinput
-```
-
 
 ### Compile `.mo` Message Translation File
 

--- a/src/_posts/languages/python/django/2000-01-01-start.md
+++ b/src/_posts/languages/python/django/2000-01-01-start.md
@@ -1,7 +1,7 @@
 ---
 title: Get Started with Django on Scalingo
 nav: Get Started
-modified_at: 2024-08-22 00:00:00
+modified_at: 2025-01-30 00:00:00
 tags: python django tutorial getting-started-tutorial
 index: 1
 ---

--- a/src/_posts/languages/python/django/2000-01-01-start.md
+++ b/src/_posts/languages/python/django/2000-01-01-start.md
@@ -189,6 +189,10 @@ ensure bug free migrations.
 
 ### Static File Serving
 
+You can rely on [the `whitenoise` package](https://pypi.org/project/whitenoise/) to serve your Django static files.
+
+From [the whitenoise docs](https://whitenoise.readthedocs.io/en/stable/#quickstart-for-django-apps):
+
 In your settings configuration file `myapp/settings.py`:
 
 ```python
@@ -198,25 +202,21 @@ STATIC_URL = '/static/'
 STATICFILES_DIRS = (
     os.path.join(BASE_DIR, 'static'),
 )
+
+MIDDLEWARE = [
+    # ...
+    "django.middleware.security.SecurityMiddleware",
+    "whitenoise.middleware.WhiteNoiseMiddleware",
+    # ...
+]
+
+STORAGES = {
+    # ...
+    "staticfiles": {
+        "BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage",
+    },
+}
 ```
-
-In the `myapp/wsgi.py` file, replace
-
-```python
-from django.core.wsgi import get_wsgi_application
-application = get_wsgi_application()
-```
-
-With
-
-```python
-from django.core.wsgi import get_wsgi_application
-from dj_static import Cling
-
-application = Cling(get_wsgi_application())
-```
-
-`Cling` is part of the `dj_static` module and is designed to serve static files.
 
 If you don't need to serve static files, you can setup the following
 environment variable:


### PR DESCRIPTION
Hi there :wave: 

This week it was the first time I deployed a Django app to Scalingo. It works really well! I spotted some quirks in the documentation so here is a PR that fixes them:

- There is a useless section about the `collectstatic` command; maybe the Python buildpack has started handling that part quite recently and the docs hasn't been updated, but clearly now it's useless
- The serving of static files is recommended through `dj-static`, a Django app that's completely unmaintained for a long time; so I replaced it with whitenoise, the new standard on that matter