### PR TITLE
chore(java): JDK 1.8.0_442, 11.0.26, 17.0.14, 21.0.6 and 23.0.2

### DIFF
--- a/src/_posts/languages/java/2000-01-01-start.md
+++ b/src/_posts/languages/java/2000-01-01-start.md
@@ -1,7 +1,7 @@
 ---
 title: Java on Scalingo
 nav: Introduction
-modified_at: 2024-10-23 12:00:00
+modified_at: 2025-02-05 12:00:00
 tags: java
 index: 1
 ---
@@ -16,11 +16,11 @@ The following Java versions are available:
 
 | Java SE Version | scalingo-20       | scalingo-22       |
 | --------------: | ----------------: | ----------------: |
-| **`23`**        | up to `23.0.1`    | up to `23.0.1`    |
-| **`21 (LTS)`**  | up to `21.0.5`    | up to `21.0.5`    |
-| **`17 (LTS)`**  | up to `17.0.13`   | up to `17.0.13`   |
-| **`11 (LTS)`**  | up to `11.0.25`   | up to `11.0.24`   |
-| **`8 (LTS)`**   | up to `1.8.0_432` | up to `1.8.0_432` |
+| **`23`**        | up to `23.0.2`    | up to `23.0.2`    |
+| **`21 (LTS)`**  | up to `21.0.6`    | up to `21.0.6`    |
+| **`17 (LTS)`**  | up to `17.0.14`   | up to `17.0.14`   |
+| **`11 (LTS)`**  | up to `11.0.26`   | up to `11.0.25`   |
+| **`8 (LTS)`**   | up to `1.8.0_442` | up to `1.8.0_442` |
 
 For Java SE 8, the JDK version is numbered `1.8`.
 

--- a/src/changelog/buildpacks/_posts/2025-02-05-java-23.0.2-21.0.6-17.0.14-11.0.26-8.0_442.md
+++ b/src/changelog/buildpacks/_posts/2025-02-05-java-23.0.2-21.0.6-17.0.14-11.0.26-8.0_442.md
@@ -1,0 +1,12 @@
+---
+modified_at: 2025-02-05 12:00:00
+title: 'Java - Support for JDK 1.8.0_442, 11.0.26, 17.0.14, 21.0.6 and 23.0.2'
+github: 'https://github.com/Scalingo/buildpack-jvm-common'
+---
+
+The following JDK versions are now available:
+- up to 1.8.0_442 (LTS)
+- up to 11.0.26 (LTS)
+- up to 17.0.14 (LTS)
+- up to 21.0.6 (LTS)
+- up to 23.0.2


### PR DESCRIPTION
Fix https://github.com/Scalingo/buildpack-jvm-common/issues/56