### PR TITLE
docs(changelog): go-scalingo v11.0.3

### DIFF
--- a/src/changelog/sdk/_posts/2026-04-15-go-scalingo-v11.0.3.md
+++ b/src/changelog/sdk/_posts/2026-04-15-go-scalingo-v11.0.3.md
@@ -1,0 +1,9 @@
+---
+modified_at: 2026-04-15 00:00:00
+title: 'go-scalingo - New version: 11.0.3'
+github: 'https://github.com/Scalingo/go-scalingo'
+---
+
+## Changelog
+
+* fix(run): add JSON tag for `OperationURL`


### PR DESCRIPTION
Related to https://github.com/Scalingo/go-scalingo/pull/500 and https://github.com/Scalingo/go-scalingo/releases/tag/v11.0.3