### PR TITLE
chore(java-war-buildpack): webapp-runner 9.0.109.0 and 10.1.46.0

### DIFF
--- a/src/_posts/platform/deployment/2000-01-01-deploy-java-jar-war.md
+++ b/src/_posts/platform/deployment/2000-01-01-deploy-java-jar-war.md
@@ -1,7 +1,7 @@
 ---
 title: Deployment of JAR and WAR archives
 nav: Deploy JAR/WAR
-modified_at: 2025-09-15 00:00:00
+modified_at: 2025-10-02 00:00:00
 index: 8
 tags: deployment, java, jar, war
 ---
@@ -105,8 +105,8 @@ The latest available versions currently are:
 
 | Tomcat Version | `scalingo-20` (EOL) | `scalingo-22`       | `scalingo-24`       |
 | -------------: | ------------------: | ------------------: | ------------------: |
-| **`10.1`**     | up to `10.1.44.0`   | up to `10.1.44.0`   | up to `10.1.44.0`   |
-| **`9.0`**      | up to `9.0.108.0`   | up to `9.0.108.0`   | up to `9.0.108.0`   |
+| **`10.1`**     | up to `10.1.46.0`   | up to `10.1.46.0`   | up to `10.1.46.0`   |
+| **`9.0`**      | up to `9.0.108.0`   | up to `9.0.109.0`   | up to `9.0.109.0`   |
 | `8.5`          | up to `8.5.68.1`    | up to `8.5.68.1`    | up to `8.5.68.1`    |
 
 The default Tomcat version on all stacks is the latest `9.0` version.

--- a/src/changelog/buildpacks/_posts/2025-10-02-java-tomcat-webapp-runner-9.0.109.0-10.1.46.0.md
+++ b/src/changelog/buildpacks/_posts/2025-10-02-java-tomcat-webapp-runner-9.0.109.0-10.1.46.0.md
@@ -1,0 +1,9 @@
+---
+modified_at: 2025-10-02 12:00:00
+title: 'Java - Webapp Runner (Tomcat) 9.0.109.0 and 10.1.46.0 are now available'
+github: 'https://github.com/Scalingo/java-war-buildpack'
+---
+
+Tomcat `9.0.109.0` and `10.1.46.0` are now available.
+
+Tomcat `9.0.109.0 ` is now the default version.


### PR DESCRIPTION
Related to https://github.com/Scalingo/java-war-buildpack/issues/59