### PR TITLE
fix(samples): remove deprecated Mosca

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -223,9 +223,6 @@ samples:
   - url: java-grails3
     name: Java/Grails 3
     logo: groovy-grails
-  - url: node-mosca
-    name: NodeJS/Mosca/MQTT
-    logo: mosca
   - url: kotlin
     name: Kotlin
     logo: kotlin


### PR DESCRIPTION
The repository has apparently recently been deprecated (https://github.com/Scalingo/sample-node-mosca), and the app is no longer deployed (https://node-mosca.is-easy-on-scalingo.com/). Hence I think it should be removed from the list of samples.