### PR TITLE
Fix: spelling and link to DNSimple

### DIFF
--- a/src/_posts/platform/networking/public/cert/2000-01-01-default.md
+++ b/src/_posts/platform/networking/public/cert/2000-01-01-default.md
@@ -82,7 +82,7 @@ able to renew the certificate.
 
 This renewal process can be done manually, or it can be automated when working
 with several registrars. We currently support [Azure DNS](#azure-dns),
-[Cloudflare](#cloudflare), [dnsimple](#dnssimple), [Gandi](#gandi), [Google
+[Cloudflare](#cloudflare), [DNSimple](#dnsimple), [Gandi](#gandi), [Google
 Cloud DNS](#google-cloud-dns), [GoDaddy](#godaddy), [OVH Cloud](#ovh-cloud),
 and [AWS Route 53](#aws-route-53).
 
@@ -123,16 +123,16 @@ permissions on the target zone (e.g. `example.com`):
 For more information about Cloudflare, see their
 [documentation][cloudflare-doc].
 
-### dnsimple
+### DNSimple
 
 The following environment variables must be created and properly filled:
 
 | Environment Variable       | Description               |
 | -------------------------- | ------------------------- |
 | `DNS_PROVIDER`             | Must be set to `dnsimple` |
-| `DNS_DNSIMPLE_OAUTH_TOKEN` | Your dnsimple OAuth token |
+| `DNS_DNSIMPLE_OAUTH_TOKEN` | Your DNSimple OAuth token |
 
-For more information about dnsimple, see their[documentation][dnsimple-doc].
+For more information about DNSimple, see their[documentation][dnsimple-doc].
 
 ### Gandi
 


### PR DESCRIPTION
- Fixed the link to DNSimple in [the DNS docs](https://doc.scalingo.com/platform/networking/public/cert/default#dnsimple)
- Fixed the spelling and capitalization of DNSimple to match their website