### PR TITLE
Improve ruby documentation

### DIFF
--- a/src/_posts/languages/ruby/2000-01-01-start.md
+++ b/src/_posts/languages/ruby/2000-01-01-start.md
@@ -142,7 +142,7 @@ The configuration file looks like the following:
 
 ```ruby
 workers Integer(ENV['WEB_CONCURRENCY'] || 2)
-threads_count = Integer(ENV['MAX_THREADS'] || 5)
+threads_count = Integer(ENV['MAX_THREADS'] || 3)
 threads threads_count, threads_count
 
 preload_app!
@@ -157,16 +157,15 @@ on_worker_boot do
 end
 ```
 
-Thus you can change the global settings by modifying the environment
-variables `WEB_CONCURRENCY` and `MAX_THREADS` and restarting your app.
+With these settings, you can change the number of web workers and threads by defining 
+the `WEB_CONCURRENCY` and `MAX_THREADS` environment variables and restarting your app.
 
-## WEB_CONCURRENCY
+### WEB_CONCURRENCY
 
-The level of concurrency configured is defined automatically according to the
-memory of the containers of your application. If you want to override this value,
-you can define the environment variable: `WEB_CONCURRENCY`.
-
-The default values are:
+The recommended level of concurrency for the web server is defined automatically according 
+to the available memory of the containers of your application. If you want to override 
+this value, you can define the environment variable: `WEB_CONCURRENCY`.
+If you do not define this variable, the buildpack will set its value according to this table:
 
 | Container Memory (MB) | Default Concurrency |
 |-----------------------|---------------------|


### PR DESCRIPTION
- Update fallback value for MAX_THREADS (Rails now recommends 3 instead of 5)
- Clarify that MAX_THREADS is not automatically set, but WEB_CONCURRENCY is, and how to override it.