### PR TITLE
[IRQ-446] Answering the need to clarify allow-listing domain procedure

### DIFF
--- a/src/_posts/security/procedures/2000-01-01-secnumcloud.md
+++ b/src/_posts/security/procedures/2000-01-01-secnumcloud.md
@@ -46,7 +46,7 @@ A standard user cannot directly access `osc-secnum-fr1`: your user account must 
 - If your company already hosts one or more applications in the `osc-secnum-fr1` region, the application owner can invite you directly as a collaborator.
 - If your company domain is not yet allow-listed, you may ask the support team to register it. Once validated, all users from that domain will be eligible to access the region without further access confirmation needed from the support.
 
-#### Access without whitelisted domain
+#### Access without allow-listed domain
 
 - If your company domain has not been declared or allow-listed, the request must still come from the application owner.
 - The owner of the application must invite the user as a collaborator.


### PR DESCRIPTION
From: https://scalingo.atlassian.net/browse/IRQ-446
Internal procedure change: https://github.com/Scalingo/specifications/pull/486
## Overview:
This commit significantly improves the documentation for accessing the SecNumCloud (osc-secnum-fr1) region by clarifying the domain whitelisting procedures and access requirements for users.

### 1. Enhanced user access section
Clarified Language and improved Clarity: made it clear that user accounts must be explicitly allow-listed before accessing the region
### 2. Refined "Pre-conditions" language
Enhanced the description for legitimate access reasons, domain verification and added requirement that company domains must already be associated with existing applications in the region.
### 3. Restructured access procedures
Streamlined process for users from companies with existing SecNumCloud presence
Access without whitelisted domain: Clear process for new domain requests
Domain declaration and regularization

## Objectives:
Reduced Support Burden: clearer procedures reduce unclear requests - better explanation of verification requirements
Compliance documentation: better alignment with SecNumCloud security requirements