### PR TITLE
[IRQ-571] udpate the SNC region access requirements

### DIFF
--- a/src/_posts/security/procedures/2000-01-01-secnumcloud.md
+++ b/src/_posts/security/procedures/2000-01-01-secnumcloud.md
@@ -1,7 +1,7 @@
 ---
 title: Getting access to SecNumCloud Region
 nav: SecNumCloud
-modified_at: 2025-10-23 00:00:00
+modified_at: 2026-04-20 00:00:00
 tags: security procedures secnumcloud
 ---
 
@@ -9,11 +9,9 @@ tags: security procedures secnumcloud
 
 ### Pre-conditions
 
-- The application must be owned by a *company* or *public entity* (no
-  individuals are allowed)
-- The owner must be physically representated in Europe (have an office in an EU country)
-- Have a legitimate reason to be hosted in a SecNumCloud environment: business
-  requirement, legal requirement, reinforced security...
+- The application must be owned by a company or public body. Individual applicants are not eligible.
+- The owning entity must be established in the European Union and maintain a physical presence in an EU member state.
+- The application must have a legitimate need to be hosted in a SecNumCloud environment, whether for business, regulatory, or security reasons.
 
 ### Procedure
 


### PR DESCRIPTION
Update SecNumCloud customer region pre-conditions

This PR updates the documentation page for accessing the SecNumCloud region ([2000-01-01-secnumcloud.md](vscode-file://vscode-app/snap/code/231/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)).

Changes:

Rewrote the three pre-conditions to be clearer and better aligned with our compliance requirements:
Clarified that individual applicants are not eligible (must be a company or public body)
Replaced "physically represented in Europe" with clearer wording requiring the entity to be established in the EU and maintain a physical presence in an EU member state
Rephrased the "legitimate reason" requirement to explicitly mention business, regulatory, or security needs