### PR TITLE
Update doc for new OpenSearch version 2.19.3-1

### DIFF
--- a/src/_posts/databases/opensearch/about/2000-01-01-overview.md
+++ b/src/_posts/databases/opensearch/about/2000-01-01-overview.md
@@ -1,7 +1,7 @@
 ---
 title: Overview
 nav: Overview
-modified_at: 2025-06-02 12:00:00
+modified_at: 2025-09-05 12:00:00
 tags: database opensearch addon
 index: 1
 ---
@@ -48,10 +48,10 @@ bug fixes and security patches.
 
 | OpenSearch Version | Full Version   |
 | -----------------: | -------------: |
-| **`2`**            | up to `2.19.1` |
+| **`2`**            | up to `2.19.3` |
 
 The default version when provisioning a Scalingo for OpenSearch® addon is
-**`2.19.1-7`**.
+**`2.19.3-1`**.
 
 {% note %}
 If you need to provision a Scalingo for OpenSearch® addon with a specific

--- a/src/_posts/databases/opensearch/getting-started/2000-01-01-accessing.md
+++ b/src/_posts/databases/opensearch/getting-started/2000-01-01-accessing.md
@@ -1,7 +1,7 @@
 ---
 title: Accessing Your Scalingo for OpenSearch® Addon
 nav: Accessing
-modified_at: 2025-06-10 12:00:00
+modified_at: 2025-09-05 12:00:00
 tags: databases opensearch addon
 index: 3
 ---
@@ -45,12 +45,12 @@ Instead, any tool speaking HTTP can be used to interact with the database:
      "cluster_uuid" : "F22ZsuhSTp6boW-HlMWuqB",
      "version" : {
        "distribution" : "opensearch",
-       "number" : "2.19.1",
+       "number" : "2.19.3",
        "build_type" : "tar",
-       "build_hash" : "2e4741fb45d1b150aaeeadf66d41445b23ff5982",
-       "build_date" : "2025-02-27T01:16:47.726162386Z",
+       "build_hash" : "a90f864b8524bc75570a8461ccb569d2a4bfed42",
+       "build_date" : "2025-07-21T22:34:18.003652598Z",
        "build_snapshot" : false,
-       "lucene_version" : "9.12.1",
+       "lucene_version" : "9.12.2",
        "minimum_wire_compatibility_version" : "7.10.0",
        "minimum_index_compatibility_version" : "7.0.0"
      },

--- a/src/changelog/databases/_posts/2025-09-05-opensearch-2.19.3-1.md
+++ b/src/changelog/databases/_posts/2025-09-05-opensearch-2.19.3-1.md
@@ -1,0 +1,12 @@
+---
+modified_at: 2024-09-05 00:00:00
+title: 'OpenSearch - New Scalingo release: 2.19.3-1'
+---
+
+New default version: **2.19.3-1**.
+
+Changelog:
+
+Docker images on [Docker Hub](https://hub.docker.com/r/scalingo/opensearch):
+
+* `scalingo/opensearch:2.19.3-1`


### PR DESCRIPTION
!! NO MERGE BEFORE OPENSEARCH VERSION 2.19.3 BUMP IN APPSDECK-DATABASE !!

Fix [#3624](https://github.com/Scalingo/appsdeck-database/issues/3624)