### PR TITLE
Update Betterstack log-drain documentation

### DIFF
--- a/src/_posts/platform/app/2000-01-01-log-drain.md
+++ b/src/_posts/platform/app/2000-01-01-log-drain.md
@@ -80,10 +80,11 @@ This variable is available on
 
 #### Better Stack Logs
 ```bash
-scalingo --app my-app log-drains-add --type logtail \
-  --token 123456789abcdef
+scalingo --app my-app log-drains-add --type betterstack \
+  --host *.betterstackdata.com --token 123456789abcdef
 ```
 Parameters:
+* `host`: Better Stack ingesting host
 * `token`: Better Stack Logs's Bearer Token
 
 This variable is available on


### PR DESCRIPTION
For a full betterstack support, the host is also required on top of the token.

WIth https://github.com/Scalingo/logs-service/issues/540.