### PR TITLE
chore(postgresql): update PostgreSQL versions

### DIFF
--- a/src/_includes/database_postgresql_extensions.md
+++ b/src/_includes/database_postgresql_extensions.md
@@ -108,27 +108,27 @@ vim Syntax:
   </tr>
   <tr valign="top">
     <td align="left"><code class="language-plaintext highlighter-rouge">postgis</code></td>
-    <td align="left"><code>3.6.2</code></td>
+    <td align="left"><code>3.6.4</code></td>
     <td align="left">PostGIS geometry and geography spatial types and functions</td>
   </tr>
   <tr valign="top">
     <td align="left"><code class="language-plaintext highlighter-rouge">postgis_raster</code></td>
-    <td align="left"><code>3.6.2</code></td>
+    <td align="left"><code>3.6.4</code></td>
     <td align="left">PostGIS raster types and functions</td>
   </tr>
   <tr valign="top">
     <td align="left"><code class="language-plaintext highlighter-rouge">postgis_sfcgal</code></td>
-    <td align="left"><code>3.6.2</code></td>
+    <td align="left"><code>3.6.4</code></td>
     <td align="left">PostGIS SFCGAL functions</td>
   </tr>
   <tr valign="top">
     <td align="left"><code class="language-plaintext highlighter-rouge">postgis_tiger_geocoder</code></td>
-    <td align="left"><code>3.6.2</code></td>
+    <td align="left"><code>3.6.4</code></td>
     <td align="left">PostGIS tiger geocoder and reverse geocoder</td>
   </tr>
   <tr valign="top">
     <td align="left"><code class="language-plaintext highlighter-rouge">postgis_topology</code></td>
-    <td align="left"><code>3.6.2</code></td>
+    <td align="left"><code>3.6.4</code></td>
     <td align="left">PostGIS topology spatial types and functions</td>
   </tr>
   <tr valign="top">
@@ -158,7 +158,7 @@ vim Syntax:
   </tr>
   <tr valign="top">
     <td align="left"><code class="language-plaintext highlighter-rouge">vector</code></td>
-    <td align="left"><code>0.8.2</code></td>
+    <td align="left"><code>0.8.6</code></td>
     <td align="left">vector data type and ivfflat and hnsw access methods</td>
   </tr>
 </table>

--- a/src/_posts/databases/postgresql/about/2000-01-01-overview.md
+++ b/src/_posts/databases/postgresql/about/2000-01-01-overview.md
@@ -1,7 +1,7 @@
 ---
 title: Scalingo for PostgreSQL® Overview
 nav: Overview
-modified_at: 2026-04-09 12:00:00
+modified_at: 2026-08-19 12:00:00
 tags: database postgresql addon
 index: 1
 ---
@@ -49,10 +49,10 @@ ensure security, performance, and operational efficiency.
 
 | PostgreSQL Version | Full Version      | EOL      |
 | -----------------: | ----------------- | -------- |
-| **`17`**           | up to `17.9.0-2`  | Nov 2029 |
-| `16`               | up to `16.13.0-2` | Nov 2028 |
-| `15`               | up to `15.17.0-2` | Nov 2027 |
-| `14`               | up to `14.22.0-1` | Nov 2026 |
+| **`17`**           | up to `17.11.0-1` | Nov 2029 |
+| `16`               | up to `16.15.0-1` | Nov 2028 |
+| `15`               | up to `15.19.0-1` | Nov 2027 |
+| `14`               | up to `14.24.0-1` | Nov 2026 |
 
 The default version when provisioning a Scalingo for PostgreSQL® addon is the
 latest **`17`** version.

--- a/src/changelog/databases/_posts/2026-08-19-postgresql-17.11.0-1.md
+++ b/src/changelog/databases/_posts/2026-08-19-postgresql-17.11.0-1.md
@@ -1,0 +1,22 @@
+---
+modified_at: 2026-08-19 12:00:00
+title: 'PostgreSQL - New Versions: 17.11.0-1, 16.15.0-1, 15.19.0-1 and 14.24.0-1'
+---
+
+Changelog:
+
+- New minor versions available:
+  - v17.11.0-1
+  - v16.15.0-1
+  - v15.19.0-1
+  - v14.24.0-1
+- Updated extensions:
+  - PostGIS v3.6.4
+  - pgvector v0.8.6
+
+Docker images on [Docker Hub](https://hub.docker.com/r/scalingo/postgresql):
+
+* `scalingo/postgresql:17.11.0-1`
+* `scalingo/postgresql:16.15.0-1`
+* `scalingo/postgresql:15.19.0-1`
+* `scalingo/postgresql:14.24.0-1`


### PR DESCRIPTION
Update the public PostgreSQL documentation for the latest minor releases.

- Update available versions to 14.24.0-1, 15.19.0-1, 16.15.0-1 and 17.11.0-1
- Update PostGIS to 3.6.4 and pgvector to 0.8.6
- Add the PostgreSQL release changelog
