### PR TITLE
Fix missing step about buildpack in Logstash deployment

### DIFF
--- a/src/_posts/databases/opensearch/guides/ingesting-logs/2000-01-01-logstash.md
+++ b/src/_posts/databases/opensearch/guides/ingesting-logs/2000-01-01-logstash.md
@@ -40,9 +40,9 @@ Scalingo. Here are the few extra steps to follow:
    cd logstash-scalingo
    ```
 
-2. Create the application on Scalingo:
+2. Create the application on Scalingo with the right buildpack:
    ```bash
-   scalingo create my-logstash
+   scalingo create my-logstash --buildpack https://github.com/Scalingo/logstash-buildpack
    ```
 
 3. (optional) Scale the container to an L size:
@@ -66,12 +66,7 @@ Scalingo. Here are the few extra steps to follow:
    scalingo --app my-logstash env-set PASSWORD=logstash-password
    ```
 
-7. Indicate that the buildpack to use is the one for Logstash:
-   ```bash
-   scalingo --app my-logstash env-set BUILDPACK_URL=https://github.com/Scalingo/logstash-buildpack
-   ```
-
-8. Everything's ready, deploy to Scalingo:
+7. Everything's ready, deploy to Scalingo:
    ```bash
    git push scalingo master
    ```


### PR DESCRIPTION
The buildpack configuration has been removed from the repo by the commit https://github.com/Scalingo/logstash-scalingo/commit/77f41b4f7b7b8307bc2e80d34940b94f8d973664 So we now have to declare the buildpack. If not, we get this error:
  !     An error occurred when parsing Procfile
  !   Error deploying the application