### PR TITLE
fix(changelog): add breadcrumb labels and use canonical detail links 

### DIFF
--- a/src/_plugins/jekyll-breadcrumb-tag.rb
+++ b/src/_plugins/jekyll-breadcrumb-tag.rb
@@ -13,7 +13,11 @@ module Jekyll
         new_path += "/#{part}"
         title = breadcrumb_hash[new_path]
 
-        "<a href=\"#{new_path}\">#{title}</a>"
+        if new_path.start_with?("/changelog/")
+          title
+        else
+          "<a href=\"#{new_path}\">#{title}</a>"
+        end
       end.join(" - ")
     end
   end

--- a/src/_plugins/jekyll-dirname-generator.rb
+++ b/src/_plugins/jekyll-dirname-generator.rb
@@ -114,8 +114,25 @@ module Dirname
       @all_posts = site.posts.docs
       @breadcrumb_hash = {}
       tree = directory_hash("src/_posts/")
+
+      # Changelog posts live outside src/_posts, so they are not part of the
+      # documentation tree. Register only their parent breadcrumb labels here
+      # without adding changelog entries to the main navigation.
+      add_changelog_breadcrumbs
+
       site.data["tree"] = tree["children"]
       site.data["breadcrumb_hash"] = @breadcrumb_hash
+    end
+
+    def add_changelog_breadcrumbs
+      @breadcrumb_hash["/changelog"] = "Changelog"
+
+      @all_posts.each do |doc|
+        next unless doc.relative_path.start_with?("changelog/")
+
+        category = doc.relative_path.split("/")[1]
+        @breadcrumb_hash["/changelog/#{category}"] = category.tr("_", " ").titleize
+      end
     end
   end
 end

--- a/src/changelog.html
+++ b/src/changelog.html
@@ -23,8 +23,8 @@ modified_at: 2015-09-09 00:00:00
     <article>
       <div id="{{post.id | slugify}}" class="heading" data-type="heading"
         data-state="{% if body != " " %}closed{% else %}empty{% endif %}">
-        <input type="checkbox" id="{{post.id | url_decode  }}" class="hidden">
-        <label class="flex flex-row flex-wrap gap-y-4 w-full p-6 {% cycle 'bg-sc-gray-4', 'even' %} cursor-pointer" for="{{post.id | url_decode}}">
+        <input type="checkbox" id="{{ post.url }}" class="hidden">
+        <label class="flex flex-row flex-wrap gap-y-4 w-full p-6 {% cycle 'bg-sc-gray-4', 'even' %} cursor-pointer" for="{{ post.url }}">
           <div class="w-1/2 lg:w-1/6">
             {{ post.modified_at | date: "%b %-d, %Y" }}
           </div>


### PR DESCRIPTION
## Summary

Fix changelog detail page breadcrumbs and expose canonical changelog detail URLs in the changelog HTML.

## Details

Changelog entries live outside `src/_posts`, so their parent paths were not registered in `breadcrumb_hash`. As a result, changelog detail pages rendered an empty breadcrumb like ` - ` above the title.

This PR registers only the missing changelog breadcrumb labels:

- `/changelog` → `Changelog`
- `/changelog/<category>` → formatted category name

Changelog categories are rendered as plain text in breadcrumbs because category URLs like `/changelog/databases` do not exist and should not be clickable.

This PR also updates the changelog list checkbox `id` and matching `label for` to use `post.url` instead of `post.id | url_decode`, so the HTML exposes the canonical Jekyll URL with hyphens, for example:

- `/changelog/api/continuous-backup-events`

instead of:

- `/changelog/api/continuous_backup_events`