### PR TITLE
Fix latest CLI changelog

### DIFF
--- a/src/changelog/cli/_posts/2025-08-20-1.38.0.md
+++ b/src/changelog/cli/_posts/2025-08-20-1.38.0.md
@@ -11,7 +11,7 @@ github: 'https://github.com/Scalingo/cli/releases'
 ### Changelog
 
 {% warning %}
-    /!\ This change requires the [command completion](https://doc.scalingo.com/tools/cli/start#command-completion) to be re-run.
+This change requires the [command completion](https://doc.scalingo.com/tools/cli/start#command-completion) to be re-run.
 {% endwarning %}
 
 * chore(deps): update urfave/cli from v2 to v3


### PR DESCRIPTION
The formatting was a bit broken when compiling the documentation. It appeared in a block of code and not as a proper warning.