### PR TITLE
fix(cli/features) specify run command containing hyphens

### DIFF
--- a/src/_posts/tools/cli/2000-01-01-features.md
+++ b/src/_posts/tools/cli/2000-01-01-features.md
@@ -170,6 +170,9 @@ scalingo --app my-app run --file ./dump.sql <command>
 
 # Start the one-off container with a specific size of container
 scalingo --app my-app run --size 2XL <command>
+
+# When using hyphens in the job command, you must use double quotation marks
+scalingo --app my-app run "bundle exec rails console --sandbox"
 ```
 
 ## Get metrics of your application


### PR DESCRIPTION
Example

```sh
 ➜ scalingo --app $APPNAME run echo toto
-----> Starting container one-off-4636  Done in 0.104 seconds
-----> Connecting to container [one-off-4636]...  
-----> Process 'echo toto' is starting...  
toto

➜ scalingo --app $APPNAME run echo "--toto"
Incorrect Usage: flag provided but not defined: -toto

Fail to run command: flag provided but not defined: -toto
```