### PR TITLE
[STORY-3867] Publish stack release changelog

### DIFF
--- a/src/changelog/base_image/_posts/2026-06-02-scalingo-22-v16-scalingo-24-v6.md
+++ b/src/changelog/base_image/_posts/2026-06-02-scalingo-22-v16-scalingo-24-v6.md
@@ -1,0 +1,21 @@
+---
+modified_at: 2026-06-02 00:00:00
+title: 'Stack scalingo-24 v6, scalingo-22 v16, scalingo-24-minimal v5 and scalingo-22-minimal v15'
+---
+
+These new versions contain the following changes:
+
+* feat(cacerts): update to the most recent version
+* Full `apt upgrade` for all stacks
+
+For a comprehensive list of packages installed in the different stacks, please refer to our documentation:
+
+* [scalingo-22]({% post_url platform/internals/stacks/2000-01-01-scalingo-22-stack %}#ubuntu-packages)
+* [scalingo-24]({% post_url platform/internals/stacks/2000-01-01-scalingo-24-stack %}#ubuntu-packages)
+
+As always, the Docker images are available on Docker Hub:
+
+* [scalingo-22](https://hub.docker.com/r/scalingo/scalingo-22)
+* [scalingo-22-minimal](https://hub.docker.com/r/scalingo/scalingo-22-minimal)
+* [scalingo-24](https://hub.docker.com/r/scalingo/scalingo-24)
+* [scalingo-24-minimal](https://hub.docker.com/r/scalingo/scalingo-24-minimal)


### PR DESCRIPTION
- Publish the changelog entry for scalingo-24 v6 and scalingo-22 v16
- Include the matching minimal stack versions: scalingo-24-minimal v5 and scalingo-22-minimal v15.
- Link to the stack package documentation and Docker Hub images
