### PR TITLE
Fix: ElasticSearch tutorial

### DIFF
--- a/src/_posts/platform/getting-started/2000-01-01-getting-started-with-elk.md
+++ b/src/_posts/platform/getting-started/2000-01-01-getting-started-with-elk.md
@@ -1,6 +1,6 @@
 ---
 title: Getting started with the ELK Stack on Scalingo
-modified_at: 2025-01-27 00:00:00
+modified_at: 2025-08-05 00:00:00
 tags: elk tutorial logstash elasticsearch kibana log
 index: 11
 ---
@@ -42,6 +42,7 @@ To get started, you can use [our boilerplate](https://github.com/Scalingo/logsta
 
 ```bash
 $ git clone https://github.com/Scalingo/logstash-boilerplate
+$ git checkout es7-compat
 $ cd logstash-boilerplate
 ```
 

--- a/src/_posts/platform/getting-started/2000-01-01-getting-started-with-elk.md
+++ b/src/_posts/platform/getting-started/2000-01-01-getting-started-with-elk.md
@@ -41,9 +41,9 @@ database. This is the *EL* part in *ELK*.
 To get started, you can use [our boilerplate](https://github.com/Scalingo/logstash-boilerplate):
 
 ```bash
-$ git clone https://github.com/Scalingo/logstash-boilerplate
-$ git checkout es7-compat
-$ cd logstash-boilerplate
+git clone https://github.com/Scalingo/logstash-boilerplate
+cd logstash-boilerplate
+git checkout es7-compat
 ```
 
 Next, create an application on Scalingo that will run our Logstash app:


### PR DESCRIPTION
This PR fixes the Getting Started tutorial for ELK and adds the command to check out the correct branch.