### PR TITLE
Announce 3XL container size

### DIFF
--- a/src/_posts/languages/java/2000-01-01-start.md
+++ b/src/_posts/languages/java/2000-01-01-start.md
@@ -1,7 +1,7 @@
 ---
 title: Java on Scalingo
 nav: Introduction
-modified_at: 2026-05-26 00:00:00
+modified_at: 2026-07-21 00:00:00
 tags: java
 index: 1
 ---
@@ -123,6 +123,7 @@ you selected for your application:
 | L              | 1024        | 671                    |
 | XL             | 2048        | 1536                   |
 | 2XL            | 4096        | 3176                   |
+| 3XL            | 8192        | 6451                   |
 
 This setting controls the Java heap, not every memory allocation made by the JVM
 process.

--- a/src/_posts/languages/php/2000-01-01-start.md
+++ b/src/_posts/languages/php/2000-01-01-start.md
@@ -1,7 +1,7 @@
 ---
 title: PHP on Scalingo
 nav: Introduction
-modified_at: 2026-07-03 12:00:00
+modified_at: 2026-07-21 00:00:00
 tags: php
 index: 1
 ---
@@ -123,6 +123,7 @@ the used formula is: `floor(available_memory / php_memory_limit) + 2`
 | L              | 1024        | 7                   |
 | XL             | 2048        | 12                  |
 | 2XL            | 4096        | 22                  |
+| 3XL            | 8192        | 43                  |
 
 ### Concurrency Fine Tuning
 

--- a/src/_posts/languages/python/2000-01-01-start.md
+++ b/src/_posts/languages/python/2000-01-01-start.md
@@ -1,7 +1,7 @@
 ---
 title: Python
 nav: Introduction
-modified_at: 2026-07-13 12:00:00
+modified_at: 2026-07-21 00:00:00
 tags: python
 index: 1
 ---
@@ -126,6 +126,7 @@ The default level of concurrency is automatically defined, depending on the amou
 | L              | 1024        | 4                   |
 | XL             | 2048        | 8                   |
 | 2XL            | 4096        | 16                  |
+| 3XL            | 8192        | 32                  |
 
 For further details about this calculation, please see the [WEB_CONCURRENCY.sh](https://github.com/Scalingo/python-buildpack/blob/master/vendor/WEB_CONCURRENCY.sh) script of the Python buildpack.
 

--- a/src/_posts/languages/ruby/2000-01-01-start.md
+++ b/src/_posts/languages/ruby/2000-01-01-start.md
@@ -1,7 +1,7 @@
 ---
 title: Ruby
 nav: Introduction
-modified_at: 2026-06-03 12:00:00
+modified_at: 2026-07-21 00:00:00
 tags: ruby
 index: 1
 ---
@@ -167,6 +167,7 @@ amount of memory available in the container running the app:
 | L              | 1024        | 2                   |
 | XL             | 2048        | 2                   |
 | 2XL            | 4096        | 4                   |
+| 3XL            | 8192        | 4                   |
 
 For further details about this calculation, please see the
 [`lib/language_pack/ruby.rb`][web_concurrency_file] file of the Ruby buildpack.

--- a/src/_posts/platform/app/scaling/2000-01-01-scaling.md
+++ b/src/_posts/platform/app/scaling/2000-01-01-scaling.md
@@ -92,7 +92,7 @@ the application structure with
 ## Limitations
 
 - Vertical scaling is limited by the platform. The biggest container we can
-  currently boot is the `2XL` container, with 4GB of RAM. See the
+  currently boot is the `3XL` container, with 8 GB of RAM. See the
   [container sizes][container-sizes] documentation for the full list of sizes
   and their specifications.
 - Horizontal scaling is limited by default to a maximum of 10 containers per

--- a/src/_posts/platform/internals/2000-01-01-container-sizes.md
+++ b/src/_posts/platform/internals/2000-01-01-container-sizes.md
@@ -1,6 +1,6 @@
 ---
 title: Container Sizes
-modified_at: 2026-05-05 00:00:00
+modified_at: 2026-07-21 00:00:00
 tags: containers sizes
 index: 2
 ---
@@ -16,6 +16,7 @@ capabilities and isolation characteristics associated with each profile.
 | **L**   | 1024        | 1024      | Standard             | 512         | 1048576   |
 | **XL**  | 2048        | 2048      | High                 | 1024        | 1048576   |
 | **2XL** | 4096        | 4096      | High                 | 2048        | 1048576   |
+| **3XL** | 8192        | 8192      | High                 | 4096        | 1048576   |
 
 The default container size is **M**.
 

--- a/src/changelog/platform/_posts/2026-07-21-3xl-container-size.md
+++ b/src/changelog/platform/_posts/2026-07-21-3xl-container-size.md
@@ -1,0 +1,11 @@
+---
+modified_at: 2026-07-21 00:00:00
+title: 'New 3XL Container Size'
+---
+
+A new `3XL` container size is now available for applications that require more
+memory. It provides 8 GB of memory with high CPU priority.
+
+You can select it from the Dashboard or with the CLI when scaling an
+application. See the [Container Sizes]({% post_url platform/internals/2000-01-01-container-sizes %})
+documentation for its resource and process limits.


### PR DESCRIPTION
Adds the 3XL container size to the changelog and container sizing documentation.

Updates Java, PHP, Python, and Ruby runtime sizing tables with the corresponding 3XL memory, heap, and concurrency defaults.