### PR TITLE
Add PostgreSQL 14 EOL deprecation notice

### DIFF
--- a/src/changelog/databases/_posts/2026-06-09-postgresql-14-eol-notice.md
+++ b/src/changelog/databases/_posts/2026-06-09-postgresql-14-eol-notice.md
@@ -1,0 +1,24 @@
+---
+modified_at: 2026-06-09 12:00:00
+title: 'PostgreSQL 14 - Deprecation Plan'
+---
+
+PostgreSQL 14 will reach the end of its support cycle on November 12, 2026. After
+this date, this version will no longer receive updates, security patches, or
+maintenance fixes.
+
+We encourage you to start planning the upgrade of your PostgreSQL instances to
+version 15 or later.
+
+## Deprecation Plan
+
+- **June 2026:** End-of-support notification sent to owners and collaborators of
+  PostgreSQL 14 databases.
+- **November 12, 2026:** PostgreSQL 14 reaches end of life.
+- **January 11, 2027:** Remaining PostgreSQL 14 databases will be automatically
+  upgraded to the latest available minor version of PostgreSQL 15.
+
+We recommend upgrading proactively so you can validate that your services
+continue to work as expected before the automatic upgrade campaign starts.
+
+[Read our best practices for managing PostgreSQL upgrades]({% post_url databases/postgresql/shared-resources/guides/2000-01-01-upgrading %})

--- a/src/changelog/databases/_posts/2026-06-09-postgresql-14-eol-notice.md
+++ b/src/changelog/databases/_posts/2026-06-09-postgresql-14-eol-notice.md
@@ -1,5 +1,5 @@
 ---
-modified_at: 2026-06-09 12:00:00
+modified_at: 2026-06-09 09:00:00
 title: 'PostgreSQL 14 - Deprecation Plan'
 ---
 

--- a/src/changelog/databases/_posts/2026-06-09-postgresql-14-eol-notice.md
+++ b/src/changelog/databases/_posts/2026-06-09-postgresql-14-eol-notice.md
@@ -1,24 +1,24 @@
 ---
 modified_at: 2026-06-09 09:00:00
-title: 'PostgreSQL 14 - Deprecation Plan'
+title: 'PostgreSQL® 14 - Deprecation Plan'
 ---
 
-PostgreSQL 14 will reach the end of its support cycle on November 12, 2026. After
+PostgreSQL® 14 will reach the end of its support cycle on November 12, 2026. After
 this date, this version will no longer receive updates, security patches, or
 maintenance fixes.
 
-We encourage you to start planning the upgrade of your PostgreSQL instances to
+We encourage you to start planning the upgrade of your PostgreSQL® instances to
 version 15 or later.
 
 ## Deprecation Plan
 
 - **June 2026:** End-of-support notification sent to owners and collaborators of
-  PostgreSQL 14 databases.
-- **November 12, 2026:** PostgreSQL 14 reaches end of life.
-- **January 11, 2027:** Remaining PostgreSQL 14 databases will be automatically
-  upgraded to the latest available minor version of PostgreSQL 15.
+  PostgreSQL® 14 databases.
+- **November 12, 2026:** PostgreSQL® 14 reaches end of life.
+- **January 11, 2027:** Remaining PostgreSQL® 14 databases will be automatically
+  upgraded to the latest available minor version of PostgreSQL® 15.
 
 We recommend upgrading proactively so you can validate that your services
 continue to work as expected before the automatic upgrade campaign starts.
 
-[Read our best practices for managing PostgreSQL upgrades]({% post_url databases/postgresql/shared-resources/guides/2000-01-01-upgrading %})
+[Read our best practices for managing PostgreSQL® upgrades]({% post_url databases/postgresql/shared-resources/guides/2000-01-01-upgrading %})


### PR DESCRIPTION
Add PostgreSQL 14 EOL deprecation notice

Adds a changelog entry for PostgreSQL 14 end-of-life on November 12, 2026, with deprecation timeline and automatic upgrade date (January 11, 2027).