### PR TITLE
chore(buildpacks): go-buildpack and nodejs-buildpack updates

### DIFF
--- a/src/_posts/languages/go/2000-01-01-start.md
+++ b/src/_posts/languages/go/2000-01-01-start.md
@@ -1,7 +1,7 @@
 ---
 title: Go
 nav: Introduction
-modified_at: 2026-06-16 00:00:00
+modified_at: 2026-07-09 00:00:00
 tags: go
 index: 1
 ---
@@ -16,9 +16,8 @@ The following versions of Go are available:
 
 | Go Version  | `scalingo-22` ([EOL]) | `scalingo-24`   | `scalingo-26`   |
 | ----------: | --------------------: | --------------: | --------------: |
-| **`1.26`** | up to `1.26.4`         | up to `1.26.4`  | up to `1.26.4`  |
-| **`1.25`** | up to `1.25.11`        | up to `1.25.11` | up to `1.25.11` |
-| **`1.24`** | up to `1.24.13`        | up to `1.24.13` | up to `1.24.13` |
+| **`1.26`** | up to `1.26.5`         | up to `1.26.5`  | up to `1.26.5`  |
+| **`1.25`** | up to `1.25.12`        | up to `1.25.12` | up to `1.25.12` |
 
 The default Go version on all stacks is the latest `go1.25` version.
 

--- a/src/_posts/languages/nodejs/2000-01-01-start.md
+++ b/src/_posts/languages/nodejs/2000-01-01-start.md
@@ -1,7 +1,7 @@
 ---
 title: Node.js
 nav: Introduction
-modified_at: 2026-06-26 12:00:00
+modified_at: 2026-07-09 12:00:00
 tags: nodejs
 index: 1
 ---
@@ -22,7 +22,7 @@ The following Node.js versions are available:
 
 | Node.js version | `scalingo-22` ([EOL]) | `scalingo-24`   | `scalingo-26`   |
 | --------------: | --------------------: | --------------: | --------------: |
-| `v26`           | up to `26.4.0`        | up to `26.4.0`  | up to `26.4.0`  |
+| `v26`           | up to `26.5.0`        | up to `26.5.0`  | up to `26.5.0`  |
 | `v24` (LTS)     | up to `24.18.0`       | up to `24.18.0` | up to `24.18.0` |
 | `v22` (LTS)     | up to `22.23.1`       | up to `22.23.1` | up to `22.23.1` |
 

--- a/src/changelog/buildpacks/_posts/2026-07-09-go-1.25.12-1.26.5.md
+++ b/src/changelog/buildpacks/_posts/2026-07-09-go-1.25.12-1.26.5.md
@@ -1,0 +1,13 @@
+---
+modified_at: 2026-07-09 12:00:00
+title: 'Go - Go 1.25.12 and 1.26.5 are now available'
+github: 'https://github.com/Scalingo/go-buildpack'
+---
+
+Go versions `1.25.12` and `1.26.5` are now available.\
+They are also the new default versions for, respectively, `go1.25` and
+`go1.26`.
+
+Changelogs:
+- [Go 1.26.5](https://go.dev/doc/devel/release#go1.26.5)
+- [Go 1.25.12](https://go.dev/doc/devel/release#go1.25.12)

--- a/src/changelog/buildpacks/_posts/2026-07-09-nodejs-26.5.0.md
+++ b/src/changelog/buildpacks/_posts/2026-07-09-nodejs-26.5.0.md
@@ -1,0 +1,9 @@
+---
+modified_at: 2026-07-09 12:00:00
+title: 'Node.js - Node.js 26.5.0 is now available'
+github: 'https://github.com/Scalingo/nodejs-buildpack'
+---
+
+Node.js `26.5.0` is now available.
+
+[Changelog](https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V26.md#26.5.0)


### PR DESCRIPTION
- Fix https://github.com/Scalingo/go-buildpack/issues/97
- Fix https://github.com/Scalingo/nodejs-buildpack/issues/257
- Fix https://github.com/Scalingo/nodejs-buildpack/issues/260