### PR TITLE
Add MySQL 8.0 LTS deprecation notice

### DIFF
--- a/src/changelog/databases/_posts/2026-06-09-mysql-8.0-deprecation.md
+++ b/src/changelog/databases/_posts/2026-06-09-mysql-8.0-deprecation.md
@@ -21,4 +21,4 @@ We encourage you to start planning the upgrade of your MySQL instances to MySQL
 We recommend upgrading proactively so you can validate that your services
 continue to work as expected before the automatic upgrade campaign starts.
 
-[Read our prerequisites before upgrading to MySQL® 8.4 LTS]({% post_url databases/mysql/guides/2000-01-01-upgrading %})
+[Read our prerequisites before upgrading to MySQL® 8.4 LTS]({% post_url databases/mysql/guides/2000-01-01-mysql-84-prerequisites %})

--- a/src/changelog/databases/_posts/2026-06-09-mysql-8.0-deprecation.md
+++ b/src/changelog/databases/_posts/2026-06-09-mysql-8.0-deprecation.md
@@ -1,22 +1,22 @@
 ---
 modified_at: 2026-06-09 09:00:00
-title: 'MySQL 8.0 LTS - Deprecation Plan'
+title: 'MySQL® 8.0 LTS - Deprecation Plan'
 ---
 
-MySQL 8.0 LTS reached the end of its support cycle on April 30, 2026. Since
+MySQL® 8.0 LTS reached the end of its support cycle on April 30, 2026. Since
 then, this version no longer receives updates, security patches, or
 maintenance fixes.
 
-We encourage you to start planning the upgrade of your MySQL instances to MySQL
+We encourage you to start planning the upgrade of your MySQL® instances to MySQL®
 8.4 LTS as soon as possible.
 
 ## Deprecation Plan
 
-- **April 30, 2026:** MySQL 8.0 LTS reached end of support.
+- **April 30, 2026:** MySQL® 8.0 LTS reached end of support.
 - **June 2026:** End-of-support notification sent to owners and collaborators of
-  MySQL 8.0 LTS databases.
-- **October 12, 2026:** Remaining MySQL 8.0 LTS databases will be automatically
-  upgraded to the latest available version of MySQL 8.4 LTS.
+  MySQL® 8.0 LTS databases.
+- **October 12, 2026:** Remaining MySQL® 8.0 LTS databases will be automatically
+  upgraded to the latest available version of MySQL® 8.4 LTS.
 
 We recommend upgrading proactively so you can validate that your services
 continue to work as expected before the automatic upgrade campaign starts.

--- a/src/changelog/databases/_posts/2026-06-09-mysql-8.0-deprecation.md￼
+++ b/src/changelog/databases/_posts/2026-06-09-mysql-8.0-deprecation.md￼
@@ -1,0 +1,25 @@
+---
+modified_at: 2026-06-09 09:00:00
+title: 'MySQL 8.0 LTS - Deprecation Plan'
+---
+
+MySQL 8.0 LTS reached the end of its support cycle on April 30, 2026. Since
+this date, this version no longer receives updates, security patches, or
+maintenance fixes.
+
+We encourage you to start planning the upgrade of your MySQL instances to MySQL
+8.4 LTS as soon as possible.
+
+## Deprecation Plan
+
+- **April 30, 2026:** MySQL 8.0 reaches end of support.
+- **June 2026:** End-of-support notification sent to owners and collaborators of
+  MySQL 8.0 databases.
+- **October 12, 2026:** Remaining MySQL 8.0 databases will be automatically
+  upgraded to the latest available minor version of MySQL 8.0, then to MySQL 8.4
+  LTS.
+
+We recommend upgrading proactively so you can validate that your services
+continue to work as expected before the automatic upgrade campaign starts.
+
+[Read our prerequisites before upgrading to MySQL® 8.4 LTS]({% post_url databases/mysql/guides/2000-01-01-upgrading %})

--- a/src/changelog/databases/_posts/2026-06-09-mysql-8.0-deprecation.md￼
+++ b/src/changelog/databases/_posts/2026-06-09-mysql-8.0-deprecation.md￼
@@ -4,7 +4,7 @@ title: 'MySQL 8.0 LTS - Deprecation Plan'
 ---
 
 MySQL 8.0 LTS reached the end of its support cycle on April 30, 2026. Since
-this date, this version no longer receives updates, security patches, or
+then, this version no longer receives updates, security patches, or
 maintenance fixes.
 
 We encourage you to start planning the upgrade of your MySQL instances to MySQL
@@ -12,12 +12,11 @@ We encourage you to start planning the upgrade of your MySQL instances to MySQL
 
 ## Deprecation Plan
 
-- **April 30, 2026:** MySQL 8.0 reaches end of support.
+- **April 30, 2026:** MySQL 8.0 LTS reached end of support.
 - **June 2026:** End-of-support notification sent to owners and collaborators of
-  MySQL 8.0 databases.
-- **October 12, 2026:** Remaining MySQL 8.0 databases will be automatically
-  upgraded to the latest available minor version of MySQL 8.0, then to MySQL 8.4
-  LTS.
+  MySQL 8.0 LTS databases.
+- **October 12, 2026:** Remaining MySQL 8.0 LTS databases will be automatically
+  upgraded to the latest available version of MySQL 8.4 LTS.
 
 We recommend upgrading proactively so you can validate that your services
 continue to work as expected before the automatic upgrade campaign starts.


### PR DESCRIPTION
Add MySQL 8.0 LTS deprecation notice

Adds a changelog entry for MySQL 8.0 LTS end-of-life process, with deprecation timeline and automatic upgrade date (October 12, 2026).