### PR TITLE
Add container size alongside memory in WEB_CONCURRENCY table

### DIFF
--- a/src/_posts/languages/ruby/2000-01-01-start.md
+++ b/src/_posts/languages/ruby/2000-01-01-start.md
@@ -167,12 +167,12 @@ to the available memory of the containers of your application. If you want to ov
 this value, you can define the environment variable: `WEB_CONCURRENCY`.
 If you do not define this variable, the buildpack will set its value according to this table:
 
-| Container Memory (MB) | Default Concurrency |
-|-----------------------|---------------------|
-| 256                   | 1                   |
-| 512                   | 1                   |
-| 1024                  | 2                   |
-| 2048                  | 2                   |
-| 4096                  | 4                   |
-| 8192                  | 4                   |
+| Container Size | Container Memory (MB) | Default Concurrency |
+|----------------|-----------------------|---------------------|
+| S              | 256                   | 1                   |
+| M              | 512                   | 1                   |
+| L              | 1024                  | 2                   |
+| XL             | 2048                  | 2                   |
+| 2XL            | 4096                  | 4                   |
+| ?              | 8192                  | 4                   |
 


### PR DESCRIPTION
Because the metrics dashboard shows the container size and more than the available RAM (to account for swap used).