### PR TITLE
fix(php): correcting link regarding version constraint

### DIFF
--- a/src/_posts/languages/php/2000-01-01-start.md
+++ b/src/_posts/languages/php/2000-01-01-start.md
@@ -1,7 +1,7 @@
 ---
 title: PHP on Scalingo
 nav: Introduction
-modified_at: 2025-10-27 00:00:00
+modified_at: 2025-11-25 00:00:00
 tags: php
 index: 1
 ---
@@ -75,7 +75,7 @@ important updates. Instead, you should specify `~8.2.3` to install a version
 `>=8.2.3 and <8.3.0` or specify `~8.2` to install a version `>=8.2 and <9.0.0`.
 
 Further details about version constraints can be found in the
-[Composer documentation](https://getcomposer.org/doc/articles/versions.md#writing-version-constraints)
+[Semver documentation](https://github.com/npm/node-semver?tab=readme-ov-file#advanced-range-syntax)
 {% endnote %}
 
 If you do not use `compose.json` (classic app), you can specify the PHP version 


### PR DESCRIPTION
Fix [#3434](https://github.com/Scalingo/documentation/issues/3434)