### PR TITLE
[STORY-2326] Create project releases

### DIFF
--- a/src/changelog/cli/_posts/2025-08-08-1.37.0.md
+++ b/src/changelog/cli/_posts/2025-08-08-1.37.0.md
@@ -1,5 +1,5 @@
 ---
-modified_at: 2025-08-01 00:00:00
+modified_at: 2025-08-08 00:00:00
 title: 'CLI - New versions: 1.37.0'
 github: 'https://github.com/Scalingo/cli/releases'
 ---

--- a/src/changelog/sdk/_posts/2025-08-08-go-scalingo-v8.4.0.md
+++ b/src/changelog/sdk/_posts/2025-08-08-go-scalingo-v8.4.0.md
@@ -1,5 +1,5 @@
 ---
-modified_at:	2025-08-01 12:00:00
+modified_at:	2025-08-08 12:00:00
 title:	'go-scalingo - New version: 8.4.0'
 github: 'https://github.com/Scalingo/go-scalingo'
 ---

--- a/src/changelog/tools/_posts/2025-08-11-terraform-provider-scalingo-2.5.0.md
+++ b/src/changelog/tools/_posts/2025-08-11-terraform-provider-scalingo-2.5.0.md
@@ -1,5 +1,5 @@
 ---
-modified_at: 2025-08-02 12:00:00
+modified_at: 2025-08-11 00:00:00
 title: 'Release of v2.5.0 for Scalingo Terraform Provider'
 ---
 


### PR DESCRIPTION
This PR updates several things:

- A new release of go-scalingo
- A new release of the CLI
- A new release for the Terraform provider

The update of the documentation itself will be done in another branch (probably `feat/STORY-2130/update-doc-about-projects-management` started by @stplec).