### PR TITLE
[STORY-1326] fix(css): fix table view on mobile

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -17,6 +17,17 @@
   margin-top: -75px;
 }
 
+
+/* Fix table on mobile */
+@media screen and (max-width: 768px) {
+  table {
+    display: block !important;
+    max-width: 95vw !important;
+    overflow-x: auto !important;
+    white-space: nowrap !important;
+  }
+}
+
 article h2 {
   @apply text-sc-gray-1 text-sc-title-2 font-bold mb-4 mt-6;
 }


### PR DESCRIPTION
Fix table view on mobile without using 
`<div class="overflow-horizontal-content" markdown="1">`