### PR TITLE
feat(nginx): release of nginx 1.30.3 and 1.31.2

### DIFF
--- a/src/_includes/nginx_versions.md
+++ b/src/_includes/nginx_versions.md
@@ -2,8 +2,8 @@ Scalingo supports the following versions of Nginx:
 
 | Nginx version         | `scalingo-22` ([EOL]) | `scalingo-24`  | `scalingo-26`  |
 | --------------------: | --------------------: | -------------: | -------------: |
-| **`1.31`** (Mainline) | Up to `1.31.1`        | Up to `1.31.1` | Up to `1.31.1` |
-| **`1.30`** (Stable)   | Up to `1.30.2`        | Up to `1.30.2` | Up to `1.30.2` |
+| **`1.31`** (Mainline) | Up to `1.31.2`        | Up to `1.31.2` | Up to `1.31.2` |
+| **`1.30`** (Stable)   | Up to `1.30.3`        | Up to `1.30.3` | Up to `1.30.3` |
 
 {% include scalingo_22_deprecation_note.md %}
 

--- a/src/changelog/buildpacks/_posts/2026-06-22-nginx-1.30.3.md
+++ b/src/changelog/buildpacks/_posts/2026-06-22-nginx-1.30.3.md
@@ -1,0 +1,12 @@
+---
+modified_at: 2026-06-22 12:00:00
+title: 'nginx: nginx 1.30.3 (stable) is now available'
+github: 'https://github.com/Scalingo/nginx-buildpack'
+---
+
+nginx `1.30.3` (stable) is now available.
+
+This is also the default version deployed on all stacks when using the
+[nginx-buildpack](https://github.com/Scalingo/nginx-buildpack).
+
+[Changelog](https://nginx.org/en/CHANGES-1.30)

--- a/src/changelog/buildpacks/_posts/2026-06-22-nginx-1.31.2.md
+++ b/src/changelog/buildpacks/_posts/2026-06-22-nginx-1.31.2.md
@@ -1,0 +1,9 @@
+---
+modified_at: 2026-06-22 12:00:00
+title: 'nginx: nginx 1.31.2 (mainline) is now available'
+github: 'https://github.com/Scalingo/nginx-buildpack'
+---
+
+nginx `1.31.2` (mainline) is now available.
+
+[Changelog](https://nginx.org/en/CHANGES)


### PR DESCRIPTION
- `scalingo-22`: https://semver.scalingo.com/nginx-scalingo-22/versions
- `scalingo-24`: https://semver.scalingo.com/nginx-scalingo-24/versions
- `scalingo-26`: https://semver.scalingo.com/nginx-scalingo-26/versions
- `scalingo-22-minimal`: https://semver.scalingo.com/nginx-scalingo-22-minimal/versions
- `scalingo-24-minimal`: https://semver.scalingo.com/nginx-scalingo-24-minimal/versions
- `scalingo-26-minimal`: https://semver.scalingo.com/nginx-scalingo-26-minimal/versions

Fix https://github.com/Scalingo/nginx-buildpack/issues/159