### PR TITLE
docs(ruby): document mongo driver compatibility

### DIFF
--- a/src/_posts/languages/ruby/2000-01-01-mongoid.md
+++ b/src/_posts/languages/ruby/2000-01-01-mongoid.md
@@ -1,9 +1,14 @@
 ---
 title: Configure Mongoid
 nav: Mongoid
-modified_at: 2023-12-22 00:00:00
+modified_at: 2026-05-18 00:00:00
 tags: ruby mongoid mongodb
 ---
+
+{% warning %}
+  Use the Mongo Ruby driver `mongo` up to version `2.23.0` when connecting to
+  MongoDB Server `3.6` or `4.0`.
+{% endwarning %}
 
 You need to create the file `config/mongoid.yml` in order to configure Mongoid:
 
@@ -20,6 +25,29 @@ production:
       uri: <%= ENV['SCALINGO_MONGO_URL'] %>
 ```
 
+Add the `mongo` gem to your `Gemfile`:
+
+```ruby
+gem 'mongo', '2.23.0'
+```
+
+
+## Connection Options
+
 If you want to modify connection options or the connections pooling, you can
-find all the information in the [official
-documentation](https://www.mongodb.com/docs/mongoid/current/installation/).
+find all the information in the [official documentation][mongoid-documentation].
+
+
+## Mongo Ruby Driver Compatibility
+
+Scalingo for MongoDB® supports MongoDB up to version `4.0.3`, the latest open
+source version available.
+
+The Mongo Ruby driver `mongo` version `2.24.0` removed support for MongoDB
+Server `3.6` and `4.0`. As a consequence, **Ruby applications using MongoDB on
+Scalingo must pin the `mongo` gem to version `2.23.0` or lower.**
+
+For more information, see the [MongoDB Ruby Driver release notes][ruby-driver-release-notes].
+
+[ruby-driver-release-notes]: https://www.mongodb.com/docs/ruby-driver/current/reference/release-notes/#std-label-ruby-version-2.23
+[mongoid-documentation]: https://www.mongodb.com/docs/mongoid/current/

--- a/src/_posts/languages/ruby/2000-01-01-mongoid.md
+++ b/src/_posts/languages/ruby/2000-01-01-mongoid.md
@@ -6,7 +6,7 @@ tags: ruby mongoid mongodb
 ---
 
 {% warning %}
-  Use the Mongo Ruby driver `mongo` up to version `2.23.0` when connecting to
+  Use the MongoDB Ruby driver `mongo` up to version `2.23.0` when connecting to
   MongoDB Server `3.6` or `4.0`.
 {% endwarning %}
 
@@ -38,10 +38,9 @@ If you want to modify connection options or the connections pooling, you can
 find all the information in the [official documentation][mongoid-documentation].
 
 
-## Mongo Ruby Driver Compatibility
+## MongoDB Ruby Driver Compatibility
 
-Scalingo for MongoDB® supports MongoDB up to version `4.0.3`, the latest open
-source version available.
+Scalingo for MongoDB® supports MongoDB up to version `4.0.3`, the latest version available under AGPL 3.0.
 
 The Mongo Ruby driver `mongo` version `2.24.0` removed support for MongoDB
 Server `3.6` and `4.0`. As a consequence, **Ruby applications using MongoDB on


### PR DESCRIPTION
Document Mongo Ruby driver compatibility with Scalingo for MongoDB.

## Changes

- Add a warning recommending `mongo` `2.23.0` for MongoDB `3.6` and `4.0`.
- Add a `Gemfile` example.
- Explain that `mongo` `2.24.0` dropped support for MongoDB `3.6` and `4.0`.
- Link to the MongoDB Ruby driver release notes.