### PR TITLE
fix: newline syntax

### DIFF
--- a/src/_posts/databases/about/2000-01-01-backup-policies.md
+++ b/src/_posts/databases/about/2000-01-01-backup-policies.md
@@ -9,7 +9,7 @@ index: 30
 
 {% warning %}
 The backup features described in this page are only available for Starter and
-Business plans.\
+Business plans.\\
 They are **not** available for Sandbox plans.
 {% endwarning %}
 


### PR DESCRIPTION
Kramdown states that:
"If you want to have an explicit line break (i.e. a `<br />` tag) you need to end a line with two or more spaces or two backslashes!"

This indeed fixes the newline issue.

(Related to https://github.com/Scalingo/documentation/pull/3241)