### PR TITLE
fix(nextjs): Fix documentation about the hostname boot parameter for standalone mode

### DIFF
--- a/src/_posts/languages/nodejs/2000-01-01-nextjs-standalone.md
+++ b/src/_posts/languages/nodejs/2000-01-01-nextjs-standalone.md
@@ -1,6 +1,6 @@
 ---
 title: Next.js in standalone mode
-modified_at: 2024-07-26 11:26:57
+modified_at: 2026-08-25 00:00:00
 tags: nodejs nextjs standalone
 index: 5
 ---
@@ -37,14 +37,14 @@ Start the server using Node.js.
 ```json
 {
   "scripts": {
-    "start": "node .next/standalone/server.js --hostname 0.0.0.0"
+    "start": "HOSTNAME=0.0.0.0 node .next/standalone/server.js"
     // others scripts
   }
 }
 ```
 
 {% warning %}
-  Ensure that the `--hostname` is set to 0.0.0.0 to avoid the [boot timeout issue]({% post_url languages/nodejs/2000-01-01-start %}#nextjs).
+  Ensure that the `HOSTNAME` env var is set to `0.0.0.0` to avoid the [boot timeout issue]({% post_url languages/nodejs/2000-01-01-start %}#nextjs). It should only be set for the node.js process, not globally on the application side.
 {% endwarning %}
 
 {% note %}


### PR DESCRIPTION
Fix #3913