### PR TITLE
fix(puppeteer): stack system dependencies

### DIFF
--- a/src/_posts/languages/nodejs/2000-01-01-puppeteer.md
+++ b/src/_posts/languages/nodejs/2000-01-01-puppeteer.md
@@ -1,6 +1,6 @@
 ---
 title: Install Puppeteer
-modified_at: 2023-08-28 00:00:00
+modified_at: 2026-04-09 00:00:00
 tags: nodejs puppeteer
 ---
 
@@ -22,7 +22,7 @@ git add .buildpacks
 git commit --message="Add multi-buildpack"
 ```
 
-Depending on your stack, you'll need different system dependencies in a `Aptfile` at the root of your project.
+Depending on your stack, you'll need different system dependencies in the `Aptfile` at the root of your project.
 
 **Ubuntu 22.04**
 
@@ -36,10 +36,14 @@ libgtk-3-0 libgbm-dev libnotify-dev libnss3 libxss1 libasound2 libxtst6 xauth xv
 libgtk-3-0t64 libgbm-dev libnotify-dev libnss3 libxss1 libasound2t64 libxtst6 xauth xvfb
 ```
 
-**NOTE**: These are minimal dependencies, a more thorough list of system dependencies is available in the chromium [source repository](https://source.chromium.org/chromium/chromium/src/+/main:chrome/installer/linux/debian/dist_package_versions.json;l=150)
+{% note %}
+These are minimal dependencies, a more thorough list of system dependencies is available in the chromium [source repository](https://source.chromium.org/chromium/chromium/src/+/main:chrome/installer/linux/debian/dist_package_versions.json;l=150)
+{% endnote %}
 
 ```
 gconf-service libasound2 libatk1.0-0 libatk-bridge2.0-0 libc6 libcairo2 libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget libcairo-gobject2 libxinerama1 libgtk2.0-0 libpangoft2-1.0-0 libthai0 libpixman-1-0 libxcb-render0 libharfbuzz0b libdatrie1 libgraphite2-3 libgbm-dev
 ```
 
-**WARNING**: Puppeteer must be run with the option `--no-sandbox` on Scalingo. This option must be added with care. You should only add this option against some code you own.
+{% warning %}
+Puppeteer must be run with the option `--no-sandbox` on Scalingo. This option must be added with care. You should only add this option against some code you own.
+{% endwarning %}

--- a/src/_posts/languages/nodejs/2000-01-01-puppeteer.md
+++ b/src/_posts/languages/nodejs/2000-01-01-puppeteer.md
@@ -24,11 +24,7 @@ git commit --message="Add multi-buildpack"
 
 Depending on your stack, you'll need different system dependencies in the `Aptfile` at the root of your project.
 
-**Ubuntu 22.04**
-
-```
-libgtk-3-0 libgbm-dev libnotify-dev libnss3 libxss1 libasound2 libxtst6 xauth xvfb
-```
+- For `scalingo-22`:
 
 **Ubuntu 24.04**
 

--- a/src/_posts/languages/nodejs/2000-01-01-puppeteer.md
+++ b/src/_posts/languages/nodejs/2000-01-01-puppeteer.md
@@ -26,14 +26,19 @@ Depending on your stack, you'll need different system dependencies in the `Aptfi
 
 - For `scalingo-22`:
 
+```
+libgtk-3-0 libgbm-dev libnotify-dev libnss3 libxss1 libasound2 libxtst6 xauth xvfb
+```
+
 - For `scalingo-24`:
+
+```
+libgtk-3-0t64 libgbm-dev libnotify-dev libnss3 libxss1 libasound2t64 libxtst6 xauth xvfb
+```
 
 {% note %}
 These are minimal dependencies, a more thorough list of system dependencies is available in the chromium [source repository](https://source.chromium.org/chromium/chromium/src/+/main:chrome/installer/linux/debian/dist_package_versions.json;l=150)
 {% endnote %}
-
-```
-```
 
 {% warning %}
 Puppeteer must be run with the option `--no-sandbox` on Scalingo. This option must be added with care. You should only add this option against some code you own.

--- a/src/_posts/languages/nodejs/2000-01-01-puppeteer.md
+++ b/src/_posts/languages/nodejs/2000-01-01-puppeteer.md
@@ -33,7 +33,6 @@ These are minimal dependencies, a more thorough list of system dependencies is a
 {% endnote %}
 
 ```
-gconf-service libasound2 libatk1.0-0 libatk-bridge2.0-0 libc6 libcairo2 libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget libcairo-gobject2 libxinerama1 libgtk2.0-0 libpangoft2-1.0-0 libthai0 libpixman-1-0 libxcb-render0 libharfbuzz0b libdatrie1 libgraphite2-3 libgbm-dev
 ```
 
 {% warning %}

--- a/src/_posts/languages/nodejs/2000-01-01-puppeteer.md
+++ b/src/_posts/languages/nodejs/2000-01-01-puppeteer.md
@@ -37,7 +37,7 @@ libgtk-3-0t64 libgbm-dev libnotify-dev libnss3 libxss1 libasound2t64 libxtst6 xa
 ```
 
 {% note %}
-These are minimal dependencies, a more thorough list of system dependencies is available in the chromium [source repository](https://source.chromium.org/chromium/chromium/src/+/main:chrome/installer/linux/debian/dist_package_versions.json;l=150)
+These are minimal dependencies originally documented by [cypress](https://docs.cypress.io/app/get-started/install-cypress#Linux-Prerequisites). A more thorough list of system dependencies is available in the chromium [source repository](https://source.chromium.org/chromium/chromium/src/+/main:chrome/installer/linux/debian/dist_package_versions.json;l=150)
 {% endnote %}
 
 {% warning %}

--- a/src/_posts/languages/nodejs/2000-01-01-puppeteer.md
+++ b/src/_posts/languages/nodejs/2000-01-01-puppeteer.md
@@ -26,11 +26,7 @@ Depending on your stack, you'll need different system dependencies in the `Aptfi
 
 - For `scalingo-22`:
 
-**Ubuntu 24.04**
-
-```
-libgtk-3-0t64 libgbm-dev libnotify-dev libnss3 libxss1 libasound2t64 libxtst6 xauth xvfb
-```
+- For `scalingo-24`:
 
 {% note %}
 These are minimal dependencies, a more thorough list of system dependencies is available in the chromium [source repository](https://source.chromium.org/chromium/chromium/src/+/main:chrome/installer/linux/debian/dist_package_versions.json;l=150)

--- a/src/_posts/languages/nodejs/2000-01-01-puppeteer.md
+++ b/src/_posts/languages/nodejs/2000-01-01-puppeteer.md
@@ -22,10 +22,24 @@ git add .buildpacks
 git commit --message="Add multi-buildpack"
 ```
 
-You need to instruct the APT buildpack to install the dependencies Puppeteer requires. Create a `Aptfile` at the root of your project with the following content:
+Depending on your stack, you'll need different system dependencies in a `Aptfile` at the root of your project.
+
+**Ubuntu 22.04**
+
+```
+libgtk-3-0 libgbm-dev libnotify-dev libnss3 libxss1 libasound2 libxtst6 xauth xvfb
+```
+
+**Ubuntu 24.04**
+
+```
+libgtk-3-0t64 libgbm-dev libnotify-dev libnss3 libxss1 libasound2t64 libxtst6 xauth xvfb
+```
+
+**NOTE**: These are minimal dependencies, a more thorough list of system dependencies is available in the chromium [source repository](https://source.chromium.org/chromium/chromium/src/+/main:chrome/installer/linux/debian/dist_package_versions.json;l=150)
 
 ```
 gconf-service libasound2 libatk1.0-0 libatk-bridge2.0-0 libc6 libcairo2 libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget libcairo-gobject2 libxinerama1 libgtk2.0-0 libpangoft2-1.0-0 libthai0 libpixman-1-0 libxcb-render0 libharfbuzz0b libdatrie1 libgraphite2-3 libgbm-dev
 ```
 
-Puppeteer must be run with the option `--no-sandbox` on Scalingo. This option must be added with care. You should only add this option against some code you own.
+**WARNING**: Puppeteer must be run with the option `--no-sandbox` on Scalingo. This option must be added with care. You should only add this option against some code you own.


### PR DESCRIPTION
Trying to solve #3662

The main points that I wanted to clarify:

- The existing list of dependencies is a bit overwhelming, especially when keeping the target image under 1,5Gb
- Some of the dependencies don't exist in Ubuntu 24 (`libasound2`, `gconf-service`…)
- Other actors like cypress maintain a short list of dependencies, that worked in my production case (we could quote the original page)