### PR TITLE
docs(changelog): announce application swap deprecation

### DIFF
--- a/src/_includes/application_swap_deprecation_note.md
+++ b/src/_includes/application_swap_deprecation_note.md
@@ -2,5 +2,5 @@
 Swap memory for application containers is being phased out progressively.\\
 Swap-related limits, metrics, alerts, and autoscaling options may remain visible
 during the transition. See the [swap deprecation plan]({% post_url
-changelog/deployment/2026-05-29-application-containers-swap-deprecation %}).
+changelog#changelog-deployment-application-containers-swap-deprecation %}).
 {% endnote %}

--- a/src/_includes/application_swap_deprecation_note.md
+++ b/src/_includes/application_swap_deprecation_note.md
@@ -1,6 +1,5 @@
 {% note %}
 Swap memory for application containers is being phased out progressively.\\
 Swap-related limits, metrics, alerts, and autoscaling options may remain visible
-during the transition. See the [swap deprecation plan]({% post_url
-changelog#changelog-deployment-application-containers-swap-deprecation %}).
+during the transition. See the [swap deprecation plan](/changelog#changelog-deployment-application-containers-swap-deprecation).
 {% endnote %}

--- a/src/_includes/application_swap_deprecation_note.md
+++ b/src/_includes/application_swap_deprecation_note.md
@@ -1,0 +1,6 @@
+{% note %}
+Swap memory for application containers is being phased out progressively.\\
+Swap-related limits, metrics, alerts, and autoscaling options may remain visible
+during the transition. See the [swap deprecation plan]({% post_url
+changelog/deployment/2026-05-29-application-containers-swap-deprecation %}).
+{% endnote %}

--- a/src/_posts/platform/app/2000-01-01-alerts.md
+++ b/src/_posts/platform/app/2000-01-01-alerts.md
@@ -41,7 +41,9 @@ Metric
   - RPM per container: If your application is scaled on multiple containers,
     the RPM per container divides the RPM of the application by the amount of
     containers.
- 
+
+{% include application_swap_deprecation_note.md %}
+
 Limit
 : Any float value.
 

--- a/src/_posts/platform/app/2000-01-01-metrics.md
+++ b/src/_posts/platform/app/2000-01-01-metrics.md
@@ -64,10 +64,12 @@ The container charts use the container types defined in your [Procfile]({%
 post_url platform/app/2000-01-01-procfile %}).
 
 For each container type, two charts are shown. The first one shows the **CPU
-usage** and the second one the **memory usage** and **swap usage** usage of this 
+usage** and the second one the **memory usage** and **swap usage** of this
 type of container.
 
-The CPU chart may exceed 100% if the application uses more than one core of the 
+{% include application_swap_deprecation_note.md %}
+
+The CPU chart may exceed 100% if the application uses more than one core of the
 CPU.
 
 For the memory chart, the memory (in blue) and swap usage (in red)

--- a/src/_posts/platform/app/scaling/2000-01-01-scaling.md
+++ b/src/_posts/platform/app/scaling/2000-01-01-scaling.md
@@ -70,6 +70,7 @@ Here is a quick comparison table, in the context of a Platform as a Service:
 | **Flexibility** | Low, limited by physical/virtual constraints | High, limited by the application architecture |
 | **When**        | Lack or overuse of CPU or RAM (swap increase or decrease) | Increase or decrease in total application traffic |
 
+{% include application_swap_deprecation_note.md %}
 
 ## Limitations
 

--- a/src/_posts/platform/app/scaling/2000-01-01-scaling.md
+++ b/src/_posts/platform/app/scaling/2000-01-01-scaling.md
@@ -70,8 +70,6 @@ Here is a quick comparison table, in the context of a Platform as a Service:
 | **Flexibility** | Low, limited by physical/virtual constraints | High, limited by the application architecture |
 | **When**        | Lack or overuse of CPU or RAM (swap increase or decrease) | Increase or decrease in total application traffic |
 
-{% include application_swap_deprecation_note.md %}
-
 ## Limitations
 
 - Vertical scaling is limited by the platform. The biggest container we can

--- a/src/_posts/platform/app/scaling/2000-01-01-scalingo-autoscaler.md
+++ b/src/_posts/platform/app/scaling/2000-01-01-scalingo-autoscaler.md
@@ -66,8 +66,7 @@ An Autoscaler can depend on 6 different metrics:
 | [RAM consumption](#ram-consumption)                                      | `technical` | `memory`            |
 | [Swap consumption](#swap-consumption)                                    | `technical` | `swap`              |
 
-
-
+{% include application_swap_deprecation_note.md %}
 
 ### RPM per container (recommended)
 

--- a/src/_posts/platform/app/scaling/2000-01-01-scalingo-autoscaler.md
+++ b/src/_posts/platform/app/scaling/2000-01-01-scalingo-autoscaler.md
@@ -66,8 +66,6 @@ An Autoscaler can depend on 6 different metrics:
 | [RAM consumption](#ram-consumption)                                      | `technical` | `memory`            |
 | [Swap consumption](#swap-consumption)                                    | `technical` | `swap`              |
 
-{% include application_swap_deprecation_note.md %}
-
 ### RPM per container (recommended)
 
 Requests Per Minute (RPM) per container is calculated as the total number of
@@ -178,6 +176,8 @@ prevent out-of-memory errors and ensure smooth operations.
 Swap consumption tracks the use of disk-based swap memory, which occurs when an
 application exceeds its allocated RAM. While swap provides additional capacity,
 excessive usage can significantly degrade performance.
+
+{% include application_swap_deprecation_note.md %}
 
 #### Usage
 

--- a/src/_posts/platform/internals/2000-01-01-container-sizes.md
+++ b/src/_posts/platform/internals/2000-01-01-container-sizes.md
@@ -21,6 +21,7 @@ The default container size is **M**.
 
 Prices are available on the [Scalingo pricing page](https://scalingo.com/pricing).
 
+{% include application_swap_deprecation_note.md %}
 
 {: #cpu}**CPU Priority**
 : All containers can use all available CPU cores.

--- a/src/changelog/deployment/_posts/2026-05-29-application-containers-swap-deprecation.md
+++ b/src/changelog/deployment/_posts/2026-05-29-application-containers-swap-deprecation.md
@@ -1,0 +1,17 @@
+---
+modified_at: 2026-05-29 00:00:00
+title: 'Application containers: swap deprecation plan'
+---
+
+Scalingo is progressively phasing out swap memory for application containers.
+
+The rollout will be progressive:
+
+- **June 1, 2026**: new customers will use the no-swap behavior by default.
+- **September 1, 2026**: new applications created by existing customers will use
+  the no-swap behavior by default.
+- **January 1, 2027**: all application containers will use the no-swap behavior.
+
+Existing applications keep their current behavior until they are migrated.
+
+The documentation will be updated progressively to reflect this change.

--- a/src/changelog/deployment/_posts/2026-05-29-application-containers-swap-deprecation.md
+++ b/src/changelog/deployment/_posts/2026-05-29-application-containers-swap-deprecation.md
@@ -1,22 +1,27 @@
 ---
-modified_at: 2026-05-29 00:00:00
-title: 'Swap will be disabled for applications'
+modified_at: 2026-06-01 00:00:00
+title: 'Swap memory will be progressively disabled from application containers'
 ---
+
+**Swap will no longer be available for application containers.**
 
 Scalingo is progressively updating how memory limits are enforced for
 application containers.
 
-Applications will no longer be able to rely on swap memory. If an application
-exceeds its available memory, it may stop with an out-of-memory error and
-restart according to the usual restart policy.
+Application containers will no longer be able to rely on swap memory. If an 
+application exceeds its available memory, its container may be stopped with 
+an out-of-memory error and restarted according to the usual restart policy.
 
-The rollout will be progressive:
+The rollout will happen progressively:
 
-- **June 1, 2026**: new customers will use the no-swap behavior by default.
-- **September 1, 2026**: new applications created by existing customers will use
-  the no-swap behavior by default.
-- **January 1, 2027**: all application containers will use the no-swap behavior.
+- **1 June 2026**: swap will no longer be enabled for new Scalingo customers
+- **1 September 2026**: swap will no longer be enabled for new applications 
+  created by existing customers
+- **1 January 2027**: swap will be disabled for all application containers
 
-Existing applications keep their current behavior until they are migrated.
+**In most cases, no immediate action is required.**
+
+We recommend reviewing your applications' memory usage during the transition 
+period and configuring memory alerts if needed.
 
 The documentation will be updated progressively to reflect this change.

--- a/src/changelog/deployment/_posts/2026-05-29-application-containers-swap-deprecation.md
+++ b/src/changelog/deployment/_posts/2026-05-29-application-containers-swap-deprecation.md
@@ -3,8 +3,6 @@ modified_at: 2026-06-01 00:00:00
 title: 'Swap memory will be progressively disabled from application containers'
 ---
 
-**Swap will no longer be available for application containers.**
-
 Scalingo is progressively updating how memory limits are enforced for
 application containers.
 

--- a/src/changelog/deployment/_posts/2026-05-29-application-containers-swap-deprecation.md
+++ b/src/changelog/deployment/_posts/2026-05-29-application-containers-swap-deprecation.md
@@ -1,9 +1,14 @@
 ---
 modified_at: 2026-05-29 00:00:00
-title: 'Application containers: swap deprecation plan'
+title: 'Swap will be disabled for applications'
 ---
 
-Scalingo is progressively phasing out swap memory for application containers.
+Scalingo is progressively updating how memory limits are enforced for
+application containers.
+
+Applications will no longer be able to rely on swap memory. If an application
+exceeds its available memory, it may stop with an out-of-memory error and
+restart according to the usual restart policy.
 
 The rollout will be progressive:
 


### PR DESCRIPTION
# Summary

Adds a changelog entry announcing the progressive deprecation of swap memory for application containers.

Also adds a reusable note on the relevant documentation pages to clarify that swap-related limits, metrics, alerts, and autoscaling options may remain visible during the transition, with a link to the changelog plan.