### PR TITLE
Create latest releases for CLI, go-scalingo and terraform-provider-scalingo

### DIFF
--- a/src/changelog/cli/_posts/2025-09-11-1.39.0.md
+++ b/src/changelog/cli/_posts/2025-09-11-1.39.0.md
@@ -1,0 +1,17 @@
+---
+modified_at: 2025-09-11 15:00:00
+title: 'CLI - New versions: 1.39.0'
+github: 'https://github.com/Scalingo/cli/releases'
+---
+
+### Installation
+
+[https://cli.scalingo.com](https://cli.scalingo.com)
+
+### Changelog
+
+* task(backups-config): update error message when unscheduling periodic backup
+* feat(backups): prevent download of OpenSearch and Elasticsearch backups
+* feat(domains): add 'Manual Action' column if needed
+
+**Full Changelog**: https://github.com/Scalingo/cli/compare/1.37.0...1.38.0

--- a/src/changelog/cli/_posts/2025-09-24-1.40.0.md
+++ b/src/changelog/cli/_posts/2025-09-24-1.40.0.md
@@ -1,0 +1,18 @@
+---
+modified_at: 2025-09-24 15:00:00
+title: 'CLI - New versions: 1.40.0'
+github: 'https://github.com/Scalingo/cli/releases'
+---
+
+### Installation
+
+[https://cli.scalingo.com](https://cli.scalingo.com)
+
+### Changelog
+
+Some features listed in this changelog, like private networks, are currently only available to selected users.
+
+* feat(apps): create `project-set` command for applications
+* feat(private-networks): add command to list private network domain names
+
+**Full Changelog**: https://github.com/Scalingo/cli/compare/1.37.0...1.38.0

--- a/src/changelog/sdk/_posts/2025-09-23-go-scalingo-v8.6.0.md
+++ b/src/changelog/sdk/_posts/2025-09-23-go-scalingo-v8.6.0.md
@@ -6,4 +6,6 @@ github: 'https://github.com/Scalingo/go-scalingo'
 
 ### Changelog
 
+Some features listed in this changelog, like private networks, are currently only available to selected users.
+
 * feat(private-networks): add private_networks service and method to list application private network domain names

--- a/src/changelog/sdk/_posts/2025-09-24-go-scalingo-v8.7.0.md
+++ b/src/changelog/sdk/_posts/2025-09-24-go-scalingo-v8.7.0.md
@@ -1,0 +1,9 @@
+---
+modified_at:	2025-09-24 15:15:00
+title:	'go-scalingo - New version: 8.7.0'
+github: 'https://github.com/Scalingo/go-scalingo'
+---
+
+### Changelog
+
+* feat(applications): create a new method to set the project

--- a/src/changelog/tools/_posts/2025-09-24-terraform-provider-scalingo-2.6.0.md
+++ b/src/changelog/tools/_posts/2025-09-24-terraform-provider-scalingo-2.6.0.md
@@ -1,0 +1,8 @@
+---
+modified_at: 2025-09-24 00:00:00
+title: 'Release of v2.6.0 for Scalingo Terraform Provider'
+---
+
+### Changelog
+
+* resource(scaling_app): handle project ID update


### PR DESCRIPTION
I also created the 1.39 release not for the CLI, which was missing.