### PR TITLE
Fix link and text formatting in Go Modules tutorial

### DIFF
--- a/src/_posts/languages/go/2000-01-01-gomod.md
+++ b/src/_posts/languages/go/2000-01-01-gomod.md
@@ -1,17 +1,17 @@
 ---
 title: Manage Go dependencies with Go Modules
-nav: Manage dependencies with go.mod
-modified_at: 2022-06-10 00:00:00
-tags: go dependencies
+nav: Manage Go Modules
+modified_at: 2026-05-11 00:00:00
+tags: go dependencies go.mod
 index: 2
 ---
 
-This tutorial explains how to deploy a Go application which is using Go Modules to manage its
-dependencies.
+Scalingo uses Go Modules to install dependencies for Go applications. This page
+explains the `go.mod` configuration options recognized by the Scalingo Go
+buildpack during deployment.
 
-To handle the version management of the dependencies, please follow [the offical Go
-Modules guide](https://go.dev/wiki/Modules), this page will focus on the deployment of
-the app.
+For dependency version management, refer to the [official Go Modules
+reference](https://go.dev/ref/mod).
 
 ## Configuration
 

--- a/src/_posts/languages/go/2000-01-01-gomod.md
+++ b/src/_posts/languages/go/2000-01-01-gomod.md
@@ -7,14 +7,16 @@ index: 2
 ---
 
 This tutorial explains how to deploy a Go application which is using Go Modules to manage its
-dependencies. To handle the version management of the dependencies, please follow [the offical Go
-Modules guide](https://github.com/golang/go/wiki/Modules), this page will focus on the deployment of
-the app. Go Modules can be used starting with Go 1.11.
+dependencies.
+
+To handle the version management of the dependencies, please follow [the offical Go
+Modules guide](https://go.dev/wiki/Modules), this page will focus on the deployment of
+the app.
 
 ## Configuration
 
 The `go.mod` file allows for arbitrary comments. This buildpack utilizes [build
-constraint](https://golang.org/pkg/go/build/#hdr-Build_Constraints) style
+constraint](https://pkg.go.dev/go/build#hdr-Build_Constraints) style
 comments to track Scalingo build specific configuration which is encoded in the
 following way:
 


### PR DESCRIPTION
Corrected the link to the official Go Modules guide and improved the text formatting.