### PR TITLE
feat: mention that the buildpack is used when a poetry project is detected

### DIFF
--- a/src/_posts/languages/python/2000-01-01-start.md
+++ b/src/_posts/languages/python/2000-01-01-start.md
@@ -11,7 +11,7 @@ The Python language is officially supported on the platform.
 ## Detection
 
 To ensure our deployment system considers your application as a Python
-application, a file `Pipfile`, `requirements.txt` or `setup.py` should be
+application, a file `Pipfile`, `requirements.txt`, `setup.py` or `poetry.lock` should be
 present at the root of your project, defining the dependencies of your app.
 
 ## Python Versions


### PR DESCRIPTION
As mentionned in the python-buildpack README, a poetry.lock can also trigger the usage of this buildpack: https://github.com/Scalingo/python-buildpack?tab=readme-ov-file#application-requirements