### PR TITLE
chore(ruby-buildpack): defaults to Ruby 3.3.7

### DIFF
--- a/src/_posts/languages/ruby/2000-01-01-start.md
+++ b/src/_posts/languages/ruby/2000-01-01-start.md
@@ -1,7 +1,7 @@
 ---
 title: Ruby
 nav: Introduction
-modified_at: 2025-02-17 12:00:00
+modified_at: 2025-03-20 12:00:00
 tags: ruby
 index: 1
 ---
@@ -91,11 +91,11 @@ $ git push scalingo master
 ### Select a Version
 
 The default Ruby version on both `scalingo-20` and `scalingo-22` is the latest
-**`3.1`** version. If you need to install another version, specify it in your
-`Gemfile`, using the `ruby` keyword. For example, to install Ruby `3.3.0`:
+**`3.3`** version. If you need to install another version, specify it in your
+`Gemfile`, using the `ruby` keyword. For example, to install Ruby `3.4.2`:
 
 ```ruby
-ruby "3.3.0"
+ruby "3.4.2"
 ```
 
 

--- a/src/changelog/buildpacks/_posts/2025-03-20-ruby-3.3.7.md
+++ b/src/changelog/buildpacks/_posts/2025-03-20-ruby-3.3.7.md
@@ -1,0 +1,9 @@
+---
+modified_at: 2025-03-20 12:00:00
+title: 'Ruby - Version 3.3.7 is the new default'
+github: 'https://github.com/Scalingo/ruby-buildpack'
+---
+
+- Ruby `3.3.7` is now the default version.
+- Bundler `2.3.x` is now the default version (when no version present in the
+  `Gemfile.lock`).


### PR DESCRIPTION
Fix https://github.com/Scalingo/ruby-buildpack/issues/100