### PR TITLE
docs(redis): update plan change process downtime information

### DIFF
--- a/src/_posts/databases/redis/2000-01-01-start.md
+++ b/src/_posts/databases/redis/2000-01-01-start.md
@@ -1,7 +1,7 @@
 ---
 title: Scalingo for Caching
 nav: Introduction
-modified_at: 2025-06-06 00:00:00
+modified_at: 2025-12-29 00:00:00
 tags: databases redis addon
 index: 1
 ---
@@ -193,7 +193,66 @@ This feature uses [two settings](https://redis.io/topics/lru-cache) of Redis® O
 
 ## Changing Plans
 
-You can upgrade or downgrade your database plan whenever you need it. This operation happens instantly thanks to Docker containers and no manual input is required. When you change the plan, your database will be stopped then restarted on a new host with new parameters of the chosen plan. During the operation the connection is dropped between your app and the database. Finally, after the operation is successful, the related app will be restarted.
+You can change your Scalingo for Caching addon plan whenever you want. The
+operation is launched instantly, no manual input is required.
+
+The impact on your application and the downtime vary depending on several
+factors such as the current plan being used and the one you wish to change for
+(see below for further information).
+
+{% warning %}
+While switching to a more powerful plan is rather safe, you should take extra
+care when changing for a less powerful plan: please make sure the new plan can
+handle all your data and fits your application workload.
+{% endwarning %}
+
+### Understanding the Plan Change Process
+
+#### From Starter to Starter
+
+When changing the size of a Starter plan, the platform reboots the existing
+instance with the new size. This leads to a small service interruption
+during which the database is not available. This shouldn't exceed a few seconds
+though.
+
+| From (class) | To (class) | To (size) | Downtime | Duration     |
+| ------------ | ---------- | --------- | -------- | ------------ |
+| Starter      | Starter    | Any       | **Yes**  | 2-10 seconds |
+
+#### From Starter to Business
+
+When changing for a Business plan, the platform starts additional instances
+with the targeted size. If necessary, it then reboots the previously existing
+instance with the targeted size. There should be no downtime at all, thanks to
+the failover mechanism included with the Business plan.
+
+| From (class) | To (class) | To (size) | Downtime | Duration     |
+| ------------ | ---------- | --------- | -------- | ------------ |
+| Starter      | Business   | Any       | **No**   | Zero         |
+
+#### From Business to Starter
+
+When changing for a lower class, the platform first powers the surplus
+instances off. When necessary, the remaining instance is rebooted with the
+targeted new size. This can lead to a small service interruption during which
+the database is not available. This shouldn't exceed a few seconds though.
+
+| From (class) | To (class) | To (size) | Downtime | Duration     |
+| ------------ | ---------- | --------- | -------- | ------------ |
+| Business     | Starter    | Same      | **No**   | Zero         |
+| Business     | Starter    | Larger    | **Yes**  | 2-10 seconds |
+| Business     | Starter    | Smaller   | **Yes**  | 2-10 seconds |
+
+#### From Business to Business
+
+When changing the size of a Business plan, the platform reboots the instances
+with the targeted new size one by one. There's no downtime during this
+operation, thanks to the high availability mechanism included in the Business
+plan.
+
+| From (class) | To (class) | To (size) | Downtime | Duration     |
+| ------------ | ---------- | --------- | -------- | ------------ |
+| Business     | Business   | Any       | **No**   | Zero         |
 
 ### From the Dashboard
 


### PR DESCRIPTION
Fixes #3283

Updates the downtime information for redis during plan change.

Question: Do we need to update mongodb / elasticsearch and influxdb information too?