### PR TITLE
[SECINC-125] SSB-2025-001

### DIFF
--- a/src/_posts/security/bulletins/2025-10-07-SSB-2025-001.md
+++ b/src/_posts/security/bulletins/2025-10-07-SSB-2025-001.md
@@ -8,13 +8,22 @@ cvss:
   base: 7.4
 ---
 
+A major vulnerability ([CVE-2025-49844](https://redis.io/blog/security-advisory-cve-2025-49844/)) has been reported in Redis, a widely used in-memory data structure store, deployed on our Database-as-a-Service (DBaaS) platform.
+
 The vulnerability allows an authenticated user to exploit a use-after-free memory corruption bug within Redis’s embedded Lua interpreter.
 A specially crafted Lua script can escape the Lua sandbox and execute arbitrary code on the Redis host.
-The vulnerability was originally evaluated with a CVSS v4.0 base score of 10 but Scalingo re-evaluated it to 7.4 due to required authentication and Scalingo's security controls.
+The vulnerability was originally evaluated with a CVSS v4.0 base score of 10.0, but Scalingo re-evaluated it to 7.4 due to required authentication and Scalingo's security controls.
+
+{% note %}
+Your data hosted on Scalingo is not at risk of being accessed or compromised through this vulnerability.
+
+Your databases will be automatically upgraded to patched versions over the next 3 weeks.
+{% endnote %}
 
 ## Incident analysis
 
 Disclosed by Redis, the vulnerability (nicknamed RediShell) affects all Redis versions supporting Lua scripting since its introduction over 13 years ago.
+
 Redis assigned it the identifier CVE-2025-49844 and published patched versions on October 3, 2025.
 
 The following versions are affected by this vulnerability:
@@ -22,10 +31,10 @@ The following versions are affected by this vulnerability:
 - All versions prior to 6.2.20
 - Versions 7.0.0 through 7.2.10
 
-**Note**: Redis versions 7.4+ use a different license (RSALv2 + SSPLv1) that prevents Scalingo from distributing them. Scalingo's managed Redis service remains on the Redis 7.2 branch.
-
 While the issue technically enables remote code execution, exploitation requires authenticated access and the ability to execute Lua scripts.
 Therefore, the practical risk depends on configuration and exposure: internet-exposed or unauthenticated Redis instances are at highest risk.
+
+**Note**: Redis versions 7.4+ use a different license (RSALv2 + SSPLv1) that prevents Scalingo from distributing them. Scalingo's managed Redis service remains on the Redis 7.2 branch.
 
 ### Remediation: what we did
 
@@ -37,8 +46,7 @@ Scalingo took the following actions after Redis's disclosure:
 
 - Made the patched versions available for:
 
-  - All newly provisioned Redis databases, and
-
+  - All newly provisioned Redis databases
   - Manual upgrade by customers via the Scalingo Dashboard or CLI.
 
 - Scheduled automatic upgrades for all customer Redis databases over the next 3 weeks. (For all databases running v6 and v7, they'll be updated in less than a week):
@@ -56,7 +64,6 @@ Redis databases on Scalingo are:
 - Always executed in isolated Linux containers;
 
 - Protected by strong, randomly generated passwords;
-
 - Not exposed to the internet unless explicitly configured by the user.
 
 Because the exploit requires authenticated access, the likelihood of exploitation on Scalingo is very low.
@@ -86,7 +93,7 @@ Scalingo continues to monitor upstream Redis channels and our telemetry for pote
 No immediate action required for customers using managed Redis add-ons.
 Automatic upgrades to patched versions are scheduled over the next 3 weeks to ensure all instances are protected.
 
-Ensure that internet access for your Redis instances is only enabled if absolutely necessary.
+Ensure that internet access for your Redis instances is only enabled if absolutely necessary. This feature is disabled by default and can ben controlled via the Scalingo Dashboard or CLI.
 
 ## What we will do in the future
 

--- a/src/_posts/security/bulletins/2025-10-07-SSB-2025-001.md
+++ b/src/_posts/security/bulletins/2025-10-07-SSB-2025-001.md
@@ -55,8 +55,6 @@ Scalingo took the following actions after Redis's disclosure:
   - Redis 6 to Redis 6 (latest)
   - Redis 7 to Redis 7 (latest)
 
-**No signs of exploitation were detected in Scalingo's environment.**
-
 ## Impact
 
 Redis databases on Scalingo are:
@@ -67,26 +65,8 @@ Redis databases on Scalingo are:
 - Not exposed to the internet unless explicitly configured by the user.
 
 Because the exploit requires authenticated access, the likelihood of exploitation on Scalingo is very low.
+
 Even in a hypothetical successful attack, the impact would be limited to the Redis container scope—there is no path to escape the container or access other customer data.
-
-## Incident Response
-
-Following Redis’s disclosure:
-
-- We performed an environment-wide scan to ensure all Redis instances were upgraded.
-
-- We verified container isolation and password enforcement across all Redis services.
-
-Scalingo continues to monitor upstream Redis channels and our telemetry for potential post-disclosure exploitation activity.
-
-## Timeline
-
-| 2025-05-16  | Vulnerability reported by Wiz Research during Pwn2Own Berlin |
-| 2025-10-03  | Redis publishes its official security advisory and patches       |
-| 2025-10-07  | Scalingo builds and tests patched Redis 6.2.20 and 7.2.11      |
-| 2025-10-07  | Patched versions made available for new instances and manual upgrades |
-| 2025-10-07  | Automatic upgrade plan announced for next 3 weeks               |
-| 2025-10-07  | Public disclosure of Scalingo Security Bulletin SSB-2025-001     |
 
 ## What you should do
 
@@ -121,6 +101,15 @@ No other add-ons or services are impacted.
 ## Contact
 
 If you have any questions or require further assistance, please contact our support team. We remain committed to ensuring the security of our platform and the protection of our users’ data.
+
+## Timeline
+
+| 2025-05-16  | Vulnerability reported by Wiz Research during Pwn2Own Berlin |
+| 2025-10-03  | Redis publishes its official security advisory and patches       |
+| 2025-10-07  | Scalingo builds and tests patched Redis 6.2.20 and 7.2.11      |
+| 2025-10-07  | Patched versions made available for new instances and manual upgrades |
+| 2025-10-07  | Automatic upgrade plan announced for next 3 weeks               |
+| 2025-10-07  | Public disclosure of Scalingo Security Bulletin SSB-2025-001     |
 
 ## Changelog
 

--- a/src/_posts/security/bulletins/2025-10-07-SSB-2025-001.md
+++ b/src/_posts/security/bulletins/2025-10-07-SSB-2025-001.md
@@ -41,7 +41,7 @@ Scalingo took the following actions after Redis's disclosure:
 
   - Manual upgrade by customers via the Scalingo Dashboard or CLI.
 
-- Scheduled automatic upgrades for all customer Redis databases over the next 3 weeks:
+- Scheduled automatic upgrades for all customer Redis databases over the next 3 weeks. (For all databases running v6 and v7, they'll be updated in less than a week):
   - Redis 4 to Redis 5 (latest)
   - Redis 5 to Redis 6 (latest) 
   - Redis 6 to Redis 6 (latest)

--- a/src/_posts/security/bulletins/2025-10-07-SSB-2025-001.md
+++ b/src/_posts/security/bulletins/2025-10-07-SSB-2025-001.md
@@ -73,7 +73,7 @@ Even in a hypothetical successful attack, the impact would be limited to the Red
 No immediate action required for customers using managed Redis add-ons.
 Automatic upgrades to patched versions are scheduled over the next 3 weeks to ensure all instances are protected.
 
-Ensure that internet access for your Redis instances is only enabled if absolutely necessary. This feature is disabled by default and can been controlled via the Scalingo Dashboard or CLI.
+Ensure that internet access for your Redis instances is only enabled if absolutely necessary. This feature is disabled by default and can be controlled via the Scalingo Dashboard or CLI.
 
 ## What we will do in the future
 

--- a/src/_posts/security/bulletins/2025-10-07-SSB-2025-001.md
+++ b/src/_posts/security/bulletins/2025-10-07-SSB-2025-001.md
@@ -1,0 +1,117 @@
+---
+title: SSB-2025-001 - Critical Remote Code Execution in Redis (“RediShell”)
+nav:  SSB-2025-000 (Redis)
+modified_at: 2025-10-07 00:00:00
+tags: security bulletin scalingo redis rce vulnerability
+cvss:
+  version: 4.0
+  base: 10.0
+---
+
+The vulnerability allows an authenticated user to exploit a use-after-free memory corruption bug within Redis’s embedded Lua interpreter.
+A specially crafted Lua script can escape the Lua sandbox and execute arbitrary code on the Redis host.
+
+## Incident Analysis
+
+Discovered and responsibly disclosed by Wiz Research, the vulnerability (nicknamed RediShell) affects all Redis versions supporting Lua scripting since its introduction over 13 years ago.
+Redis assigned it the identifier CVE-2025-49844 and published patched versions on October 3, 2025.
+
+While the issue technically enables remote code execution, exploitation requires authenticated access and the ability to execute Lua scripts.
+Therefore, the practical risk depends on configuration and exposure: internet-exposed or unauthenticated Redis instances are at highest risk.
+
+### Remediation: What We Did
+
+Scalingo took the following actions immediately after Redis’s disclosure:
+
+- Built and tested the patched Redis releases provided upstream.
+
+- Upgraded all managed Redis database containers to fixed versions.
+
+- Made patched versions available for:
+
+  - All newly provisioned Redis databases, and
+
+  - Manual upgrade by customers via the Scalingo Dashboard or CLI.
+
+**No signs of exploitation were detected in Scalingo’s environment.**
+
+## Impact
+
+Redis databases on Scalingo are:
+
+- Always executed in isolated Docker containers;
+
+- Protected by strong, randomly generated passwords;
+
+- Not exposed to the internet unless explicitly configured by the user.
+
+Because the exploit requires authenticated access, the likelihood of exploitation on Scalingo is very low.
+Even in a hypothetical successful attack, the impact would be limited to the Redis container scope—there is no path to escape the container or access other customer data.
+
+## Incident Response
+
+Following Redis’s disclosure:
+
+- We performed an environment-wide scan to ensure all Redis instances were upgraded.
+
+- We verified container isolation and password enforcement across all Redis services.
+
+- We confirmed no anomalous access patterns or unauthorized connections were detected.
+
+Scalingo continues to monitor upstream Redis channels and our telemetry for potential post-disclosure exploitation activity.
+
+## Timeline
+
+| May 16 2025  | Vulnerability reported by Wiz Research during Pwn2Own Berlin |
+| Oct 3 2025   | Redis publishes its official security advisory and patches       |
+| Oct 4–7 2025 | Scalingo builds and tests patched Redis versions                 |
+| Oct 7 2025   | All Scalingo Redis add-ons upgraded and verified                 |
+| Oct 7 2025   | Public disclosure of Scalingo Security Bulletin SSB-2025-001     |
+
+## What you should do
+
+No immediate action required for customers using managed Redis add-ons.
+These instances were automatically upgraded.
+
+Customers running custom Redis Docker images must rebuild them with one of the fixed versions.
+
+Ensure that:
+
+- Network access to Redis is restricted to trusted applications.
+
+- Authentication (requirepass) remains enabled and protected with a strong password.
+
+- Unnecessary commands (including Lua scripting) are disabled if not in use.
+
+## What we will do in the future
+
+Scalingo will:
+
+- Continue to monitor Redis security advisories and backport fixes promptly.
+
+- Strengthen automated vulnerability scanning of database container images.
+
+Enhance internal Lua script usage monitoring within managed Redis services.
+
+## Product Impacts
+
+### Scalingo PaaS
+
+No impact on the application platform layer.
+
+### Scalingo DBaaS Add-ons
+
+All Redis add-ons have been patched and verified.
+No other managed database services (PostgreSQL, MySQL, MongoDB, Elasticsearch, etc.) are affected.
+
+### Other Scalingo Add-ons and Services
+
+No other add-ons or services are impacted.
+
+## Contact
+
+If you have any questions or require further assistance, please contact our support team. We remain committed to ensuring the security of our platform and the protection of our users’ data.
+
+## Changelog
+
+2025-10-07: Initial publication of SSB-2025-001

--- a/src/_posts/security/bulletins/2025-10-07-SSB-2025-001.md
+++ b/src/_posts/security/bulletins/2025-10-07-SSB-2025-001.md
@@ -73,7 +73,7 @@ Even in a hypothetical successful attack, the impact would be limited to the Red
 No immediate action required for customers using managed Redis add-ons.
 Automatic upgrades to patched versions are scheduled over the next 3 weeks to ensure all instances are protected.
 
-Ensure that internet access for your Redis instances is only enabled if absolutely necessary. This feature is disabled by default and can ben controlled via the Scalingo Dashboard or CLI.
+Ensure that internet access for your Redis instances is only enabled if absolutely necessary. This feature is disabled by default and can been controlled via the Scalingo Dashboard or CLI.
 
 ## What we will do in the future
 

--- a/src/_posts/security/bulletins/2025-10-07-SSB-2025-001.md
+++ b/src/_posts/security/bulletins/2025-10-07-SSB-2025-001.md
@@ -53,7 +53,7 @@ Scalingo took the following actions after Redis's disclosure:
 
 Redis databases on Scalingo are:
 
-- Always executed in isolated Docker containers;
+- Always executed in isolated Linux containers;
 
 - Protected by strong, randomly generated passwords;
 

--- a/src/_posts/security/bulletins/2025-10-07-SSB-2025-001.md
+++ b/src/_posts/security/bulletins/2025-10-07-SSB-2025-001.md
@@ -60,8 +60,6 @@ Following Redis’s disclosure:
 
 - We verified container isolation and password enforcement across all Redis services.
 
-- We confirmed no anomalous access patterns or unauthorized connections were detected.
-
 Scalingo continues to monitor upstream Redis channels and our telemetry for potential post-disclosure exploitation activity.
 
 ## Timeline

--- a/src/_posts/security/bulletins/2025-10-07-SSB-2025-001.md
+++ b/src/_posts/security/bulletins/2025-10-07-SSB-2025-001.md
@@ -5,33 +5,37 @@ modified_at: 2025-10-07 00:00:00
 tags: security bulletin scalingo redis rce vulnerability
 cvss:
   version: 4.0
-  base: 10.0
+  base: 7.4
 ---
 
 The vulnerability allows an authenticated user to exploit a use-after-free memory corruption bug within Redis’s embedded Lua interpreter.
 A specially crafted Lua script can escape the Lua sandbox and execute arbitrary code on the Redis host.
+The vulnerability was originally evaluated with a CVSS v4.0 base score of 10 but Scalingo re-evaluated it to 7.4 due to the required conditions for exploitation.
 
-## Incident Analysis
+## Incident analysis
 
-Discovered and responsibly disclosed by Wiz Research, the vulnerability (nicknamed RediShell) affects all Redis versions supporting Lua scripting since its introduction over 13 years ago.
+Disclosed by Redis, the vulnerability (nicknamed RediShell) affects all Redis versions supporting Lua scripting since its introduction over 13 years ago.
 Redis assigned it the identifier CVE-2025-49844 and published patched versions on October 3, 2025.
+If you are using a version <6.2.20 and <7.2.11, you are concerned by this vulnerability.
 
 While the issue technically enables remote code execution, exploitation requires authenticated access and the ability to execute Lua scripts.
 Therefore, the practical risk depends on configuration and exposure: internet-exposed or unauthenticated Redis instances are at highest risk.
 
-### Remediation: What We Did
+### Remediation: what we did
 
-Scalingo took the following actions immediately after Redis’s disclosure:
+Scalingo took the following actions after Redis’s disclosure:
 
 - Built and tested the patched Redis releases provided upstream.
 
-- Upgraded all managed Redis database containers to fixed versions.
+- Patched Scalingo's internal systems that use Redis.
 
 - Made patched versions available for:
 
   - All newly provisioned Redis databases, and
 
   - Manual upgrade by customers via the Scalingo Dashboard or CLI.
+
+- Scheduled an automatic upgrade for all customer Redis databases during the next maintenance window.
 
 **No signs of exploitation were detected in Scalingo’s environment.**
 
@@ -62,38 +66,26 @@ Scalingo continues to monitor upstream Redis channels and our telemetry for pote
 
 ## Timeline
 
-| May 16 2025  | Vulnerability reported by Wiz Research during Pwn2Own Berlin |
-| Oct 3 2025   | Redis publishes its official security advisory and patches       |
-| Oct 4–7 2025 | Scalingo builds and tests patched Redis versions                 |
-| Oct 7 2025   | All Scalingo Redis add-ons upgraded and verified                 |
-| Oct 7 2025   | Public disclosure of Scalingo Security Bulletin SSB-2025-001     |
+| 2025-05-16  | Vulnerability reported by Wiz Research during Pwn2Own Berlin |
+| 2025-10-03  | Redis publishes its official security advisory and patches       |
+| 2025-10-07  | Scalingo builds and tests patched Redis versions                 |
+| 2025-10-07  | All Scalingo Redis add-ons upgraded and verified                 |
+| 2025-10-07  | Public disclosure of Scalingo Security Bulletin SSB-2025-001     |
 
 ## What you should do
 
 No immediate action required for customers using managed Redis add-ons.
-These instances were automatically upgraded.
+These instances are automatically going to be upgraded.
 
-Customers running custom Redis Docker images must rebuild them with one of the fixed versions.
-
-Ensure that:
-
-- Network access to Redis is restricted to trusted applications.
-
-- Authentication (requirepass) remains enabled and protected with a strong password.
-
-- Unnecessary commands (including Lua scripting) are disabled if not in use.
+Ensure that internet access for your Redis instances is only enabled if absolutely necessary.
 
 ## What we will do in the future
 
 Scalingo will:
-
-- Automatically update databases with the latest Redis patched versions for customer using the maintenance window feature.
   
 - Continue to monitor Redis security advisories and backport fixes promptly.
 
-- Strengthen automated vulnerability scanning of database container images.
-
-Enhance internal Lua script usage monitoring within managed Redis services.
+- Strengthen automated vulnerability monitoring.
 
 ## Product Impacts
 
@@ -104,7 +96,7 @@ No impact on the application platform layer.
 ### Scalingo DBaaS Add-ons
 
 All Redis add-ons have been patched and verified.
-No other managed database services (PostgreSQL, MySQL, MongoDB, Elasticsearch, etc.) are affected.
+No other managed database services (PostgreSQL, MySQL, MongoDB, Elasticsearch, OpenSearch, InfluxDB) are affected.
 
 ### Other Scalingo Add-ons and Services
 

--- a/src/_posts/security/bulletins/2025-10-07-SSB-2025-001.md
+++ b/src/_posts/security/bulletins/2025-10-07-SSB-2025-001.md
@@ -1,7 +1,7 @@
 ---
 title: SSB-2025-001 - Critical Remote Code Execution in Redis (“RediShell”)
 nav:  SSB-2025-001 (Redis)
-modified_at: 2025-10-07 00:00:00
+modified_at: 2025-10-08 00:00:00
 tags: security bulletin scalingo redis rce vulnerability
 cvss:
   version: 4.0
@@ -108,9 +108,8 @@ If you have any questions or require further assistance, please contact our supp
 | 2025-10-03  | Redis publishes its official security advisory and patches       |
 | 2025-10-07  | Scalingo builds and tests patched Redis 6.2.20 and 7.2.11      |
 | 2025-10-07  | Patched versions made available for new instances and manual upgrades |
-| 2025-10-07  | Automatic upgrade plan announced for next 3 weeks               |
-| 2025-10-07  | Public disclosure of Scalingo Security Bulletin SSB-2025-001     |
+| 2025-10-08  | Public disclosure of Scalingo Security Bulletin SSB-2025-001     |
 
 ## Changelog
 
-2025-10-07: Initial publication of SSB-2025-001
+2025-10-08: Initial publication of SSB-2025-001

--- a/src/_posts/security/bulletins/2025-10-07-SSB-2025-001.md
+++ b/src/_posts/security/bulletins/2025-10-07-SSB-2025-001.md
@@ -1,6 +1,6 @@
 ---
 title: SSB-2025-001 - Critical Remote Code Execution in Redis (“RediShell”)
-nav:  SSB-2025-000 (Redis)
+nav:  SSB-2025-001 (Redis)
 modified_at: 2025-10-07 00:00:00
 tags: security bulletin scalingo redis rce vulnerability
 cvss:

--- a/src/_posts/security/bulletins/2025-10-07-SSB-2025-001.md
+++ b/src/_posts/security/bulletins/2025-10-07-SSB-2025-001.md
@@ -87,6 +87,8 @@ Ensure that:
 
 Scalingo will:
 
+- Automatically update databases with the latest Redis patched versions for customer using the maintenance window feature.
+  
 - Continue to monitor Redis security advisories and backport fixes promptly.
 
 - Strengthen automated vulnerability scanning of database container images.

--- a/src/_posts/security/bulletins/2025-10-07-SSB-2025-001.md
+++ b/src/_posts/security/bulletins/2025-10-07-SSB-2025-001.md
@@ -18,6 +18,7 @@ Disclosed by Redis, the vulnerability (nicknamed RediShell) affects all Redis ve
 Redis assigned it the identifier CVE-2025-49844 and published patched versions on October 3, 2025.
 
 The following versions are affected by this vulnerability:
+
 - All versions prior to 6.2.20
 - Versions 7.0.0 through 7.2.10
 
@@ -47,7 +48,6 @@ Scalingo took the following actions after Redis's disclosure:
   - Redis 7 to Redis 7 (latest)
 
 **No signs of exploitation were detected in Scalingo's environment.**
-
 
 ## Impact
 

--- a/src/_posts/security/bulletins/2025-10-07-SSB-2025-001.md
+++ b/src/_posts/security/bulletins/2025-10-07-SSB-2025-001.md
@@ -83,7 +83,7 @@ Scalingo will:
   
 - Continue to monitor Redis security advisories and backport fixes promptly.
 
-- Strengthen automated vulnerability monitoring.
+- Continue to strengthen automated vulnerability monitoring to increase detection capabilities.
 
 ## Product Impacts
 


### PR DESCRIPTION
From recent detection, CVE-2025-49844
Tracked in this SECINC issue: [125](https://scalingo.atlassian.net/browse/SECINC-125)
&
[VUL-366](https://scalingo.atlassian.net/browse/VUL-366)

All remediations handled here:
[#3687 bump(redis) Version 6.2.20 and 7.2.11 to fix CVE‑2025‑49844](https://github.com/Scalingo/appsdeck-database/pull/3687)

[#3377 changelog(databases) 2025-10-07-redis.7.2.11-1.md](https://github.com/Scalingo/documentation/pull/3377)

[VUL-366]: https://scalingo.atlassian.net/browse/VUL-366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ