### PR TITLE
Update duration of TLS certificates to 45 days

### DIFF
--- a/src/_posts/platform/networking/public/cert/2000-01-01-default.md
+++ b/src/_posts/platform/networking/public/cert/2000-01-01-default.md
@@ -14,7 +14,7 @@ are created.
 When adding a [custom domain name][domains-custom], Scalingo automatically
 leverage Let's Encrypt to generate a dedicated TLS certificate.
 
-Once issued, a Let's Encrypt certificate is given a 90 days validity period.
+Once issued, a Let's Encrypt certificate is given a 45 days validity period.
 The platform ensures all certificates are renewed when necessary. This process
 is fully automated and integrated, so you don't have to worry about it.
 

--- a/src/_posts/platform/networking/public/cert/2000-01-01-default.md
+++ b/src/_posts/platform/networking/public/cert/2000-01-01-default.md
@@ -19,7 +19,7 @@ The platform ensures all certificates are renewed when necessary. This process
 is fully automated and integrated, so you don't have to worry about it.
 
 The platform also follows Let's Encrypt best practices by starting the renewal
-process when a certificate is 60 days old. If the renewal process fails, the
+process when a certificate is 30 days old. If the renewal process fails, the
 platform automatically retries later. The delay between each attempt is
 determined using an exponential backoff algorithm. This algorithm is capped to
 a **minimum** of one attempt per day.

--- a/src/changelog/platform/_posts/2026-06-01-lets-encrypt-certificate-duration.md
+++ b/src/changelog/platform/_posts/2026-06-01-lets-encrypt-certificate-duration.md
@@ -1,6 +1,6 @@
 ---
 modified_at: 2026-06-01 00:00:00
-title: 'Reduce Let's Encrypt certificate duration to 45 days'
+title: 'Reduce Lets Encrypt certificate duration to 45 days'
 ---
 
 Let's Encrypt certificates are now generated for a duration of 45 days, instead of 90 days previously.

--- a/src/changelog/platform/_posts/2026-06-01-lets-encrypt-certificate-duration.md
+++ b/src/changelog/platform/_posts/2026-06-01-lets-encrypt-certificate-duration.md
@@ -1,0 +1,9 @@
+---
+modified_at: 2026-06-01 00:00:00
+title: 'Reduce Let's Encrypt certificate duration to 45 days'
+---
+
+Let's Encrypt certificates are now generated for a duration of 45 days, instead of 90 days previously.
+This change is in line with Let's Encrypt's best practices for certificate management and security.
+
+👉 [Read the certificate setup guide]({% post_url platform/networking/public/cert/2000-01-01-default %})


### PR DESCRIPTION
It was forgotten when doing [this](https://github.com/Scalingo/scalingo-acme-agent/issues/406).