### PR TITLE
Generalize inline code padding inside and outside notes

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -498,8 +498,6 @@ article aside.note a {
 article aside.note code.language-plaintext {
   background-color: var(--color-primary-purple-200-60);
   color: var(--color-primary-purple-800);
-  padding: 0.6px;
-  border-radius: 6px;
 }
 
 article aside.warning {
@@ -535,8 +533,6 @@ article aside.warning a {
 article aside.warning code.language-plaintext {
   background-color: var(--color-error-200);
   color: var(--color-error-900);
-  padding: 0.6px;
-  border-radius: 6px;
 }
 
 article aside.note ul,
@@ -765,6 +761,8 @@ article code.language-plaintext {
   font-family: var(--font-mono);
   font-size: 1em;
   font-weight: 400;
+  padding: 0 0.3rem;
+  border-radius: 4px;
 }
 
 article code {


### PR DESCRIPTION
# Before
<img width="741" height="489" alt="Screenshot 2026-06-09 at 18 00 42" src="https://github.com/user-attachments/assets/55a037b4-12e3-45c7-a349-fbe7559d0807" />


# After
<img width="743" height="494" alt="Screenshot 2026-06-09 at 18 00 36" src="https://github.com/user-attachments/assets/3f13c1b4-750e-4e64-a6a7-4a92a08ae2c4" />

