### PR TITLE
feat(sonarqube): deprecate SonarQube tutorial

### DIFF
--- a/src/_layouts/tutorials_category.html
+++ b/src/_layouts/tutorials_category.html
@@ -11,7 +11,7 @@ layout: tutorials
     </div>
 
     <div class="grid grid-cols-1 xl:grid-cols-2 2xl:max-w-2/3 gap-6 mt-6 mb-24">
-        {% assign tutorials = site.tutorials | where: "category", page.category | sort: "modified_at" %}
+        {% assign tutorials = site.tutorials | where: "category", page.category | where_exp: "page", "page.deprecated != true" | sort: "modified_at" %}
         {% for tutorial in tutorials %}
         <a href="{{ tutorial.url }}">
             <div class="flex items-center bg-sc-gray-5 rounded-lg h-24 px-5 border-l-8 border-primary-orange-300 group transform hover:border-l-12 duration-200 ease-out hover:shadow-lg">
@@ -26,6 +26,6 @@ layout: tutorials
                 <div class="text-primary-orange-400 justify-end transform group-hover:translate-x-1 duration-200 ease-out">{% icon arrow_right %}</div>
             </div>
         </a>
-    {% endfor %}
+        {% endfor %}
     </div>
 </div>

--- a/src/_layouts/tutorials_main.html
+++ b/src/_layouts/tutorials_main.html
@@ -11,9 +11,8 @@ layout: tutorials
     </div>
 
     <div class="grid grid-cols-1 xl:grid-cols-2 2xl:max-w-2/3 gap-6 mt-6 mb-24">
-    {% assign tutorials = site.tutorials | sort: 'modified_at' | reverse | slice: 0, 12 %}
+    {% assign tutorials = site.tutorials | where_exp: "page", "page.deprecated != true" | where_exp: "page", "page.category != nil" | sort: "modified_at" | reverse | slice: 0, 12 %}
     {% for tutorial in tutorials %}
-        {% if tutorial.category %}
         <a href="{{ tutorial.url }}">
             <div class="flex items-center bg-sc-gray-5 rounded-lg h-24 px-5 border-l-8 border-primary-orange-300 group transform hover:border-l-12 duration-200 ease-out hover:shadow-lg">
                 <div class="flex items-center h-12 min-w-[48px] max-w-[48px] mr-6">{% icon {{ tutorial.logo }} %}</div>
@@ -27,7 +26,6 @@ layout: tutorials
                 <div class="text-primary-orange-400 justify-end transform group-hover:translate-x-1 duration-200 ease-out">{% icon arrow_right %}</div>
             </div>
         </a>
-        {% endif %}
     {% endfor %}
     </div>
 </div>

--- a/src/_tutorials/sonarqube/index.md
+++ b/src/_tutorials/sonarqube/index.md
@@ -6,13 +6,38 @@ products:
   - Scalingo for PostgreSQL®
   - Multi-buildpack
 permalink: /tutorials/sonarqube
-modified_at: 2025-08-07
+modified_at: 2026-05-11
+deprecated: true
 ---
 
 SonarQube is an automatic code review tool to detect bugs, vulnerabilities, and
 code smells in your project. It can integrate with your existing workflow to
 enable continuous code inspection across your project branches and pull
 requests.
+
+{% warning %}
+**This tutorial is now deprecated.**
+
+SonarQube has been shipping their own Elasticsearch® engine for a few years.
+The database is fully integrated into SonarQube. Configuration options allowing
+to connect to an external Elasticsearch® database have been removed, and
+SonarQube team has now repeatedly confirmed that they won't support this
+feature.
+
+Consequently, deploying SonarQube on Scalingo induces that the Elasticsearch®
+database lives and dies with the container runnning it, resulting in several
+no-goes:
+
+- Data won't survive reboots, nor updates.
+- Scalingo can't provide any backup mechanism for this database.
+- Application can't scale horizontally.
+
+**Considering the above, it's impossible for us to keep supporting SonarQube
+deployments on Scalingo.**
+
+The instructions below are kept temporarily and will be removed on the 12th of
+November 2026 (2026-11-12), after a 6 months notice period.
+{% endwarning %}
 
 
 ## Planning your Deployment


### PR DESCRIPTION
Also update filters in layouts so that the page doesn't include deprecated tutorials.